### PR TITLE
feat(iho): port Annex rule to port/iho-v2

### DIFF
--- a/lib/pubid/iho/builder.rb
+++ b/lib/pubid/iho/builder.rb
@@ -12,6 +12,7 @@ module Pubid
           code:     stringify(hash[:code]),
           appendix: stringify(hash[:appendix]),
           part:     stringify(hash[:part]),
+          annex:    stringify(hash[:annex]),
           version:  stringify(hash[:version]),
         }.compact
 

--- a/lib/pubid/iho/identifiers/base.rb
+++ b/lib/pubid/iho/identifiers/base.rb
@@ -8,7 +8,7 @@ module Pubid
       # Base class for all IHO identifiers.
       #
       # IHO identifiers have the form:
-      #   IHO {S|P|M|B|C}-{code}[ Ap. {appendix}][ Part {part}][ {version}]
+      #   IHO {S|P|M|B|C}-{code}[ Ap. {appendix}][ Part {part}][ Annex {annex}][ {version}]
       #
       # The leading IHO publisher prefix is optional on input but always
       # emitted on output.
@@ -19,6 +19,7 @@ module Pubid
         attribute :code,      :string
         attribute :appendix,  :string
         attribute :part,      :string
+        attribute :annex,     :string
         attribute :version,   :string
 
         def self.parse(string)
@@ -36,6 +37,7 @@ module Pubid
           rendered = +"#{publisher} #{letter}-#{code}"
           rendered << " Ap. #{appendix}" if appendix
           rendered << " Part #{part}"    if part
+          rendered << " Annex #{annex}"  if annex
           rendered << " #{version}"      if version
           rendered
         end

--- a/lib/pubid/iho/parser.rb
+++ b/lib/pubid/iho/parser.rb
@@ -35,6 +35,10 @@ module Pubid
           )
       end
 
+      rule(:annex) do
+        space >> str("Annex") >> space >> match("[A-Z]").as(:annex)
+      end
+
       rule(:version) do
         space >> (digits >> dot >> digits >> dot >> digits).as(:version)
       end
@@ -42,7 +46,7 @@ module Pubid
       rule(:identifier) do
         (str("IHO") >> space).maybe >>
           series >> dash >> code >>
-          appendix.maybe >> part.maybe >> version.maybe
+          appendix.maybe >> part.maybe >> annex.maybe >> version.maybe
       end
 
       root :identifier

--- a/lib/pubid/iho/urn_generator.rb
+++ b/lib/pubid/iho/urn_generator.rb
@@ -4,7 +4,7 @@ module Pubid
   module Iho
     # Generates URN strings for IHO identifiers.
     #
-    # Format: urn:iho:{type-letter-lowercase}:{code}[:ap.{appendix}][:part.{part}][:{version}]
+    # Format: urn:iho:{type-letter-lowercase}:{code}[:ap.{appendix}][:part.{part}][:annex.{annex}][:{version}]
     # Example: urn:iho:s:44:5.0.0 for "IHO S-44 5.0.0".
     class UrnGenerator
       attr_reader :identifier
@@ -17,9 +17,10 @@ module Pubid
         parts = ["urn", "iho"]
         parts << identifier.type[:short].to_s.downcase
         parts << identifier.code.to_s
-        parts << "ap.#{identifier.appendix}" if identifier.appendix
-        parts << "part.#{identifier.part}"   if identifier.part
-        parts << identifier.version.to_s     if identifier.version
+        parts << "ap.#{identifier.appendix}"     if identifier.appendix
+        parts << "part.#{identifier.part}"       if identifier.part
+        parts << "annex.#{identifier.annex}"     if identifier.annex
+        parts << identifier.version.to_s         if identifier.version
         parts.join(":")
       end
     end

--- a/spec/pubid/iho/identifier_spec.rb
+++ b/spec/pubid/iho/identifier_spec.rb
@@ -40,8 +40,13 @@ RSpec.describe Pubid::Iho::Identifier do
       "IHO S-100 Part 4c 1.0.0"      => "IHO S-100 Part 4c 1.0.0",
       "IHO S-100 Part 17a 1.0.0"     => "IHO S-100 Part 17a 1.0.0",
       "IHO S-100 Part 4a"            => "IHO S-100 Part 4a",
+      # annex (S-100 Annex A "Terms and Definitions", S-98 Annex A/B/C)
+      "IHO S-100 Annex A 5.2.0"      => "IHO S-100 Annex A 5.2.0",
+      "IHO S-100 Annex A"            => "IHO S-100 Annex A",
+      "IHO S-98 Annex C 1.0.0"       => "IHO S-98 Annex C 1.0.0",
       # IHO prefix is optional on input, always emitted on output
       "S-100 Part 4a 1.0.0"          => "IHO S-100 Part 4a 1.0.0",
+      "S-100 Annex A 5.2.0"          => "IHO S-100 Annex A 5.2.0",
       "S-44 5.0.0"                   => "IHO S-44 5.0.0",
     }.each do |input, canonical|
       context "with #{input.inspect}" do

--- a/spec/pubid/iho/urn_spec.rb
+++ b/spec/pubid/iho/urn_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Pubid::Iho::UrnGenerator do
       "IHO S-44 5.0.0"          => "urn:iho:s:44:5.0.0",
       "IHO S-100 Part 4a 1.0.0" => "urn:iho:s:100:part.4a:1.0.0",
       "IHO S-65 Ap. A 1.0.0"    => "urn:iho:s:65:ap.A:1.0.0",
+      "IHO S-100 Annex A 5.2.0" => "urn:iho:s:100:annex.A:5.2.0",
       "IHO P-1/21 1.0.0"        => "urn:iho:p:1/21:1.0.0",
       "IHO M-3 2.0.0"           => "urn:iho:m:3:2.0.0",
       "IHO B-4 2.19.0"          => "urn:iho:b:4:2.19.0",


### PR DESCRIPTION
## Summary

- Mirrors metanorma/pubid#40 (which targeted `main` / v1 layout) into the v2 layout introduced by #39 on `port/iho-v2`. Same semantics: a new optional `Annex <UPPERCASE-LETTER>` segment between `Part` and `version`, e.g. `IHO S-100 Annex A 5.2.0`, `IHO S-98 Annex C 1.0.0`.
- Letter-only is intentional. Numbered annexes are out of scope.

## Files

- `lib/pubid/iho/parser.rb` — new `annex` rule, `annex.maybe` woven into `identifier` between `part.maybe` and `version.maybe`.
- `lib/pubid/iho/identifiers/base.rb` — `attribute :annex, :string`; `to_s` emits ` Annex {letter}` after Part, before version. Class-level form-doc comment updated.
- `lib/pubid/iho/builder.rb` — pass `annex: stringify(hash[:annex])` through.
- `lib/pubid/iho/urn_generator.rb` — emits `:annex.{letter}` between `:part` and the version segment.
- `spec/pubid/iho/identifier_spec.rb` — four new round-trip cases (mirrors all four contexts in #40).
- `spec/pubid/iho/urn_spec.rb` — one new URN case (`IHO S-100 Annex A 5.2.0` → `urn:iho:s:100:annex.A:5.2.0`).

## Test plan

- [x] `bundle exec rspec spec/pubid/iho/` — 61 examples, 0 failures (was 56 prior to this PR).
- [x] Round-trip: `IHO S-100 Annex A 5.2.0`, `IHO S-100 Annex A`, `IHO S-98 Annex C 1.0.0`, and `S-100 Annex A 5.2.0` (no IHO prefix on input).
- [x] URN: `Pubid::Iho.parse("IHO S-100 Annex A 5.2.0").to_urn == "urn:iho:s:100:annex.A:5.2.0"`.

Reference implementation: metanorma/pubid#40. Refs relaton/relaton-iho#23.