### PR TITLE
feat(iho): add Annex rule for IHO identifiers

### DIFF
--- a/gems/pubid-iho/lib/pubid/iho/identifier/base.rb
+++ b/gems/pubid-iho/lib/pubid/iho/identifier/base.rb
@@ -1,17 +1,18 @@
 module Pubid::Iho
   module Identifier
     class Base < Pubid::Core::Identifier::Base
-      attr_accessor :version, :appendix
+      attr_accessor :version, :appendix, :annex
 
       def self.type
         { key: :iho }
       end
 
-      def initialize(type:, publisher: "IHO", version: nil, part: nil, appendix: nil, **opts)
+      def initialize(type:, publisher: "IHO", version: nil, part: nil, appendix: nil, annex: nil, **opts)
         super(**opts.merge(publisher: publisher))
         @part = part.to_s if part
         @version = version.to_s if version
         @appendix = appendix.to_s if appendix
+        @annex = annex.to_s if annex
         if type
           unless Identifier.config.type_names.map { |_, v| v[:short] }.include?(type.to_s)
             raise Pubid::Core::Errors::WrongTypeError, "Type '#{type}' is not available"

--- a/gems/pubid-iho/lib/pubid/iho/parser.rb
+++ b/gems/pubid-iho/lib/pubid/iho/parser.rb
@@ -24,13 +24,17 @@ module Pubid::Iho
         )
     end
 
+    rule(:annex) do
+      space >> str("Annex") >> space >> match("[A-Z]").as(:annex)
+    end
+
     rule(:version) do
       space >> (digits >> dot >> digits >> dot >> digits).as(:version)
     end
 
     rule(:identifier) do
       (str("IHO") >> space).maybe >> series >> dash >> number >>
-        appendix.maybe >> part.maybe >> version.maybe
+        appendix.maybe >> part.maybe >> annex.maybe >> version.maybe
     end
 
     rule(:root) { identifier }

--- a/gems/pubid-iho/lib/pubid/iho/renderer/base.rb
+++ b/gems/pubid-iho/lib/pubid/iho/renderer/base.rb
@@ -1,7 +1,7 @@
 module Pubid::Iho::Renderer
   class Base < Pubid::Core::Renderer::Base
     def render_identifier(params)
-      "%{publisher} %{type}-%{number}%{appendix}%{part}%{version}" % params
+      "%{publisher} %{type}-%{number}%{appendix}%{part}%{annex}%{version}" % params
     end
 
     def render_part(part, _opts, _params)
@@ -10,6 +10,10 @@ module Pubid::Iho::Renderer
 
     def render_appendix(appendix, _opts, _params)
       " Ap. #{appendix}"
+    end
+
+    def render_annex(annex, _opts, _params)
+      " Annex #{annex}"
     end
 
     def render_version(version, _opts, _params)

--- a/gems/pubid-iho/spec/pubid_iho/identifier_spec.rb
+++ b/gems/pubid-iho/spec/pubid_iho/identifier_spec.rb
@@ -147,6 +147,32 @@ module Pubid::Iho
       it_behaves_like "converts pubid to pubid"
     end
 
+    # annex (S-100 Annex A "Terms and Definitions", S-98 Annex A/B/C)
+    context "IHO S-100 Annex A 5.2.0" do
+      let(:pubid) { "IHO S-100 Annex A 5.2.0" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "IHO S-100 Annex A" do
+      let(:pubid) { "IHO S-100 Annex A" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "IHO S-98 Annex C 1.0.0" do
+      let(:pubid) { "IHO S-98 Annex C 1.0.0" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "S-100 Annex A 5.2.0 (without IHO prefix)" do
+      let(:original) { "S-100 Annex A 5.2.0" }
+      let(:pubid) { "IHO S-100 Annex A 5.2.0" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
     # IHO prefix is optional on input, always emitted on output
     context "S-44 5.0.0 (without IHO prefix)" do
       let(:original) { "S-44 5.0.0" }


### PR DESCRIPTION
## Summary
- Parser: new `annex` rule (`Annex <UPPERCASE>`), woven into the identifier grammar after `part`
- `Identifier::Base`: new `:annex` attribute + constructor param
- `Renderer::Base`: new `render_annex` method, format string updated
- Specs: 4 new round-trip cases (with/without version, with/without `IHO` prefix)

## Why
`pubid-iho` already has rules for `Part` and `Ap.` (appendix) but no `Annex`. The S-100 Edition 5.2.0 collection in `metanorma/iho-s-100` contains an explicit Annex A ("Terms and Definitions"), and metanorma-iho#344 lists Annex A/B/C for S-98. Without an `Annex` rule, identifiers like `IHO S-100 Annex A` raise a parse error, which blocks the relaton-data-iho indexer (relaton/relaton-iho#23).

## Scope
- Letter-only annex IDs (Annex A through Z). Every real-world example I have seen uses letters; we can broaden later if numbered annexes appear.
- No bibliographic-model changes here. `relaton-iho` already maps `pubid.appendix` and `pubid.part` to `StructuredIdentifier`; a follow-up there will add `pubid.annex` and include `:annex` in `id_keys` / `pubid_match?`.

## Test plan
- [x] \`bundle exec rspec\` in \`gems/pubid-iho\` — 28 examples, 0 failures
- [ ] Reviewer to confirm grammar ordering (\`appendix → part → annex → version\`) is the right composition

Refs relaton/relaton-iho#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)