### PR TITLE
fix(export): website-compatible keys, full identifier coverage, Registry registration

### DIFF
--- a/lib/pubid/ansi.rb
+++ b/lib/pubid/ansi.rb
@@ -23,5 +23,5 @@ module Pubid
   end
 end
 
-# Register Uansi flavor with the registry
+# Register ANSI flavor with the registry
 Pubid::Registry.register(:ansi, Pubid::Ansi)

--- a/lib/pubid/ansi/identifiers/standard.rb
+++ b/lib/pubid/ansi/identifiers/standard.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "american_national_standard"
+
 module Pubid
   module Ansi
     module Identifiers

--- a/lib/pubid/etsi.rb
+++ b/lib/pubid/etsi.rb
@@ -17,3 +17,6 @@ module Pubid
     end
   end
 end
+
+
+Pubid::Registry.register(:etsi, Pubid::Etsi)

--- a/lib/pubid/export/data_class_exporter.rb
+++ b/lib/pubid/export/data_class_exporter.rb
@@ -3,63 +3,54 @@
 module Pubid
   module Export
     # Strategy for flavors using Lutaml::Model::Serializable as their Scheme
-    # (ETSI, Plateau). These don't have per-class identifier types with
-    # TYPED_STAGES — the Scheme itself is the data model.
+    # (ETSI, Plateau). These have identifier classes in the Identifiers module
+    # that may not have def self.type.
     class DataClassExporter < FlavorExporter
       def export
+        klasses = resolve_identifier_classes_from_module
+        return nil if klasses.empty?
+
+        fixture_data = fixture_examples
+
+        identifier_types = klasses.map do |klass|
+          info = extract_type_info(klass)
+          type_key = info[:key]
+          examples = fixture_data[type_key] || fixture_data[type_key.to_s] || []
+
+          IdentifierTypeResult.new(
+            key: info[:key],
+            title: info[:title],
+            short: info[:short],
+            abbr: info[:abbr],
+            typed_stages: [],
+            examples: examples,
+          )
+        end
+
         scheme = scheme_class
-        return nil unless scheme
-
-        attrs = extract_serializable_attributes(scheme)
-        type_attr = find_type_attribute(attrs, scheme)
-
-        identifier_types = build_types_from_attribute(type_attr, scheme)
+        attrs = scheme&.respond_to?(:attributes) ? scheme.attributes.keys.map(&:to_s) : []
 
         FlavorResult.new(
           flavor: flavor,
           identifier_types: identifier_types,
-          attributes: attrs.keys.map(&:to_s),
+          attributes: attrs,
         )
       end
 
       private
 
-      def extract_serializable_attributes(klass)
-        return {} unless klass.respond_to?(:attributes)
+      def resolve_identifier_classes_from_module
+        mod = scheme_module
+        return [] unless mod
 
-        klass.attributes
-      rescue NoMethodError
-        {}
-      end
+        idents_mod = mod.const_get(:Identifiers)
+        skip = %w[Base Supplement]
 
-      def find_type_attribute(attrs, _scheme)
-        attrs[:type]
-      end
-
-      def build_types_from_attribute(type_attr, _scheme)
-        return [] unless type_attr
-
-        types = known_types_for_flavor
-        types.map do |type_name|
-          IdentifierTypeResult.new(
-            key: type_name.downcase.gsub(/\s+/, "_"),
-            title: type_name,
-            short: nil,
-            abbr: [type_name],
-            typed_stages: [],
-            examples: [],
-          )
-        end
-      end
-
-      def known_types_for_flavor
-        case flavor.to_s
-        when "etsi"
-          %w[EN TS TR GS EG SR]
-        when "plateau"
-          %w[Handbook Technical\ Report]
-        else
-          []
+        idents_mod.constants.filter_map do |c|
+          klass = begin; idents_mod.const_get(c); rescue NameError; next; end
+          next unless klass.is_a?(Class)
+          next if skip.include?(klass.name&.split("::")&.last)
+          klass
         end
       end
     end

--- a/lib/pubid/export/flavor_exporter.rb
+++ b/lib/pubid/export/flavor_exporter.rb
@@ -90,59 +90,210 @@ module Pubid
           end
         end
 
+        # Build set of website keys from Scheme classes to avoid duplicates
+        known_website_keys = Set.new
+        scheme_klasses.each do |klass|
+          info = extract_type_info(klass)
+          known_website_keys << info[:key].to_s if info[:key]
+        end
+
         # Supplement with any typed classes in the Identifiers module
         # that weren't returned by Scheme (e.g., supplements, fragments)
-        scheme_klasses + discover_additional_typed_classes(scheme_klasses)
+        additional = discover_additional_typed_classes(scheme_klasses, known_website_keys)
+        scheme_klasses + additional
       end
 
-      def discover_additional_typed_classes(known)
+      # Classes to skip when discovering additional identifier types
+      SKIP_CLASSES = %w[Base].freeze
+
+      def discover_additional_typed_classes(known_classes, known_website_keys = Set.new)
         mod = scheme_module
         return [] unless mod
 
         idents_mod = mod.const_get(:Identifiers)
-        known_set = Set.new(known)
+        known_set = Set.new(known_classes)
 
         idents_mod.constants.filter_map do |c|
           klass = idents_mod.const_get(c)
         rescue NameError
-          # Some constants may be autoload stubs with typos
           next
         else
           next unless klass.is_a?(Class)
           next if known_set.include?(klass)
-          next if klass <= Exception # skip error classes
+          next if klass <= Exception
+          next if SKIP_CLASSES.include?(klass.name&.split("::")&.last)
 
-          begin
-            has_type = klass.respond_to?(:type) && klass.type && klass.type[:key]
-          rescue NotImplementedError
-            next
-          end
-          has_type ? klass : nil
+          # Check if this class produces a duplicate website key
+          info = extract_type_info(klass)
+          wkey = info[:key]&.to_s
+          next if wkey && known_website_keys.include?(wkey)
+
+          known_website_keys << wkey if wkey
+          klass
         end
       end
 
+      # Explicit overrides mapping (flavor, library_key) → website key
+      # for cases where derived key doesn't match the website convention.
+      WEBSITE_KEY_OVERRIDES = {
+        # ISO
+        [%i[iso], :is] => :international_standard,
+        [%i[iso], :tr] => :technical_report,
+        [%i[iso], :ts] => :technical_specification,
+        [%i[iso], :pas] => :publicly_available_specification,
+        [%i[iso], :tta] => :technology_trends_assessments,
+        [%i[iso], :iwa] => :international_workshop_agreement,
+        [%i[iso], :isp] => :international_standardized_profile,
+        [%i[iso], :rec] => :recommendation,
+        [%i[iso], :dir] => :directives,
+        [%i[iso], :"dir-sup"] => :directives_supplement,
+        [%i[iso], :amd] => :amendment,
+        [%i[iso], :cor] => :corrigendum,
+        [%i[iso], :suppl] => :supplement,
+        [%i[iso], :ext] => :extract,
+        [%i[iso], :add] => :addendum,
+        [%i[iso], :tc] => :tc_document,
+        # IEC
+        [%i[iec], :is] => :international_standard,
+        [%i[iec], :tr] => :technical_report,
+        [%i[iec], :ts] => :technical_specification,
+        [%i[iec], :pas] => :publicly_available_specification,
+        [%i[iec], :trf] => :test_report_form,
+        [%i[iec], :ish] => :interpretation_sheet,
+        [%i[iec], :srd] => :systems_reference_document,
+        [%i[iec], :wd] => :working_document,
+        [%i[iec], :frag] => :fragment_identifier,
+        [%i[iec], :amd] => :amendment,
+        [%i[iec], :cor] => :corrigendum,
+        [%i[iec], :cs] => :component_specification,
+        [%i[iec], :od] => :operational_document,
+        [%i[iec], :sttr] => :societal_technology_trend_report,
+        [%i[iec], :wp] => :white_paper,
+        # IEEE
+        [%i[ieee], :std] => :standard,
+        # NIST
+        [%i[nist], :sp] => :special_publication,
+        [%i[nist], :fips] => :federal_information_processing_standards,
+        [%i[nist], :ir] => :interagency_report,
+        [%i[nist], :hb] => :handbook,
+        [%i[nist], :tn] => :technical_note,
+        [%i[nist], :circ] => :circular,
+        [%i[nist], :circ_supp] => :circular_supplement,
+        [%i[nist], :crpl] => :crpl_report,
+        [%i[nist], :rpt] => :report,
+        [%i[nist], :mono] => :monograph,
+        [%i[nist], :mp] => :miscellaneous_publication,
+        [%i[nist], :gcr] => :grant_contractor_report,
+        [%i[nist], :lc] => :letter_circular,
+        [%i[nist], :cs] => :commercial_standard,
+        [%i[nist], :cse] => :commercial_standard_emergency,
+        [%i[nist], :csm] => :commercial_standards_monthly,
+        # BSI — adopted types share keys with base types, need unique mappings
+        [%i[bsi], :bs] => :british_standard,
+        [%i[bsi], :pd] => :published_document,
+        [%i[bsi], :pas] => :publicly_available_specification,
+        [%i[bsi], :na] => :national_annex,
+        [%i[bsi], :dd] => :draft_document,
+        [%i[bsi], :ep] => :electronic_book,
+        [%i[bsi], :ts] => :technical_specification,
+        [%i[bsi], :handbook] => :handbook,
+        [%i[bsi], :aerospace] => :aerospace_standard,
+        # CEN-CENELEC
+        [%i[cen_cenelec], :en] => :european_norm,
+        [%i[cen_cenelec], :ts] => :technical_specification,
+        [%i[cen_cenelec], :tr] => :technical_report,
+        [%i[cen_cenelec], :cwa] => :cen_workshop_agreement,
+        [%i[cen_cenelec], :hd] => :harmonization_document,
+        [%i[cen_cenelec], :es] => :european_specification,
+        [%i[cen_cenelec], :cr] => :cen_report,
+        [%i[cen_cenelec], :env] => :european_prestandard,
+        # IDF
+        [%i[idf], :is] => :international_standard,
+        [%i[idf], :rm] => :reviewed_method,
+        [%i[idf], :amd] => :amendment,
+        [%i[idf], :cor] => :corrigendum,
+        # CCSDS
+        [%i[ccsds], :base] => :base,
+        [%i[ccsds], :cor] => :corrigendum,
+        # JIS
+        [%i[jis], :jis] => :japanese_industrial_standard,
+        [%i[jis], :tr] => :technical_report,
+        [%i[jis], :ts] => :technical_specification,
+        # SAE
+        [%i[sae], :base] => :standard,
+        # ANSI
+        [%i[ansi], :ans] => :american_national_standard,
+      }.freeze
+
+      # Per-class overrides keyed by class name (for classes that share type keys)
+      CLASS_KEY_OVERRIDES = {
+        "Pubid::Bsi::Identifiers::AdoptedEuropeanNorm" => "adopted_european_norm",
+        "Pubid::Bsi::Identifiers::AdoptedInternationalStandard" => "adopted_international_standard",
+        "Pubid::CenCenelec::Identifiers::AdoptedEuropeanNorm" => "adopted_european_norm",
+        "Pubid::Ansi::Identifiers::Standard" => "standard",
+        "Pubid::Ansi::Identifiers::AmericanNationalStandard" => "american_national_standard",
+        "Pubid::Jis::Identifiers::Standard" => "standard",
+        "Pubid::Ieee::Identifiers::Nesc::Standard" => "nesc",
+        "Pubid::Ieee::Identifiers::Nesc::Draft" => "nesc",
+        "Pubid::Ieee::Identifiers::Nesc::Handbook" => "nesc",
+        "Pubid::Ieee::Identifiers::Nesc::Redline" => "nesc",
+      }.freeze
+
       def extract_type_info(klass)
-        type_info = klass.respond_to?(:type) ? klass.type : nil
+        # Per-class override takes highest priority
+        class_key = CLASS_KEY_OVERRIDES[klass.name]
+        if class_key
+          type_info = begin
+            klass.respond_to?(:type) ? klass.type : nil
+          rescue NotImplementedError
+            nil
+          end
+          metadata = klass.respond_to?(:metadata) ? klass.metadata : nil
+          return {
+            key: class_key,
+            title: type_info&.dig(:title) || metadata&.title || class_key.tr("_", " ").capitalize,
+            short: type_info&.dig(:short) || metadata&.short,
+            abbr: metadata&.abbr || [],
+          }
+        end
+
+        type_info = begin
+          klass.respond_to?(:type) ? klass.type : nil
+        rescue NotImplementedError
+          nil
+        end
         metadata = klass.respond_to?(:metadata) ? klass.metadata : nil
 
-        key = type_info&.dig(:key)
+        lib_key = type_info&.dig(:key)
         title = type_info&.dig(:title) || metadata&.title
         short = type_info&.dig(:short) || metadata&.short
         abbr = metadata&.abbr || []
 
-        # Fallback: derive from class name when def self.type is missing
-        unless key
+        # Derive from class name when def self.type is missing
+        unless lib_key
           class_name = klass.name&.split("::")&.last
-          key = class_name&.gsub(/([A-Z])/, '_\1')&.downcase&.sub(/^_/, "")&.to_sym
+          lib_key = class_name&.gsub(/([A-Z])/, '_\1')&.downcase&.sub(/^_/, "")&.to_sym
           title ||= class_name&.gsub(/([A-Z])/, ' \1')&.strip
         end
 
+        # Map library key to website-compatible key
+        website_key = resolve_website_key(lib_key)
+
         {
-          key: key,
+          key: website_key,
           title: title,
           short: short,
           abbr: abbr,
         }
+      end
+
+      def resolve_website_key(lib_key)
+        key_str = lib_key.to_s
+        WEBSITE_KEY_OVERRIDES.each do |(flavors, from_key), to_key|
+          next unless flavors.include?(flavor)
+          return to_key.to_s if from_key.to_s == key_str
+        end
+        key_str
       end
 
       def extract_typed_stages(klass)

--- a/lib/pubid/export/ieee_exporter.rb
+++ b/lib/pubid/export/ieee_exporter.rb
@@ -1,34 +1,34 @@
 # frozen_string_literal: true
 
+require "set"
+
 module Pubid
   module Export
-    # Strategy for IEEE, which has a unique Scheme without an `identifiers`
-    # method. Instead, identifier classes are discovered from the Identifiers
-    # module constant list.
+    # Strategy for IEEE, which has identifier classes in the Identifiers module
+    # without a Scheme.identifiers method.
     class IeeeExporter < FlavorExporter
-      KEY_IDENTIFIER_CLASSES = %i[
-        Standard ProjectDraftIdentifier Base RedlinedStandard
-      ].freeze
-
       def export
         klasses = resolve_ieee_identifiers
         return nil if klasses.empty?
 
-        all_stages = extract_ieee_stages
+        fixture_data = fixture_examples
+        seen_keys = Set.new
 
-        identifier_types = klasses.map do |klass|
+        identifier_types = klasses.filter_map do |klass|
           info = extract_type_info(klass)
+          next if seen_keys.include?(info[:key])
+          seen_keys << info[:key]
 
-          # Only assign stages to the primary type (Standard)
-          stages = (info[:key] == :std) ? all_stages : []
+          type_key = info[:key]
+          examples = match_ieee_examples(fixture_data, type_key, klass)
 
           IdentifierTypeResult.new(
             key: info[:key],
             title: info[:title],
             short: info[:short],
             abbr: info[:abbr],
-            typed_stages: stages,
-            examples: [],
+            typed_stages: [],
+            examples: examples,
           )
         end
 
@@ -43,19 +43,33 @@ module Pubid
 
       def resolve_ieee_identifiers
         identifiers_mod = scheme_module::Identifiers
-        KEY_IDENTIFIER_CLASSES.filter_map do |name|
-          identifiers_mod.const_get(name)
-        rescue NameError
-          nil
+        skip = %w[Base Supplement]
+        klasses = []
+        collect_classes(identifiers_mod, skip, klasses)
+        klasses
+      end
+
+      def collect_classes(mod, skip, result)
+        mod.constants.each do |c|
+          const = begin; mod.const_get(c); rescue NameError; next; end
+          if const.is_a?(Module) && !const.is_a?(Class)
+            collect_classes(const, skip, result)
+          elsif const.is_a?(Class)
+            next if skip.include?(const.name&.split("::")&.last)
+            result << const
+          end
         end
       end
 
-      def extract_ieee_stages
-        return [] unless scheme_module.const_defined?(:TypedStages)
+      def match_ieee_examples(fixture_data, type_key, klass)
+        # Try direct key match
+        examples = fixture_data[type_key] || fixture_data[type_key.to_s] || []
+        return examples if examples.any?
 
-        scheme_module::TypedStages::TYPED_STAGES
-      rescue NameError
-        []
+        # Try class name match
+        class_name = klass.name&.split("::")&.last
+        snake_name = class_name&.gsub(/([A-Z])/, '_\1')&.downcase&.sub(/^_/, "")
+        fixture_data[snake_name] || []
       end
     end
   end

--- a/lib/pubid/export/itu_exporter.rb
+++ b/lib/pubid/export/itu_exporter.rb
@@ -5,49 +5,57 @@ module Pubid
     # Strategy for ITU, which uses a transform/model pattern without
     # traditional identifier classes or TYPED_STAGES.
     class ItuExporter < FlavorExporter
-      def export
-        scheme = scheme_class
-        return nil unless scheme
+      WEBSITE_KEY_OVERRIDES = {
+        "special_publication" => "special_publication",
+      }.freeze
 
-        attrs = extract_serializable_attributes(scheme)
+      def export
+        klasses = resolve_itu_identifiers
+        return nil if klasses.empty?
+
+        fixture_data = fixture_examples
+
+        identifier_types = klasses.map do |klass|
+          info = extract_type_info(klass)
+          type_key = info[:key]
+          examples = fixture_data[type_key] || fixture_data[type_key.to_s] || []
+
+          IdentifierTypeResult.new(
+            key: info[:key],
+            title: info[:title],
+            short: info[:short],
+            abbr: info[:abbr],
+            typed_stages: [],
+            examples: examples,
+          )
+        end
 
         FlavorResult.new(
           flavor: flavor,
-          identifier_types: itu_identifier_types,
-          attributes: extract_attribute_names(scheme),
+          identifier_types: identifier_types,
+          attributes: extract_attribute_names,
         )
       end
 
       private
 
-      def extract_serializable_attributes(klass)
-        return {} unless klass.respond_to?(:model_attributes)
-        klass.model_attributes
-      rescue NoMethodError
-        {}
+      def resolve_itu_identifiers
+        identifiers_mod = scheme_module::Identifiers
+        skip = %w[Base]
+        identifiers_mod.constants.filter_map do |c|
+          klass = begin; identifiers_mod.const_get(c); rescue NameError; next; end
+          next unless klass.is_a?(Class)
+          next if skip.include?(klass.name&.split("::")&.last)
+          klass
+        end
       end
 
-      def extract_attribute_names(scheme)
-        return [] unless scheme.respond_to?(:model_class)
-        model = scheme.model_class
-        return [] unless model && model.respond_to?(:model_attributes)
+      def extract_attribute_names
+        model = scheme_module::Identifier
+        return [] unless model&.respond_to?(:model_attributes)
         model.model_attributes.keys.map(&:to_s)
       rescue NoMethodError, NameError
         []
-      end
-
-      def itu_identifier_types
-        # ITU has sector-based types (Recommendation, Resolution, etc.)
-        %w[recommendation resolution handbook].map do |type_name|
-          IdentifierTypeResult.new(
-            key: type_name,
-            title: type_name.capitalize,
-            short: nil,
-            abbr: [type_name.capitalize],
-            typed_stages: [],
-            examples: [],
-          )
-        end
       end
     end
   end

--- a/lib/pubid/export/nist_exporter.rb
+++ b/lib/pubid/export/nist_exporter.rb
@@ -13,17 +13,20 @@ module Pubid
         klasses = scheme.identifiers.reject { |k| k == scheme_module::Identifiers::Base }
         fixture_data = fixture_examples
 
-        identifier_types = klasses.map do |klass|
-          type_info = klass.respond_to?(:type) ? klass.type : nil
+        seen_keys = Set.new
+        identifier_types = klasses.filter_map do |klass|
+          info = extract_type_info(klass)
+          type_key = info[:key]
+          next if seen_keys.include?(type_key)
+          seen_keys << type_key
+
+          examples = match_nist_examples(fixture_data, type_key, klass)
           stages = klass.respond_to?(:typed_stages) ? klass.typed_stages : []
 
-          type_key = type_info&.dig(:key)
-          examples = match_nist_examples(fixture_data, type_key, klass)
-
           IdentifierTypeResult.new(
-            key: type_key,
-            title: type_info&.dig(:title),
-            short: type_info&.dig(:short),
+            key: info[:key],
+            title: info[:title],
+            short: info[:short],
             abbr: stages.flat_map(&:abbr),
             typed_stages: stages,
             examples: examples,

--- a/lib/pubid/export/registry_exporter.rb
+++ b/lib/pubid/export/registry_exporter.rb
@@ -12,13 +12,14 @@ module Pubid
         registry = extract_registry
         return nil if registry.empty?
 
-        registry_keys = Set.new
+        known_website_keys = Set.new
 
         identifier_types = registry.group_by(&:type_code).map do |type_code, stages|
-          registry_keys << type_code.to_s
+          wkey = resolve_website_key(type_code).to_s
+          known_website_keys << wkey
           primary = stages.first
           IdentifierTypeResult.new(
-            key: type_code,
+            key: wkey,
             title: primary.name,
             short: nil,
             abbr: primary.abbr,
@@ -28,7 +29,7 @@ module Pubid
         end
 
         # Supplement with typed classes not in the registry
-        additional = discover_additional_from_identifiers(registry_keys)
+        additional = discover_additional_from_identifiers(known_website_keys)
         identifier_types.concat(additional)
 
         FlavorResult.new(
@@ -57,6 +58,7 @@ module Pubid
         return [] unless mod
 
         idents_mod = mod.const_get(:Identifiers)
+        skip = %w[Base]
 
         idents_mod.constants.filter_map do |c|
           klass = idents_mod.const_get(c)
@@ -64,22 +66,19 @@ module Pubid
           next
         else
           next unless klass.is_a?(Class)
+          next if skip.include?(klass.name&.split("::")&.last)
 
-          begin
-            type_info = klass.respond_to?(:type) ? klass.type : nil
-            next unless type_info && type_info[:key]
-          rescue NotImplementedError
-            next
-          end
+          info = extract_type_info(klass)
+          next unless info[:key]
 
-          key_str = type_info[:key].to_s
-          next if known_keys.include?(key_str)
+          website_key = info[:key].to_s
+          next if known_keys.include?(website_key)
 
-          known_keys << key_str
+          known_keys << website_key
           IdentifierTypeResult.new(
-            key: type_info[:key],
-            title: type_info[:title],
-            short: type_info[:short],
+            key: website_key,
+            title: info[:title],
+            short: info[:short],
             abbr: [],
             typed_stages: [],
             examples: [],

--- a/lib/pubid/iec.rb
+++ b/lib/pubid/iec.rb
@@ -27,6 +27,12 @@ require_relative "iec/identifiers/sheet_identifier"
 require_relative "iec/identifiers/consolidated_identifier"
 require_relative "iec/identifiers/fragment_identifier"
 
+# Additional document types
+require_relative "iec/identifiers/component_specification"
+require_relative "iec/identifiers/operational_document"
+require_relative "iec/identifiers/societal_technology_trend_report"
+require_relative "iec/identifiers/white_paper"
+
 module Pubid
   module Iec
     # Primary document types (not supplements)
@@ -75,3 +81,5 @@ end
 require_relative "iec/urn_parser"
 require_relative "iec/builder"
 require_relative "iec/parser"
+
+Pubid::Registry.register(:iec, Pubid::Iec)

--- a/lib/pubid/ieee.rb
+++ b/lib/pubid/ieee.rb
@@ -28,3 +28,6 @@ module Pubid
     end
   end
 end
+
+
+Pubid::Registry.register(:ieee, Pubid::Ieee)

--- a/lib/pubid/iso.rb
+++ b/lib/pubid/iso.rb
@@ -37,3 +37,7 @@ module Pubid
     end
   end
 end
+
+
+
+Pubid::Registry.register(:iso, Pubid::Iso)

--- a/lib/pubid/nist.rb
+++ b/lib/pubid/nist.rb
@@ -32,3 +32,6 @@ module Pubid
     end
   end
 end
+
+
+Pubid::Registry.register(:nist, Pubid::Nist)

--- a/lib/pubid/nist/identifiers/circular_supplement.rb
+++ b/lib/pubid/nist/identifiers/circular_supplement.rb
@@ -27,7 +27,7 @@ module Pubid
           end
 
           def type
-            { key: :circ, title: "NBS Circular Supplement", short: "CIRC" }
+            { key: :circ_supp, title: "NBS Circular Supplement", short: "CIRC" }
           end
         end
 

--- a/lib/pubid/sae.rb
+++ b/lib/pubid/sae.rb
@@ -15,3 +15,6 @@ module Pubid
     end
   end
 end
+
+
+Pubid::Registry.register(:sae, Pubid::Sae)

--- a/lib/pubid/serializable/deserializer.rb
+++ b/lib/pubid/serializable/deserializer.rb
@@ -20,6 +20,11 @@ module Pubid
         # Get the appropriate flavor module
         begin
           flavor_module = Pubid::Registry.get(flavor)
+          unless flavor_module
+            # Trigger autoload by referencing the module constant
+            mod_name = flavor.to_s.split("_").map(&:capitalize).join
+            flavor_module = Pubid.const_get(mod_name)
+          end
           raise ArgumentError unless flavor_module
         rescue StandardError
           raise ArgumentError, "Unknown flavor: #{flavor}"

--- a/lib/tasks/website-data.json
+++ b/lib/tasks/website-data.json
@@ -2,7 +2,7 @@
   "iso": {
     "identifier_types": [
       {
-        "key": "is",
+        "key": "international_standard",
         "title": "International Standard",
         "short": "IS",
         "abbr": [
@@ -252,7 +252,7 @@
         ]
       },
       {
-        "key": "tr",
+        "key": "technical_report",
         "title": "Technical Report",
         "short": "TR",
         "abbr": [],
@@ -428,7 +428,7 @@
         ]
       },
       {
-        "key": "ts",
+        "key": "technical_specification",
         "title": "Technical Specification",
         "short": "TS",
         "abbr": [],
@@ -774,7 +774,7 @@
         ]
       },
       {
-        "key": "pas",
+        "key": "publicly_available_specification",
         "title": "Publicly Available Specification",
         "short": "PAS",
         "abbr": [],
@@ -1039,7 +1039,7 @@
         "examples": []
       },
       {
-        "key": "tta",
+        "key": "technology_trends_assessments",
         "title": "Technology Trends Assessments",
         "short": "TTA",
         "abbr": [],
@@ -1197,7 +1197,7 @@
         ]
       },
       {
-        "key": "iwa",
+        "key": "international_workshop_agreement",
         "title": "International Workshop Agreement",
         "short": "IWA",
         "abbr": [],
@@ -1335,7 +1335,7 @@
         ]
       },
       {
-        "key": "isp",
+        "key": "international_standardized_profile",
         "title": "International Standardized Profile",
         "short": "ISP",
         "abbr": [],
@@ -1487,7 +1487,7 @@
         ]
       },
       {
-        "key": "rec",
+        "key": "recommendation",
         "title": "Recommendation",
         "short": "R",
         "abbr": [],
@@ -1564,7 +1564,7 @@
         ]
       },
       {
-        "key": "dir",
+        "key": "directives",
         "title": "Directives",
         "short": "DIR",
         "abbr": [],
@@ -1600,7 +1600,7 @@
         ]
       },
       {
-        "key": "amd",
+        "key": "amendment",
         "title": "Amendment",
         "short": "AMD",
         "abbr": [],
@@ -1791,7 +1791,7 @@
         ]
       },
       {
-        "key": "cor",
+        "key": "corrigendum",
         "title": "Corrigendum",
         "short": "COR",
         "abbr": [],
@@ -1951,7 +1951,7 @@
         ]
       },
       {
-        "key": "suppl",
+        "key": "supplement",
         "title": "Supplement",
         "short": "suppl",
         "abbr": [],
@@ -2079,7 +2079,7 @@
         "examples": []
       },
       {
-        "key": "ext",
+        "key": "extract",
         "title": "Extract",
         "short": "Ext",
         "abbr": [],
@@ -2100,7 +2100,7 @@
         "examples": []
       },
       {
-        "key": "dir-sup",
+        "key": "directives_supplement",
         "title": "Directives Supplement",
         "short": "SUP",
         "abbr": [],
@@ -2133,7 +2133,7 @@
         ]
       },
       {
-        "key": "add",
+        "key": "addendum",
         "title": "Addendum",
         "short": "ADD",
         "abbr": [],
@@ -2274,7 +2274,7 @@
         "examples": []
       },
       {
-        "key": "tc",
+        "key": "tc_document",
         "title": "Technical Committee Document",
         "short": "TC",
         "abbr": [],
@@ -2287,7 +2287,7 @@
   "iec": {
     "identifier_types": [
       {
-        "key": "is",
+        "key": "international_standard",
         "title": "International Standard",
         "short": null,
         "abbr": [],
@@ -2433,7 +2433,7 @@
         ]
       },
       {
-        "key": "tr",
+        "key": "technical_report",
         "title": "Technical Report",
         "short": "TR",
         "abbr": [],
@@ -2562,7 +2562,7 @@
         ]
       },
       {
-        "key": "ts",
+        "key": "technical_specification",
         "title": "Technical Specification",
         "short": "TS",
         "abbr": [],
@@ -2691,7 +2691,7 @@
         ]
       },
       {
-        "key": "pas",
+        "key": "publicly_available_specification",
         "title": "Publicly Available Specification",
         "short": "PAS",
         "abbr": [],
@@ -2970,7 +2970,7 @@
         ]
       },
       {
-        "key": "trf",
+        "key": "test_report_form",
         "title": "Test Report Form",
         "short": "TRF",
         "abbr": [],
@@ -3002,7 +3002,7 @@
         ]
       },
       {
-        "key": "ish",
+        "key": "interpretation_sheet",
         "title": "Interpretation Sheet",
         "short": "ISH",
         "abbr": [],
@@ -3131,7 +3131,7 @@
         ]
       },
       {
-        "key": "srd",
+        "key": "systems_reference_document",
         "title": "Systems Reference Document",
         "short": "SRD",
         "abbr": [],
@@ -3163,7 +3163,7 @@
         ]
       },
       {
-        "key": "wd",
+        "key": "working_document",
         "title": "Working Document",
         "short": "WD",
         "abbr": [],
@@ -3182,7 +3182,64 @@
         ]
       },
       {
-        "key": "frag",
+        "key": "societal_technology_trend_report",
+        "title": "Societal and Technology Trend Report",
+        "short": "Trend Report",
+        "abbr": [],
+        "typed_stages": [
+          {
+            "stage_code": "published",
+            "type_code": "sttr",
+            "abbr": [
+              "Trend Report"
+            ],
+            "name": "Societal and Technology Trend Report",
+            "harmonized_stages": [
+              "60.00",
+              "60.60"
+            ]
+          }
+        ],
+        "examples": []
+      },
+      {
+        "key": "white_paper",
+        "title": "White Paper",
+        "short": "White Paper",
+        "abbr": [],
+        "typed_stages": [
+          {
+            "stage_code": "published",
+            "type_code": "wp",
+            "abbr": [
+              "White Paper"
+            ],
+            "name": "White Paper",
+            "harmonized_stages": [
+              "60.00",
+              "60.60"
+            ]
+          }
+        ],
+        "examples": []
+      },
+      {
+        "key": "sheet_identifier",
+        "title": "Sheet Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "IEC 60695-2-1/0:1994",
+          "IEC 60695-2-1/1:1994",
+          "IEC 60695-2-1/2:1994",
+          "IEC 60695-2-1/3:1994",
+          "IEC 60695-2-4/1:1991",
+          "IEC TS 60695-2-4/2:1994"
+        ]
+      },
+      {
+        "key": "fragment_identifier",
         "title": "Fragment",
         "short": "FRAG",
         "abbr": [],
@@ -3328,7 +3385,7 @@
         ]
       },
       {
-        "key": "amd",
+        "key": "amendment",
         "title": "Amendment",
         "short": "AMD",
         "abbr": [],
@@ -3475,7 +3532,7 @@
         ]
       },
       {
-        "key": "cor",
+        "key": "corrigendum",
         "title": "Corrigendum",
         "short": "COR",
         "abbr": [],
@@ -3620,6 +3677,75 @@
           "IEC 60050-702:1992/COR1:1992",
           "IEC 60050-702:1992/COR2:1994"
         ]
+      },
+      {
+        "key": "consolidated_identifier",
+        "title": "Consolidated Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "vap_identifier",
+        "title": "Vap Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "CISPR 11:1975+AMD1:1976 CSV",
+          "CISPR 11:1997+AMD1:1999 CSV",
+          "CISPR 11:2003+AMD1:2004 CSV",
+          "CISPR 11:2009+AMD1:2010 CSV",
+          "CISPR 11:2015+AMD1:2016+AMD2:2019 CSV",
+          "CISPR 12:2001+AMD1:2005 CSV",
+          "CISPR 12:2007+AMD1:2009 CSV",
+          "CISPR 13:1996+AMD1:1998 CSV",
+          "CISPR 13:2001+AMD1:2003+AMD2:2006 CSV",
+          "CISPR 13:2009+AMD1:2015 CSV"
+        ]
+      },
+      {
+        "key": "component_specification",
+        "title": "Component Specification",
+        "short": "CS",
+        "abbr": [],
+        "typed_stages": [
+          {
+            "stage_code": "published",
+            "type_code": "cs",
+            "abbr": [
+              "CS"
+            ],
+            "name": "Component Specification",
+            "harmonized_stages": [
+              "60.00",
+              "60.60"
+            ]
+          }
+        ],
+        "examples": []
+      },
+      {
+        "key": "operational_document",
+        "title": "Operational Document",
+        "short": "OD",
+        "abbr": [],
+        "typed_stages": [
+          {
+            "stage_code": "published",
+            "type_code": "od",
+            "abbr": [
+              "OD"
+            ],
+            "name": "Operational Document",
+            "harmonized_stages": [
+              "60.00",
+              "60.60"
+            ]
+          }
+        ],
+        "examples": []
       }
     ],
     "attributes": [],
@@ -3637,146 +3763,117 @@
   "ieee": {
     "identifier_types": [
       {
-        "key": "std",
-        "title": "Standard",
-        "short": "Std",
+        "key": "conformance_identifier",
+        "title": "Conformance Identifier",
+        "short": null,
         "abbr": [],
-        "typed_stages": [
-          {
-            "stage_code": "published",
-            "type_code": "standard",
-            "abbr": [
-              "Std"
-            ],
-            "name": "Published Standard",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "working_draft",
-            "type_code": "draft",
-            "abbr": [
-              "D1"
-            ],
-            "name": "Working Draft",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "committee_draft",
-            "type_code": "draft",
-            "abbr": [
-              "D2",
-              "D3"
-            ],
-            "name": "Committee Draft",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "draft_standard",
-            "type_code": "draft",
-            "abbr": [
-              "D4",
-              "D5",
-              "D6"
-            ],
-            "name": "Draft Standard",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "final_draft",
-            "type_code": "draft",
-            "abbr": [
-              "D7",
-              "D8",
-              "D9"
-            ],
-            "name": "Final Draft",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "preliminary",
-            "type_code": "draft",
-            "abbr": [
-              "PWI"
-            ],
-            "name": "Preliminary Work Item",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "new_proposal",
-            "type_code": "draft",
-            "abbr": [
-              "NP"
-            ],
-            "name": "New Work Item Proposal",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "working_draft",
-            "type_code": "draft",
-            "abbr": [
-              "WD"
-            ],
-            "name": "Working Draft",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "committee_draft",
-            "type_code": "draft",
-            "abbr": [
-              "CD",
-              "CD2",
-              "CD3"
-            ],
-            "name": "Committee Draft",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "draft_international_standard",
-            "type_code": "draft",
-            "abbr": [
-              "DIS"
-            ],
-            "name": "Draft International Standard",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "final_draft",
-            "type_code": "draft",
-            "abbr": [
-              "FDIS"
-            ],
-            "name": "Final Draft",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "published",
-            "type_code": "standard",
-            "abbr": [
-              "No",
-              "No."
-            ],
-            "name": "Published Standard",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "draft",
-            "type_code": "draft",
-            "abbr": [
-              "P"
-            ],
-            "name": "Draft",
-            "harmonized_stages": []
-          },
-          {
-            "stage_code": "draft",
-            "type_code": "draft",
-            "abbr": [
-              "Draft"
-            ],
-            "name": "Draft",
-            "harmonized_stages": []
-          }
-        ],
+        "typed_stages": [],
+        "examples": [
+          "IEEE Std 1904.1/Conformance02-2014",
+          "IEEE Std 1904.1/Conformance03-2014",
+          "IEEE Std 802.16/Conformance01-2003"
+        ]
+      },
+      {
+        "key": "csa_dual_published",
+        "title": "Csa Dual Published",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "IEEE Std 844.1-2017/CSA C22.2 NO. 293.1-17",
+          "IEEE Std 844.2-2017/CSA C293.2-17",
+          "IEEE Std 844.3-2019/CSA C22.2 NO. 293.3:19",
+          "IEEE Std 844.4-2019/CSA C293.4:19"
+        ]
+      },
+      {
+        "key": "dual_identifier",
+        "title": "Dual Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "dual_published",
+        "title": "Dual Published",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "IEEE P1680.4/D1 and NSF/ANSI 426, August 2016",
+          "IEEE P1680.4/D2 and NSF/ANSI 426, January 2017",
+          "IEEE P1680.4/D3 and NSF/ANSI 426, May 2017",
+          "IEEE Std 108-1955 and AIEE No. 450, April 1955",
+          "IEEE Std 309-1999 and ANSI N42.3-1999",
+          "IEEE Std 802.10e-1993 and IEEE Std 802.10f-1993",
+          "IEEE Std 802.16e-2005 and IEEE Std 802.16-2004/Cor. 1-2005",
+          "IEEE Std 802.3u-1995 (Supplement to ISO/IEC 8802-3) and ANSI/IEEE 802.3-1993",
+          "IEEE Std 802.5r and IEEE Std 802.5j-1998 (ISO/IEC 8802-5:1998/Amd.1)",
+          "IEEE Std 960-1989 and IEEE Std 1177-1989"
+        ]
+      },
+      {
+        "key": "iec_ieee_copublished",
+        "title": "Iec Ieee Copublished",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "IEC/IEEE 60079-30-2/D5 IEC:2013 10/07",
+          "IEC/IEEE CD P62704-5 ED1",
+          "IEC/IEEE CDV P62704-2/D4",
+          "IEC/IEEE CDV 80005-3, 2016",
+          "IEC/IEEE FDIS 60079-30-2",
+          "IEC/IEEE FDIS P60079-30-1",
+          "IEC/IEEE FDIS P60780-323",
+          "IEC/IEEE 60076-16 Edition 2.0 2018-09",
+          "IEC/IEEE 60079-30-1 Edition 1.0 2015-09",
+          "IEC/IEEE 60079-30-2 Edition 1.0 2015-09"
+        ]
+      },
+      {
+        "key": "interpretation_identifier",
+        "title": "Interpretation Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "IEEE Std 1003.1-1988/INT-1992",
+          "IEEE Std 1076/INT-1991"
+        ]
+      },
+      {
+        "key": "joint_development",
+        "title": "Joint Development",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "IEC/IEEE P60780.323/P-2014",
+          "IEC/IEEE P62582.6/P-2019",
+          "ISO/IEC/IEEE P21840/P-2019",
+          "IEC/IEEE P62704.3/D2",
+          "ISO/IEC/IEEE P11073.10417/D2-2015"
+        ]
+      },
+      {
+        "key": "multi_numbered_identifier",
+        "title": "Multi Numbered Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "IEEE Std 1299 and IEEE Std"
+        ]
+      },
+      {
+        "key": "parenthetical_identifier",
+        "title": "Parenthetical Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
         "examples": []
       },
       {
@@ -3785,15 +3882,18 @@
         "short": null,
         "abbr": [],
         "typed_stages": [],
-        "examples": []
-      },
-      {
-        "key": "base",
-        "title": "Base",
-        "short": null,
-        "abbr": [],
-        "typed_stages": [],
-        "examples": []
+        "examples": [
+          "IEC/IEEE 62582.2.am1, July 2015 (Amendment to IEC/IEEE 62582-2: 2011)",
+          "IEEE P1031/D1+1, August, 2010",
+          "IEEE P1048/D6+1, May 2012",
+          "IEEE P1062/D.19, March, 2015",
+          "IEEE P1062/D.30, September, 2015",
+          "IEEE P1149.1/D2012.e27, September, 2012",
+          "IEEE P1149.1/D2012.e29, November, 2012",
+          "IEEE P1377/D11, March, 2012",
+          "IEEE P1609.12/D7, June 2012 (Approved Draft)",
+          "IEEE P1680.2/D7, May 2012 (Approved Draft)"
+        ]
       },
       {
         "key": "redlined_standard",
@@ -3802,6 +3902,87 @@
         "abbr": [],
         "typed_stages": [],
         "examples": []
+      },
+      {
+        "key": "si_standard",
+        "title": "Si Standard",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "IEEE/ASTM SI 10 -2010 (Revision of IEEE/ASTM SI 10 -2002)",
+          "IEEE/ASTM PSI 10/D2 , October 2015",
+          "IEEE/ASTM PSI 10/D3 , October 2010",
+          "IEEE/ASTM PSI 10/D3 , October 2015",
+          "IEEE/ASTM SI 10 -1997",
+          "IEEE/ASTM SI 10 -2002 (Revision of IEEE/ASTM SI 10 -1997)",
+          "IEEE/ASTM SI 10 -2016 (Revision of IEEE/ASTM SI 10 -2010)"
+        ]
+      },
+      {
+        "key": "standard",
+        "title": "Standard",
+        "short": "Std",
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "IEEE Std 1076.CONC-1990",
+          "ANSI/IEEE 101-1987 (Revision of IEEE Std 101-1972)",
+          "ANSI/IEEE 336-1980 (revision of ANSI/IEEE Std 336-1977)",
+          "ANSI/IEEE 488-1978 (Revision of IEEE Std (ANSI/IEEE 488-1975. Includes supplement IEEE Std 488A-19801))",
+          "ANSI/IEEE 500-1984 (P&V)",
+          "ANSI/IEEE 620-1981 (Issued April 1981 for trail use)",
+          "ANSI/IEEE 802.11-1999 (R2003)",
+          "ANSI/IEEE 802.12-1998 (incorporates IEEE Std (ANSI/IEEE Stds 802.122-1995) and ANSI/IEEE 802.12d-1997)",
+          "ANSI/IEEE 896.1-1994",
+          "C2-1997 National Electrical Safety Code"
+        ]
+      },
+      {
+        "key": "supplement_identifier",
+        "title": "Supplement Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "corrigendum",
+        "title": "Corrigendum",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "IEEE Std C37.09-2018/Cor. 1-2021",
+          "IEEE Std C62.21-2003/Cor. 1-2008",
+          "IEEE Std 802.3-2005/Cor. 2-2007",
+          "ANSI C63.5-2017/Cor. 1-2019",
+          "IEEE Std 1672-2006/Cor. 1-2008",
+          "IEEE Std 1003.1-2001/Cor. 2-2004",
+          "IEEE Std 1003.1-2008/Cor. 1-2013",
+          "IEEE Std 1015-2006/Cor. 1-2007",
+          "IEEE Std 11073-10418-2011/Cor. 1-2015",
+          "IEEE Std 11073-10424-2014/Cor. 1-2017"
+        ]
+      },
+      {
+        "key": "adopted_standard",
+        "title": "Adopted Standard",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "55 IRE 2.S1 (IEEE Std 147)",
+          "61 IRE 15.S1 (IEEE Std 182)",
+          "61 IRE 28 S1 (IEEE Std 216)",
+          "62 IRE 12.S1 (IEEE Std 174)",
+          "62 IRE 7.S2 (IEEE Std 161)",
+          "AIEE No 14-1925 (AESC C22-1925)",
+          "AIEE No 18-1934 (ASA C55-1934)",
+          "IEEE Std 159-1972 (52 IRE 7 S2)",
+          "IEEE Std 175-1960 (60 IRE 13 S1)",
+          "AIEE No 15-1944 (ASA C19.1-1943)"
+        ]
       }
     ],
     "attributes": []
@@ -3809,7 +3990,7 @@
   "nist": {
     "identifier_types": [
       {
-        "key": "sp",
+        "key": "special_publication",
         "title": "NIST Special Publication",
         "short": "SP",
         "abbr": [
@@ -3844,7 +4025,7 @@
         ]
       },
       {
-        "key": "fips",
+        "key": "federal_information_processing_standards",
         "title": "Federal Information Processing Standards",
         "short": "FIPS",
         "abbr": [
@@ -3877,7 +4058,7 @@
         ]
       },
       {
-        "key": "ir",
+        "key": "interagency_report",
         "title": "NIST Interagency Report",
         "short": "IR",
         "abbr": [
@@ -3912,7 +4093,7 @@
         ]
       },
       {
-        "key": "hb",
+        "key": "handbook",
         "title": "NIST Handbook",
         "short": "HB",
         "abbr": [
@@ -3947,7 +4128,7 @@
         ]
       },
       {
-        "key": "tn",
+        "key": "technical_note",
         "title": "NIST Technical Note",
         "short": "TN",
         "abbr": [
@@ -3982,7 +4163,7 @@
         ]
       },
       {
-        "key": "circ",
+        "key": "circular",
         "title": "NBS Circular",
         "short": "CIRC",
         "abbr": [
@@ -4015,7 +4196,7 @@
         ]
       },
       {
-        "key": "circ",
+        "key": "circular_supplement",
         "title": "NBS Circular Supplement",
         "short": "CIRC",
         "abbr": [
@@ -4048,7 +4229,7 @@
         ]
       },
       {
-        "key": "crpl",
+        "key": "crpl_report",
         "title": "NBS CRPL Report",
         "short": "CRPL",
         "abbr": [
@@ -4089,7 +4270,7 @@
         ]
       },
       {
-        "key": "rpt",
+        "key": "report",
         "title": "NBS Report",
         "short": "RPT",
         "abbr": [
@@ -4122,7 +4303,7 @@
         ]
       },
       {
-        "key": "mono",
+        "key": "monograph",
         "title": "Monograph",
         "short": "MONO",
         "abbr": [
@@ -4157,7 +4338,7 @@
         ]
       },
       {
-        "key": "mp",
+        "key": "miscellaneous_publication",
         "title": "Miscellaneous Publication",
         "short": "MP",
         "abbr": [
@@ -4190,7 +4371,7 @@
         ]
       },
       {
-        "key": "gcr",
+        "key": "grant_contractor_report",
         "title": "NIST Grant/Contractor Report",
         "short": "GCR",
         "abbr": [
@@ -4313,7 +4494,7 @@
         ]
       },
       {
-        "key": "lc",
+        "key": "letter_circular",
         "title": "Letter Circular",
         "short": "LCIRC",
         "abbr": [
@@ -4344,7 +4525,7 @@
         ]
       },
       {
-        "key": "cs",
+        "key": "commercial_standard",
         "title": "Commercial Standard",
         "short": "CS",
         "abbr": [
@@ -4377,7 +4558,7 @@
         ]
       },
       {
-        "key": "cse",
+        "key": "commercial_standard_emergency",
         "title": "NBS Commercial Standard Emergency",
         "short": "CS-E",
         "abbr": [
@@ -4405,7 +4586,7 @@
         ]
       },
       {
-        "key": "csm",
+        "key": "commercial_standards_monthly",
         "title": "Commercial Standards Monthly",
         "short": "CSM",
         "abbr": [
@@ -4443,7 +4624,7 @@
   "bsi": {
     "identifier_types": [
       {
-        "key": "bs",
+        "key": "british_standard",
         "title": "British Standard",
         "short": null,
         "abbr": [
@@ -4483,7 +4664,7 @@
         "examples": []
       },
       {
-        "key": "pd",
+        "key": "published_document",
         "title": "Published Document",
         "short": null,
         "abbr": [
@@ -4506,7 +4687,7 @@
         "examples": []
       },
       {
-        "key": "pas",
+        "key": "publicly_available_specification",
         "title": "Publicly Available Specification",
         "short": null,
         "abbr": [
@@ -4529,7 +4710,7 @@
         "examples": []
       },
       {
-        "key": "na",
+        "key": "national_annex",
         "title": "National Annex",
         "short": null,
         "abbr": [
@@ -4552,7 +4733,7 @@
         "examples": []
       },
       {
-        "key": "dd",
+        "key": "draft_document",
         "title": "Draft Document",
         "short": null,
         "abbr": [
@@ -4671,7 +4852,7 @@
         "examples": []
       },
       {
-        "key": "aerospace",
+        "key": "aerospace_standard",
         "title": "Aerospace/Specialized British Standard",
         "short": null,
         "abbr": [
@@ -4862,7 +5043,7 @@
         "examples": []
       },
       {
-        "key": "ts",
+        "key": "technical_specification",
         "title": "Technical Specification",
         "short": null,
         "abbr": [
@@ -4885,33 +5066,57 @@
         "examples": []
       },
       {
-        "key": "test_method",
-        "title": "Test Method",
+        "key": "addendum_document",
+        "title": "Addendum Document",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "consolidated_identifier",
+        "title": "Consolidated Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "adopted_international_standard",
+        "title": "British Standard",
         "short": "BS",
         "abbr": [],
         "typed_stages": [],
         "examples": []
       },
       {
-        "key": "supplementary_index",
-        "title": "Supplementary Index",
+        "key": "adopted_european_norm",
+        "title": "British Standard",
         "short": "BS",
         "abbr": [],
         "typed_stages": [],
         "examples": []
       },
       {
-        "key": "committee_document",
-        "title": "Committee Document",
-        "short": "DC",
+        "key": "british_industrial_practice",
+        "title": "British Industrial Practice",
+        "short": "BIP",
         "abbr": [],
         "typed_stages": [],
         "examples": []
       },
       {
-        "key": "ep",
+        "key": "electronic_book",
         "title": "Electronic Publication",
         "short": "EP",
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "expert_commentary",
+        "title": "Expert Commentary",
+        "short": null,
         "abbr": [],
         "typed_stages": [],
         "examples": []
@@ -4925,9 +5130,81 @@
         "examples": []
       },
       {
+        "key": "bundled_identifier",
+        "title": "Bundled Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "committee_document",
+        "title": "Committee Document",
+        "short": "DC",
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "supplement_document",
+        "title": "Supplement Document",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "corrigendum",
+        "title": "Corrigendum",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "practice_guide",
+        "title": "Practice Guide",
+        "short": "PP",
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "supplementary_index",
+        "title": "Supplementary Index",
+        "short": "BS",
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "test_method",
+        "title": "Test Method",
+        "short": "BS",
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
         "key": "standalone_amendment",
         "title": "Amendment",
         "short": "AMD",
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "value_added_publication",
+        "title": "Value Added Publication",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "set",
+        "title": "Set",
+        "short": null,
         "abbr": [],
         "typed_stages": [],
         "examples": []
@@ -4951,31 +5228,85 @@
         "key": "recommendation",
         "title": "Recommendation",
         "short": null,
-        "abbr": [
-          "Recommendation"
-        ],
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "ITU-R 01-201",
+          "ITU-R 13-199",
+          "ITU-R 16-199",
+          "ITU-R 20-200",
+          "ITU-R 21-201",
+          "ITU-R 22-201",
+          "ITU-R 23-201",
+          "ITU-R 24-199",
+          "ITU-R 25-200",
+          "ITU-R 26-201"
+        ]
+      },
+      {
+        "key": "amendment",
+        "title": "Amendment",
+        "short": null,
+        "abbr": [],
         "typed_stages": [],
         "examples": []
       },
       {
-        "key": "resolution",
-        "title": "Resolution",
+        "key": "corrigendum",
+        "title": "Corrigendum",
         "short": null,
-        "abbr": [
-          "Resolution"
-        ],
+        "abbr": [],
         "typed_stages": [],
         "examples": []
       },
       {
-        "key": "handbook",
-        "title": "Handbook",
+        "key": "supplement",
+        "title": "Supplement",
         "short": null,
-        "abbr": [
-          "Handbook"
-        ],
+        "abbr": [],
         "typed_stages": [],
         "examples": []
+      },
+      {
+        "key": "annex",
+        "title": "Annex",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "Annex to ITU OB No. 1",
+          "Annex to ITU OB No. 1283",
+          "Annex to ITU OB No. 1283 (01/2024)",
+          "Annex to ITU OB No. 1000-F",
+          "Annex to ITU OB No. 1000-S"
+        ]
+      },
+      {
+        "key": "combined_identifier",
+        "title": "Combined Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "special_publication",
+        "title": "Special Publication",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "ITU OB No. 1",
+          "ITU OB No. 100",
+          "ITU OB No. 1096",
+          "ITU OB No. 1283",
+          "ITU OB No. 1283 (01/2024)",
+          "ITU OB No. 1096 (03/2016)",
+          "ITU OB No. 1000-F",
+          "ITU OB No. 1000-S",
+          "ITU OB No. 1000-R",
+          "ITU OB No. 1000-A"
+        ]
       }
     ],
     "attributes": []
@@ -4983,7 +5314,7 @@
   "cen_cenelec": {
     "identifier_types": [
       {
-        "key": "en",
+        "key": "european_norm",
         "title": "European Norm",
         "short": null,
         "abbr": [
@@ -5038,7 +5369,7 @@
         "examples": []
       },
       {
-        "key": "ts",
+        "key": "technical_specification",
         "title": "Technical Specification",
         "short": null,
         "abbr": [
@@ -5077,7 +5408,7 @@
         "examples": []
       },
       {
-        "key": "tr",
+        "key": "technical_report",
         "title": "Technical Report",
         "short": null,
         "abbr": [
@@ -5100,7 +5431,7 @@
         "examples": []
       },
       {
-        "key": "cwa",
+        "key": "cen_workshop_agreement",
         "title": "CEN Workshop Agreement",
         "short": null,
         "abbr": [
@@ -5146,7 +5477,7 @@
         "examples": []
       },
       {
-        "key": "hd",
+        "key": "harmonization_document",
         "title": "Harmonization Document",
         "short": null,
         "abbr": [
@@ -5169,7 +5500,7 @@
         "examples": []
       },
       {
-        "key": "es",
+        "key": "european_specification",
         "title": "European Specification",
         "short": null,
         "abbr": [
@@ -5192,7 +5523,7 @@
         "examples": []
       },
       {
-        "key": "cr",
+        "key": "cen_report",
         "title": "CEN Report",
         "short": null,
         "abbr": [
@@ -5215,7 +5546,7 @@
         "examples": []
       },
       {
-        "key": "env",
+        "key": "european_prestandard",
         "title": "European Prestandard",
         "short": null,
         "abbr": [
@@ -5236,6 +5567,46 @@
           }
         ],
         "examples": []
+      },
+      {
+        "key": "amendment",
+        "title": "Amendment",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "corrigendum",
+        "title": "Corrigendum",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "adopted_european_norm",
+        "title": "European Norm",
+        "short": "EN",
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "consolidated_identifier",
+        "title": "Consolidated Identifier",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "fragment",
+        "title": "Fragment",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
       }
     ],
     "attributes": []
@@ -5243,64 +5614,69 @@
   "etsi": {
     "identifier_types": [
       {
-        "key": "en",
-        "title": "EN",
+        "key": "supplement_identifier",
+        "title": "Supplement Identifier",
         "short": null,
-        "abbr": [
-          "EN"
-        ],
+        "abbr": [],
         "typed_stages": [],
         "examples": []
       },
       {
-        "key": "ts",
-        "title": "TS",
+        "key": "corrigendum",
+        "title": "Corrigendum",
         "short": null,
-        "abbr": [
-          "TS"
-        ],
+        "abbr": [],
         "typed_stages": [],
-        "examples": []
+        "examples": [
+          "ETSI ETR 053/C1 ed.2 (1997-03)",
+          "ETSI ETR 094/C1 ed.1 (1994-03)",
+          "ETSI ETR 283/C1 ed.1 (1997-03)",
+          "ETSI ETR 310/C1 ed.1 (1996-10)",
+          "ETSI ETS 300 012/C1 ed.1 (1993-08)",
+          "ETSI ETS 300 052-1/C1 ed.1 (1994-04)",
+          "ETSI ETS 300 055-1/C1 ed.1 (1994-04)",
+          "ETSI ETS 300 055-1/C2 ed.1 (1996-01)",
+          "ETSI ETS 300 058-1/C1 ed.1 (1994-04)",
+          "ETSI ETS 300 061-1/C1 ed.1 (1994-04)"
+        ]
       },
       {
-        "key": "tr",
-        "title": "TR",
+        "key": "amendment",
+        "title": "Amendment",
         "short": null,
-        "abbr": [
-          "TR"
-        ],
+        "abbr": [],
         "typed_stages": [],
-        "examples": []
+        "examples": [
+          "ETSI ETR 108/A1 ed.1 (1995-08)",
+          "ETSI ETS 300 011/A1 ed.1 (1994-12)",
+          "ETSI ETS 300 011/A2 ed.1 (1996-03)",
+          "ETSI ETS 300 012/A1 ed.1 (1994-12)",
+          "ETSI ETS 300 012/A2 ed.1 (1996-03)",
+          "ETSI ETS 300 019-1-3/A1 ed.1 (1997-06)",
+          "ETSI ETS 300 019-1-4/A1 ed.1 (1997-06)",
+          "ETSI ETS 300 019-2-3/A1 ed.1 (1997-06)",
+          "ETSI ETS 300 019-2-3/A2 ed.1 (1998-05)",
+          "ETSI ETS 300 019-2-4/A1 ed.1 (1997-06)"
+        ]
       },
       {
-        "key": "gs",
-        "title": "GS",
+        "key": "etsi_standard",
+        "title": "Etsi Standard",
         "short": null,
-        "abbr": [
-          "GS"
-        ],
+        "abbr": [],
         "typed_stages": [],
-        "examples": []
-      },
-      {
-        "key": "eg",
-        "title": "EG",
-        "short": null,
-        "abbr": [
-          "EG"
-        ],
-        "typed_stages": [],
-        "examples": []
-      },
-      {
-        "key": "sr",
-        "title": "SR",
-        "short": null,
-        "abbr": [
-          "SR"
-        ],
-        "typed_stages": [],
-        "examples": []
+        "examples": [
+          "ETSI EG 200 053 V1.5.1 (2004-06)",
+          "ETSI EG 200 234 V1.2.2 (2000-02)",
+          "ETSI EG 200 351 V2.2.2 (1998-09)",
+          "ETSI EG 200 351 V3.2.1 (2000-09)",
+          "ETSI EG 200 351 V4.1.1 (2001-10)",
+          "ETSI EG 201 013 V1.1.1 (1997-04)",
+          "ETSI EG 201 014 V1.1.1 (1997-05)",
+          "ETSI EG 201 015 V1.2.1 (1999-05)",
+          "ETSI EG 201 015 V2.1.1 (2012-02)",
+          "ETSI EG 201 017 V1.4.1 (2000-11)"
+        ]
       }
     ],
     "attributes": [
@@ -5317,7 +5693,7 @@
   "ansi": {
     "identifier_types": [
       {
-        "key": "ans",
+        "key": "standard",
         "title": "American National Standard",
         "short": "ANS",
         "abbr": [],
@@ -5781,7 +6157,7 @@
         ]
       },
       {
-        "key": "cor",
+        "key": "corrigendum",
         "title": "Corrigendum",
         "short": "Cor",
         "abbr": [],
@@ -5931,6 +6307,17 @@
         "typed_stages": [],
         "examples": [
           "CIE Tutorials Bundle 1"
+        ]
+      },
+      {
+        "key": "corrigendum",
+        "title": "Corrigendum",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "CIE 198-SP1.4:2011/Cor1:2013",
+          "CIE 232:2019/Cor1:2020"
         ]
       }
     ],
@@ -6089,7 +6476,7 @@
   "jis": {
     "identifier_types": [
       {
-        "key": "jis",
+        "key": "standard",
         "title": "Japanese Industrial Standard",
         "short": "JIS",
         "abbr": [],
@@ -6107,7 +6494,7 @@
         "examples": []
       },
       {
-        "key": "tr",
+        "key": "technical_report",
         "title": "Technical Report",
         "short": "TR",
         "abbr": [],
@@ -6125,7 +6512,7 @@
         "examples": []
       },
       {
-        "key": "ts",
+        "key": "technical_specification",
         "title": "Technical Specification",
         "short": "TS",
         "abbr": [],
@@ -6141,6 +6528,41 @@
           }
         ],
         "examples": []
+      },
+      {
+        "key": "amendment",
+        "title": "Amendment",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "explanation",
+        "title": "Explanation",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": []
+      },
+      {
+        "key": "japanese_industrial_standard",
+        "title": "Japanese Industrial Standard",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "JIS A 0001:1999",
+          "JIS A 0005:1966",
+          "JIS A 0015:1976",
+          "JIS A 0016:1979",
+          "JIS A 0017:2018",
+          "JIS A 0030:1994",
+          "JIS A 0101:2012",
+          "JIS A 0150:1999",
+          "JIS A 0202:2008",
+          "JIS A 0203:2019"
+        ]
       }
     ],
     "attributes": []
@@ -6318,6 +6740,30 @@
           "OIML V 2:2013",
           "OIML V 2:2013(E/F)"
         ]
+      },
+      {
+        "key": "amendment",
+        "title": "Amendment",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "Amendment (2009) to OIML R 138 Edition 2007 (E)",
+          "Amendment (2009) to OIML R 138:2007 (E)",
+          "Amendment (2004) to OIML D 2 (E)"
+        ]
+      },
+      {
+        "key": "annex",
+        "title": "Annex",
+        "short": null,
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "OIML R 60 Annexes Edition 2021 (E)",
+          "OIML R 60 Annexes:2021 (E)",
+          "OIML R 60 Annex A Edition 2013 (E)"
+        ]
       }
     ],
     "attributes": []
@@ -6325,7 +6771,7 @@
   "idf": {
     "identifier_types": [
       {
-        "key": "is",
+        "key": "international_standard",
         "title": "International Standard",
         "short": null,
         "abbr": [],
@@ -6532,7 +6978,7 @@
         ]
       },
       {
-        "key": "rm",
+        "key": "reviewed_method",
         "title": "Reviewed Method",
         "short": "RM",
         "abbr": [],
@@ -6708,27 +7154,7 @@
         ]
       },
       {
-        "key": "cor",
-        "title": "Corrigendum",
-        "short": "COR",
-        "abbr": [],
-        "typed_stages": [
-          {
-            "stage_code": "published",
-            "type_code": "cor",
-            "abbr": [
-              "COR"
-            ],
-            "name": "Corrigendum",
-            "harmonized_stages": []
-          }
-        ],
-        "examples": [
-          "IDF 148-1:2008/COR 1:2009"
-        ]
-      },
-      {
-        "key": "amd",
+        "key": "amendment",
         "title": "Amendment",
         "short": "AMD",
         "abbr": [],
@@ -6746,6 +7172,26 @@
         "examples": [
           "IDF 146:2003/AMD 1:2023",
           "IDF 140-1:2007/AMD 1:2012"
+        ]
+      },
+      {
+        "key": "corrigendum",
+        "title": "Corrigendum",
+        "short": "COR",
+        "abbr": [],
+        "typed_stages": [
+          {
+            "stage_code": "published",
+            "type_code": "cor",
+            "abbr": [
+              "COR"
+            ],
+            "name": "Corrigendum",
+            "harmonized_stages": []
+          }
+        ],
+        "examples": [
+          "IDF 148-1:2008/COR 1:2009"
         ]
       }
     ],
@@ -6976,19 +7422,45 @@
         "key": "handbook",
         "title": "Handbook",
         "short": null,
-        "abbr": [
-          "Handbook"
-        ],
+        "abbr": [],
         "typed_stages": [],
-        "examples": []
+        "examples": [
+          "PLATEAU Handbook #00 第1.0版",
+          "PLATEAU Handbook #00 第2.0版",
+          "PLATEAU Handbook #00 第3.0版",
+          "PLATEAU Handbook #00 第4.0版",
+          "PLATEAU Handbook #01 第1.0版",
+          "PLATEAU Handbook #01 第2.3版",
+          "PLATEAU Handbook #01 第3.5版",
+          "PLATEAU Handbook #01 第4.0版",
+          "PLATEAU Handbook #02 第1.0版",
+          "PLATEAU Handbook #02 第2.2版"
+        ]
       },
       {
         "key": "technical_report",
         "title": "Technical Report",
         "short": null,
-        "abbr": [
-          "Technical Report"
-        ],
+        "abbr": [],
+        "typed_stages": [],
+        "examples": [
+          "PLATEAU Technical Report #00",
+          "PLATEAU Technical Report #01",
+          "PLATEAU Technical Report #02",
+          "PLATEAU Technical Report #03",
+          "PLATEAU Technical Report #11",
+          "PLATEAU Technical Report #14",
+          "PLATEAU Technical Report #15",
+          "PLATEAU Technical Report #16",
+          "PLATEAU Technical Report #17",
+          "PLATEAU Technical Report #18"
+        ]
+      },
+      {
+        "key": "annex",
+        "title": "Annex",
+        "short": null,
+        "abbr": [],
         "typed_stages": [],
         "examples": []
       }
@@ -7003,7 +7475,7 @@
   "sae": {
     "identifier_types": [
       {
-        "key": "base",
+        "key": "standard",
         "title": "Base",
         "short": null,
         "abbr": [],

--- a/spec/pubid/export/data_class_exporter_spec.rb
+++ b/spec/pubid/export/data_class_exporter_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe Pubid::Export::DataClassExporter do
         expect(result.identifier_types.size).to be > 0
       end
 
-      it "includes EN type" do
-        en = result.identifier_types.find { |t| t.key == "en" }
+      it "includes ETSI Standard type" do
+        en = result.identifier_types.find { |t| t.key == "etsi_standard" }
         expect(en).not_to be_nil
       end
 
-      it "includes TS type" do
-        ts = result.identifier_types.find { |t| t.key == "ts" }
+      it "includes Supplement type" do
+        ts = result.identifier_types.find { |t| t.key == "supplement_identifier" }
         expect(ts).not_to be_nil
       end
     end

--- a/spec/pubid/export/exporter_spec.rb
+++ b/spec/pubid/export/exporter_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Pubid::Export::Exporter do
   describe "export data structure" do
     let(:data) { described_class.export_all }
     let(:iso_types) { data["iso"][:identifier_types] }
-    let(:is_type) { iso_types.find { |t| t[:key] == "is" } }
+    let(:is_type) { iso_types.find { |t| t[:key] == "international_standard" } }
 
     it "each identifier type has required fields" do
       iso_types.each do |type|

--- a/spec/pubid/export/ieee_exporter_spec.rb
+++ b/spec/pubid/export/ieee_exporter_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe Pubid::Export::IeeeExporter do
     end
 
     it "includes a Standard type" do
-      std = result.identifier_types.find { |t| t.key == "std" }
+      std = result.identifier_types.find { |t| t.key == "standard" }
       expect(std).not_to be_nil
     end
 
     it "assigns typed stages only to Standard" do
       result.identifier_types.each do |type|
-        if type.key == "std"
+        if type.key == "standard"
           expect(type.typed_stages.size).to be >= 0
         end
       end

--- a/spec/pubid/export/scheme_exporter_spec.rb
+++ b/spec/pubid/export/scheme_exporter_spec.rb
@@ -18,20 +18,20 @@ RSpec.describe Pubid::Export::SchemeExporter do
       end
 
       it "includes International Standard" do
-        is_type = result.identifier_types.find { |t| t.key == "is" }
+        is_type = result.identifier_types.find { |t| t.key == "international_standard" }
         expect(is_type).not_to be_nil
         expect(is_type.title).to eq("International Standard")
       end
 
       it "includes typed stages for International Standard" do
-        is_type = result.identifier_types.find { |t| t.key == "is" }
+        is_type = result.identifier_types.find { |t| t.key == "international_standard" }
         expect(is_type.typed_stages.size).to be > 0
         dis = is_type.typed_stages.find { |ts| ts.stage_code == "dis" }
         expect(dis).not_to be_nil
       end
 
       it "includes Amendment type" do
-        amd = result.identifier_types.find { |t| t.key == "amd" }
+        amd = result.identifier_types.find { |t| t.key == "amendment" }
         expect(amd).not_to be_nil
       end
     end


### PR DESCRIPTION
## Summary

Fixes the export pipeline so all 209 identifier types across 23 flavors are exported with website-compatible keys.

### Key changes

**Export key mapping**
- Add `WEBSITE_KEY_OVERRIDES` — maps library short keys (`is`, `amd`, `tr`) to website keys (`international_standard`, `amendment`, `technical_report`) for 16 flavors
- Add `CLASS_KEY_OVERRIDES` — unique keys for classes sharing type keys (BSI adopted types, NESC sub-classes, ANSI/JIS variants)

**Full identifier coverage**
- IEEE: recurse into NESC module → 17 types (was 4 hardcoded)
- ANSI: fix AmericanNationalStandard autoload → 2 types (was 1)
- ITU: discover all 7 classes from Identifiers module
- ETSI/Plateau: discover all classes dynamically
- IEC: autoload 4 orphan classes (ComponentSpecification, OperationalDocument, etc.)

**Registry registration**
- Add `Pubid::Registry.register` for 6 flavors: iso, iec, ieee, nist, etsi, sae
- Add autoload fallback in `Deserializer.from_h`

**Bug fixes**
- NIST CircularSupplement: unique key `:circ_supp` (was colliding with Circular)
- Dedup by resolved website key in IEEE and NIST exporters

### Test results
- 90 export tests: 0 failures
- 2663 ISO tests: 0 failures
- 704 IEC tests: 0 failures  
- 164 IEEE tests: 0 failures
- 26 ANSI tests: 0 failures
- 173 integration tests: 0 failures