### PR TITLE
Add support for IEV shorthand parsing (v2 port)

### DIFF
--- a/lib/pubid/iec/parser.rb
+++ b/lib/pubid/iec/parser.rb
@@ -397,12 +397,16 @@ module Pubid
         DASH_CHARS.map { |char| str(char) }.reduce(:|)
       end
 
+      IEV_SHORTHAND = /\AIEV(?=\z|[\s\-])/.freeze
+
       # Preprocess input to normalize tab-separated editions and other formats
       def parse(input)
         # Normalize tab-separated editions: "IECEE AD-001\tED1.6" -> "IECEE AD-001 ED1.6"
         normalized = input.gsub(/\t/, " ")
         # Normalize comma-separated editions: "IEC CAB-G01:2025-02, Ed. 2.1" -> "IEC CAB-G01:2025-02 Ed. 2.1"
         normalized = normalized.gsub(/,\s+Ed\./, " Ed.")
+        # Expand IEV shorthand: "IEV" / "IEV-351" -> "IEC 60050" / "IEC 60050-351"
+        normalized = normalized.sub(IEV_SHORTHAND, "IEC 60050")
         super(normalized)
       end
     end

--- a/spec/pubid/iec/parser_spec.rb
+++ b/spec/pubid/iec/parser_spec.rb
@@ -89,5 +89,27 @@ RSpec.describe Pubid::Iec::Parser do
         expect(result[:date]).to eq("2012")
       end
     end
+
+    context "IEV shorthand for IEC 60050 (International Electrotechnical Vocabulary)" do
+      it "expands bare 'IEV' to 'IEC 60050'" do
+        result = subject.parse("IEV")
+        expect(result).to be_a(Hash)
+        expect(result[:publisher]).to eq("IEC")
+        expect(result[:number_with_part]).to eq("60050")
+      end
+
+      it "expands 'IEV-351' to 'IEC 60050-351'" do
+        result = subject.parse("IEV-351")
+        expect(result).to be_a(Hash)
+        expect(result[:publisher]).to eq("IEC")
+        expect(result[:number_with_part]).to eq("60050-351")
+      end
+
+      it "does not expand tokens that merely start with IEV" do
+        result = subject.parse("IEVERSION")
+        # Confirm the IEV prefix was not rewritten to IEC 60050
+        expect(result[:number_with_part].to_s).not_to start_with("60050")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Port of the IEV shorthand fix from main (`fix/iev-recongnise`) to the v2 architecture.
- Expands `IEV` → `IEC 60050` (and `IEV-NNN` → `IEC 60050-NNN`) inside `Pubid::Iec::Parser#parse`, alongside the existing tab/comma normalisations.
- `Pubid::Iec.parse`, `Pubid::Iec::Identifier.parse`, and direct `Pubid::Iec::Parser` users all route through this preprocessing step.

Fixes metanorma/pubid-ieee#125

## Context
"IEV" is IEC shorthand for IEC 60050 (*International Electrotechnical Vocabulary*). Without this rewrite, `Pubid::Iec.parse("IEV")` raises a `NoMethodError` because the parser has no rule for the bare token. The v1 fix (PR for main) did the same rewrite at the `Pubid::Iec::Identifier.parse` / `parseable?` layer — v2 has no `Pubid::Registry.parse` cross-module dispatcher, so the fix only needs to live in the IEC parser's preprocessing.

## Test plan
- [x] `Pubid::Iec::Parser.new.parse("IEV")` → `{publisher: \"IEC\", number_with_part: \"60050\"}`
- [x] `Pubid::Iec::Parser.new.parse("IEV-351")` → `{publisher: \"IEC\", number_with_part: \"60050-351\"}`
- [x] `Pubid::Iec::Parser.new.parse("IEVERSION")` → not rewritten (guard in place)
- [x] End-to-end: `Pubid::Iec.parse("IEV").to_s` → `"IEC 60050"`
- [x] End-to-end: `Pubid::Iec.parse("IEC 60050").to_s` → `"IEC 60050"` (unchanged)
- [ ] `bundle exec rspec spec/pubid/iec/parser_spec.rb` — the new specs were added and verified manually via \`ruby -Ilib -rnokogiri -r pubid\`. Running rspec on this branch currently fails during \`spec_helper\` load because \`lutaml-model\` → \`moxml\` requires \`nokogiri\`, which isn't in the \`Gemfile\`/\`pubid.gemspec\` on \`rt-new-lutaml-model\`. That gap pre-exists this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)