### PR TITLE
feat(iho): port Appendix wording, D-2 form, Suppl rule to port/iho-v2

### DIFF
--- a/lib/pubid/iho/builder.rb
+++ b/lib/pubid/iho/builder.rb
@@ -9,11 +9,12 @@ module Pubid
         type_letter = stringify(hash[:type])
 
         attrs = {
-          code:     stringify(hash[:code]),
-          appendix: stringify(hash[:appendix]),
-          part:     stringify(hash[:part]),
-          annex:    stringify(hash[:annex]),
-          version:  stringify(hash[:version]),
+          code:       stringify(hash[:code]),
+          appendix:   stringify(hash[:appendix]),
+          part:       stringify(hash[:part]),
+          annex:      stringify(hash[:annex]),
+          supplement: stringify(hash[:supplement]),
+          version:    stringify(hash[:version]),
         }.compact
 
         Scheme.identifier_klass_for_type_letter(type_letter).new(**attrs)

--- a/lib/pubid/iho/identifiers/base.rb
+++ b/lib/pubid/iho/identifiers/base.rb
@@ -8,19 +8,20 @@ module Pubid
       # Base class for all IHO identifiers.
       #
       # IHO identifiers have the form:
-      #   IHO {S|P|M|B|C}-{code}[ Ap. {appendix}][ Part {part}][ Annex {annex}][ {version}]
+      #   IHO {S|P|M|B|C}-{code}[ Ap. {appendix}][ Part {part}][ Annex {annex}][ Suppl {supplement}][ {version}]
       #
       # The leading IHO publisher prefix is optional on input but always
       # emitted on output.
       class Base < Lutaml::Model::Serializable
         include Pubid::Serializable
 
-        attribute :publisher, :string, default: "IHO"
-        attribute :code,      :string
-        attribute :appendix,  :string
-        attribute :part,      :string
-        attribute :annex,     :string
-        attribute :version,   :string
+        attribute :publisher,  :string, default: "IHO"
+        attribute :code,       :string
+        attribute :appendix,   :string
+        attribute :part,       :string
+        attribute :annex,      :string
+        attribute :supplement, :string
+        attribute :version,    :string
 
         def self.parse(string)
           Iho::Identifier.parse(string)
@@ -38,6 +39,7 @@ module Pubid
           rendered << " Ap. #{appendix}" if appendix
           rendered << " Part #{part}"    if part
           rendered << " Annex #{annex}"  if annex
+          rendered << " Suppl #{supplement}" if supplement
           rendered << " #{version}"      if version
           rendered
         end

--- a/lib/pubid/iho/parser.rb
+++ b/lib/pubid/iho/parser.rb
@@ -24,7 +24,12 @@ module Pubid
       end
 
       rule(:appendix) do
-        space >> str("Ap.") >> space >> (digits | match("[A-Z]")).as(:appendix)
+        space >> (str("Appendix") | str("Ap.")) >> space >>
+          (
+            (match("[A-Z]") >> dash >> digits) |
+            digits |
+            match("[A-Z]")
+          ).as(:appendix)
       end
 
       rule(:part) do
@@ -39,6 +44,10 @@ module Pubid
         space >> str("Annex") >> space >> match("[A-Z]").as(:annex)
       end
 
+      rule(:supplement) do
+        space >> str("Suppl") >> space >> digits.as(:supplement)
+      end
+
       rule(:version) do
         space >> (digits >> dot >> digits >> dot >> digits).as(:version)
       end
@@ -46,7 +55,7 @@ module Pubid
       rule(:identifier) do
         (str("IHO") >> space).maybe >>
           series >> dash >> code >>
-          appendix.maybe >> part.maybe >> annex.maybe >> version.maybe
+          appendix.maybe >> part.maybe >> annex.maybe >> supplement.maybe >> version.maybe
       end
 
       root :identifier

--- a/lib/pubid/iho/urn_generator.rb
+++ b/lib/pubid/iho/urn_generator.rb
@@ -4,7 +4,7 @@ module Pubid
   module Iho
     # Generates URN strings for IHO identifiers.
     #
-    # Format: urn:iho:{type-letter-lowercase}:{code}[:ap.{appendix}][:part.{part}][:annex.{annex}][:{version}]
+    # Format: urn:iho:{type-letter-lowercase}:{code}[:ap.{appendix}][:part.{part}][:annex.{annex}][:suppl.{supplement}][:{version}]
     # Example: urn:iho:s:44:5.0.0 for "IHO S-44 5.0.0".
     class UrnGenerator
       attr_reader :identifier
@@ -20,6 +20,7 @@ module Pubid
         parts << "ap.#{identifier.appendix}"     if identifier.appendix
         parts << "part.#{identifier.part}"       if identifier.part
         parts << "annex.#{identifier.annex}"     if identifier.annex
+        parts << "suppl.#{identifier.supplement}" if identifier.supplement
         parts << identifier.version.to_s         if identifier.version
         parts.join(":")
       end

--- a/spec/pubid/iho/identifier_spec.rb
+++ b/spec/pubid/iho/identifier_spec.rb
@@ -44,10 +44,19 @@ RSpec.describe Pubid::Iho::Identifier do
       "IHO S-100 Annex A 5.2.0"      => "IHO S-100 Annex A 5.2.0",
       "IHO S-100 Annex A"            => "IHO S-100 Annex A",
       "IHO S-98 Annex C 1.0.0"       => "IHO S-98 Annex C 1.0.0",
+      # appendix with letter-digit value form (S-122/S-123 Appendix D-2)
+      "IHO S-122 Ap. D-2 1.0.0"      => "IHO S-122 Ap. D-2 1.0.0",
+      # Appendix wording is accepted as input alias, canonicalises to Ap.
+      "IHO S-122 Appendix A 1.0.0"   => "IHO S-122 Ap. A 1.0.0",
+      "IHO S-122 Appendix D-2 1.0.0" => "IHO S-122 Ap. D-2 1.0.0",
+      # supplement (S-66 Suppl 1..4)
+      "IHO S-66 Suppl 1 1.0.0"       => "IHO S-66 Suppl 1 1.0.0",
+      "IHO S-66 Suppl 4 1.0.0"       => "IHO S-66 Suppl 4 1.0.0",
       # IHO prefix is optional on input, always emitted on output
       "S-100 Part 4a 1.0.0"          => "IHO S-100 Part 4a 1.0.0",
       "S-100 Annex A 5.2.0"          => "IHO S-100 Annex A 5.2.0",
       "S-44 5.0.0"                   => "IHO S-44 5.0.0",
+      "S-66 Suppl 1 1.0.0"           => "IHO S-66 Suppl 1 1.0.0",
     }.each do |input, canonical|
       context "with #{input.inspect}" do
         let(:input)     { input }

--- a/spec/pubid/iho/urn_spec.rb
+++ b/spec/pubid/iho/urn_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Pubid::Iho::UrnGenerator do
       "IHO S-100 Part 4a 1.0.0" => "urn:iho:s:100:part.4a:1.0.0",
       "IHO S-65 Ap. A 1.0.0"    => "urn:iho:s:65:ap.A:1.0.0",
       "IHO S-100 Annex A 5.2.0" => "urn:iho:s:100:annex.A:5.2.0",
+      "IHO S-66 Suppl 1 2.0.0"  => "urn:iho:s:66:suppl.1:2.0.0",
       "IHO P-1/21 1.0.0"        => "urn:iho:p:1/21:1.0.0",
       "IHO M-3 2.0.0"           => "urn:iho:m:3:2.0.0",
       "IHO B-4 2.19.0"          => "urn:iho:b:4:2.19.0",


### PR DESCRIPTION
## Summary

Ports [#42](https://github.com/metanorma/pubid/pull/42) (which targeted `main`) to `port/iho-v2`. Adds three IHO parser/renderer changes:

- `Appendix` accepted as an input alias for `Ap.` (canonical render stays `Ap.` for back-compat with existing relaton-data-iho records).
- Appendix value form extended to allow `letter-digits` (e.g. `D-2`).
- New `Suppl <digits>` rule with corresponding `:supplement` attribute, `to_s` suffix, and URN segment.

No semantic difference from #42 — only the v2 code layout differs. PR #42 targeted the legacy `gems/pubid-iho/` multi-gem layout; this PR mirrors the same changes against the flat `lib/pubid/iho/` tree backed by `Lutaml::Model::Serializable`. Stacks on top of #41 (Annex rule port).

Refs relaton/relaton-iho#23.

## Test plan

- [x] `bundle exec rspec spec/pubid/iho/` — 68 examples, 0 failures
- [x] Smoke parses confirm:
  - `parse("IHO S-122 Appendix D-2 1.0.0").appendix == "D-2"`
  - `parse("IHO S-66 Suppl 1 1.0.0").supplement == "1"`
  - `parse("IHO S-65 Ap. A 1.0.0").to_s == "IHO S-65 Ap. A 1.0.0"` (regression check)
- [x] New round-trip cases cover: `Ap. D-2`, `Appendix A` → `Ap. A`, `Appendix D-2` → `Ap. D-2`, `Suppl 1`, `Suppl 4`, `S-66 Suppl 1` → `IHO S-66 Suppl 1` (optional-prefix)
- [x] New URN case: `IHO S-66 Suppl 1 2.0.0` → `urn:iho:s:66:suppl.1:2.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)