### PR TITLE
refactor: unify identifier + Scheme hierarchies

### DIFF
--- a/lib/pubid/amca/identifiers/base.rb
+++ b/lib/pubid/amca/identifiers/base.rb
@@ -5,7 +5,7 @@ module Pubid
     module Identifiers
       # Base identifier class for ACMA identifiers
       # Single Responsibility: Common functionality for all ACMA identifier types
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         # Override base_hash to handle AMCA-specific copublisher format (string, not array)
         def base_hash
           hash = super

--- a/lib/pubid/api/scheme.rb
+++ b/lib/pubid/api/scheme.rb
@@ -13,7 +13,7 @@ require_relative "identifiers/typeless_standard"
 
 module Pubid
   module Api
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           [

--- a/lib/pubid/api/single_identifier.rb
+++ b/lib/pubid/api/single_identifier.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Api
-    class SingleIdentifier < Lutaml::Model::Serializable
+    class SingleIdentifier < Pubid::Identifier
       # Generate URN for this identifier
       #
       # @return [String] URN representation

--- a/lib/pubid/ashrae/identifiers/base.rb
+++ b/lib/pubid/ashrae/identifiers/base.rb
@@ -4,7 +4,7 @@ module Pubid
   module Ashrae
     module Identifiers
       # Base class for all ASHRAE identifiers
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         attribute :publisher, :string, default: "ASHRAE"
         attribute :code, :string
         attribute :year, :string

--- a/lib/pubid/ashrae/scheme.rb
+++ b/lib/pubid/ashrae/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Ashrae
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           [

--- a/lib/pubid/asme/scheme.rb
+++ b/lib/pubid/asme/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Asme
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           @identifiers ||= [

--- a/lib/pubid/asme/single_identifier.rb
+++ b/lib/pubid/asme/single_identifier.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Asme
-    class SingleIdentifier < Lutaml::Model::Serializable
+    class SingleIdentifier < Pubid::Identifier
       # Generate URN for this identifier
       #
       # @return [String] URN representation

--- a/lib/pubid/astm/scheme.rb
+++ b/lib/pubid/astm/scheme.rb
@@ -12,7 +12,7 @@ require_relative "identifiers/iso_dual_published"
 
 module Pubid
   module Astm
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           @identifiers ||= [

--- a/lib/pubid/astm/single_identifier.rb
+++ b/lib/pubid/astm/single_identifier.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Astm
-    class SingleIdentifier < Lutaml::Model::Serializable
+    class SingleIdentifier < Pubid::Identifier
       # Generate URN for this identifier
       #
       # @return [String] URN representation

--- a/lib/pubid/bsi/identifiers/base.rb
+++ b/lib/pubid/bsi/identifiers/base.rb
@@ -4,7 +4,7 @@ module Pubid
   module Bsi
     module Identifiers
       # Base BSI identifier (module organization)
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
       end
     end
   end

--- a/lib/pubid/bsi/scheme.rb
+++ b/lib/pubid/bsi/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Bsi
-    class Scheme
+    class Scheme < Pubid::Scheme
       # TYPED_STAGES_REGISTRY for native BSI types
       TYPED_STAGES_REGISTRY = [
         # British Standard (BS)

--- a/lib/pubid/bsi/single_identifier.rb
+++ b/lib/pubid/bsi/single_identifier.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Bsi
-    class SingleIdentifier < Lutaml::Model::Serializable
+    class SingleIdentifier < Pubid::Identifier
       # Generate URN for this identifier
       #
       # @return [String] URN representation

--- a/lib/pubid/ccsds/scheme.rb
+++ b/lib/pubid/ccsds/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Ccsds
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           [

--- a/lib/pubid/cen_cenelec/identifiers/base.rb
+++ b/lib/pubid/cen_cenelec/identifiers/base.rb
@@ -5,7 +5,7 @@ module Pubid
     module Identifiers
       # Base CEN identifier
       # Format: {PUBLISHER} NUMBER[-PART]:YEAR
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         # Generate URN for this identifier
         #
         # @return [String] URN representation

--- a/lib/pubid/cen_cenelec/scheme.rb
+++ b/lib/pubid/cen_cenelec/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module CenCenelec
-    class Scheme
+    class Scheme < Pubid::Scheme
       # TYPED_STAGES_REGISTRY for native CEN types
       TYPED_STAGES_REGISTRY = [
         # European Norm (EN)

--- a/lib/pubid/cen_cenelec/single_identifier.rb
+++ b/lib/pubid/cen_cenelec/single_identifier.rb
@@ -2,18 +2,10 @@
 
 module Pubid
   module CenCenelec
-    class SingleIdentifier < Lutaml::Model::Serializable
+    class SingleIdentifier < Pubid::Identifier
       attribute :publisher, Components::Publisher, default: -> {
         Components::Publisher.new(body: "EN")
       }
-      attribute :copublishers, Components::Publisher, collection: true
-      attribute :number, Components::Code
-      attribute :part, Components::Code
-      attribute :subpart, Components::Code
-      attribute :date, Components::Date
-      attribute :stage, Components::Stage
-      attribute :type, Components::Type
-      attribute :typed_stage, Components::TypedStage
 
       # Generate URN for this identifier
       #

--- a/lib/pubid/cie/scheme.rb
+++ b/lib/pubid/cie/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Cie
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           [

--- a/lib/pubid/csa/scheme.rb
+++ b/lib/pubid/csa/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Csa
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           @identifiers ||= [

--- a/lib/pubid/csa/single_identifier.rb
+++ b/lib/pubid/csa/single_identifier.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Csa
-    class SingleIdentifier < Lutaml::Model::Serializable
+    class SingleIdentifier < Pubid::Identifier
       # Generate URN for this identifier
       #
       # @return [String] URN representation

--- a/lib/pubid/etsi/identifiers/base.rb
+++ b/lib/pubid/etsi/identifiers/base.rb
@@ -4,7 +4,7 @@ module Pubid
   module Etsi
     module Identifiers
       # Base class for all ETSI identifiers
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         # Generate URN for this identifier
         #
         # @return [String] URN representation

--- a/lib/pubid/idf/scheme.rb
+++ b/lib/pubid/idf/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Idf
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           @identifiers ||= [

--- a/lib/pubid/iec/scheme.rb
+++ b/lib/pubid/iec/scheme.rb
@@ -10,7 +10,7 @@ require_relative "identifiers/fragment_identifier"
 
 module Pubid
   module Iec
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           [

--- a/lib/pubid/ieee/identifiers/base.rb
+++ b/lib/pubid/ieee/identifiers/base.rb
@@ -8,7 +8,7 @@ module Pubid
 
     module Identifiers
       # Base class for all IEEE identifiers
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         # Generate URN for this identifier
         #
         # @return [String] URN representation

--- a/lib/pubid/ieee/scheme.rb
+++ b/lib/pubid/ieee/scheme.rb
@@ -12,7 +12,7 @@ module Pubid
     # - TypedStage lookup by IEEE draft notation
     # - TypedStage lookup by ISO stage code
     # - Identifier class selection based on type code
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         # Locate typed stage by abbreviation
         # @param abbr [String, nil] stage abbreviation (e.g., "D1", "FDIS", "Std")

--- a/lib/pubid/iho/identifiers/base.rb
+++ b/lib/pubid/iho/identifiers/base.rb
@@ -10,7 +10,7 @@ module Pubid
       #
       # The leading IHO publisher prefix is optional on input but always
       # emitted on output.
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         attribute :publisher,  :string, default: "IHO"
         attribute :code,       :string
         attribute :appendix,   :string

--- a/lib/pubid/itu/identifiers/base.rb
+++ b/lib/pubid/itu/identifiers/base.rb
@@ -10,7 +10,7 @@ module Pubid
   module Itu
     module Identifiers
       # Base class for all ITU identifiers
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         # Long-form ↔ ITU single-letter language code map. The parser produces
         # single-letter codes (E/F/S/R/A/C); API callers (e.g. metanorma-itu)
         # pass long-form (en/fr/es/ru/ar/zh). Storage is normalized to the

--- a/lib/pubid/itu/scheme.rb
+++ b/lib/pubid/itu/scheme.rb
@@ -4,7 +4,7 @@ require_relative "model"
 
 module Pubid
   module Itu
-    class Scheme
+    class Scheme < Pubid::Scheme
       # Attribute mappings define how parsed data maps to model attributes
       ATTRIBUTE_MAPPINGS = {
         sector: :sector,

--- a/lib/pubid/jcgm/scheme.rb
+++ b/lib/pubid/jcgm/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Jcgm
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           [

--- a/lib/pubid/jis/identifiers/base.rb
+++ b/lib/pubid/jis/identifiers/base.rb
@@ -5,7 +5,7 @@ module Pubid
     module Identifiers
       # Base class for all JIS identifiers
       # Provides common attributes and behavior
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         # Generate URN for this identifier
         #
         # @return [String] URN representation

--- a/lib/pubid/jis/scheme.rb
+++ b/lib/pubid/jis/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Jis
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           [

--- a/lib/pubid/nist/identifiers/base.rb
+++ b/lib/pubid/nist/identifiers/base.rb
@@ -5,7 +5,7 @@ module Pubid
     module Identifiers
       # Base NIST/NBS identifier class
       # Each series type inherits from this and overrides series_code
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         # Generate URN for this identifier
         #
         # @return [String] URN representation

--- a/lib/pubid/nist/scheme.rb
+++ b/lib/pubid/nist/scheme.rb
@@ -4,7 +4,7 @@ module Pubid
   module Nist
     # Scheme class for NIST identifier registry
     # Single Responsibility: Identifier class registry and series-to-class mapping
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         # Aggregate TYPED_STAGES from all identifier classes
         # @return [Array<Components::TypedStage>] all typed stages

--- a/lib/pubid/oiml/identifiers/base.rb
+++ b/lib/pubid/oiml/identifiers/base.rb
@@ -3,7 +3,7 @@
 module Pubid
   module Oiml
     module Identifiers
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         attribute :publisher, :string
         attribute :type, :string
         attribute :code, Oiml::Components::Code

--- a/lib/pubid/oiml/scheme.rb
+++ b/lib/pubid/oiml/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Oiml
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           @identifiers ||= [

--- a/lib/pubid/plateau/identifiers/base.rb
+++ b/lib/pubid/plateau/identifiers/base.rb
@@ -4,7 +4,7 @@ module Pubid
   module Plateau
     module Identifiers
       # Base class for all PLATEAU identifiers
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         # Generate URN for this identifier
         #
         # @return [String] URN representation

--- a/lib/pubid/plateau/supplement_identifier.rb
+++ b/lib/pubid/plateau/supplement_identifier.rb
@@ -6,7 +6,7 @@ module Pubid
   module Plateau
     # Base class for PLATEAU supplements (Annex)
     # Supplements reference a base identifier
-    class SupplementIdentifier < Lutaml::Model::Serializable
+    class SupplementIdentifier < Pubid::Identifier
       attribute :base_identifier, Identifiers::Base
       attribute :letter, :string, default: -> {}
 

--- a/lib/pubid/sae/identifiers/base.rb
+++ b/lib/pubid/sae/identifiers/base.rb
@@ -5,7 +5,7 @@ module Pubid
     module Identifiers
       # Base SAE Identifier
       # Handles all SAE document types (AMS, AIR, ARP, AS, MA)
-      class Base < Lutaml::Model::Serializable
+      class Base < Pubid::Identifier
         # Generate URN for this identifier
         #
         # @return [String] URN representation

--- a/lib/pubid/sae/scheme.rb
+++ b/lib/pubid/sae/scheme.rb
@@ -2,7 +2,7 @@
 
 module Pubid
   module Sae
-    class Scheme
+    class Scheme < Pubid::Scheme
       class << self
         def identifiers
           [


### PR DESCRIPTION
## Summary

Unified the identifier and Scheme class hierarchies across all 22+ flavors, establishing `Pubid::Identifier` and `Pubid::Scheme` as the single root for all flavors.

### Plan 02 — Unified identifier hierarchy
- All 19 `Base` and `SingleIdentifier` classes changed from inheriting `Lutaml::Model::Serializable` directly to inheriting `Pubid::Identifier`
- Plus Plateau `SupplementIdentifier`
- All flavors now inherit shared methods: `to_urn`, `exclude`, `hash`, `eql?`, `to_mr_string`, `mr_*` templates
- Removed 8 redundant attribute declarations from CEN/CENELEC `SingleIdentifier` (identical types to parent)

### Plan 05 — Unified Scheme hierarchy
- 17 `Scheme` classes changed to inherit from `Pubid::Scheme`
- ETSI and Plateau kept on `Lutaml::Model::Serializable` (they use `attribute` as data models, not registries)
- 3 flavors (AMCA, ISO, IHO) already inherited — no change needed

### Files changed
38 files, 38 insertions, 46 deletions — net reduction in code

### Testing
Full test suite passes with 0 new failures.