### PR TITLE
fix(iso): parse `ISO/R N-CS:YYYY` and `ISO N/Add M` correctly

### DIFF
--- a/gems/pubid-iso/lib/pubid/iso/parser.rb
+++ b/gems/pubid-iso/lib/pubid/iso/parser.rb
@@ -98,7 +98,9 @@ module Pubid::Iso
     rule(:part_matcher) do
       year_digits.absent? >>
         supplements.absent? >>
-        staged_addenda.absent? >> ((roman_numerals >> digits.absent?) | match['[\dA-Z]'].repeat(1)).as(:part)
+        staged_addenda.absent? >>
+        (str("Add") | str("ADD")).absent? >>
+        ((roman_numerals >> digits.absent? >> match['[A-Z]'].absent?) | match['[\dA-Z]'].repeat(1)).as(:part)
     end
 
     rule(:part) do

--- a/gems/pubid-iso/spec/pubid_iso/identifier_parsing_spec.rb
+++ b/gems/pubid-iso/spec/pubid_iso/identifier_parsing_spec.rb
@@ -875,6 +875,18 @@ module Pubid::Iso
       it_behaves_like "converts urn to pubid", "ISO/R 194/Suppl 4"
     end
 
+    context "ISO/R 194-CS:1964" do
+      let(:pubid) { "ISO/R 194-CS:1964" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO 1656/Add 1" do
+      let(:pubid) { "ISO 1656/Add 1" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
     context "ISO/R 91-1970 — Addendum 1" do
       let(:original) { "ISO/R 91-1970 — Addendum 1" }
       let(:pubid) { "ISO/R 91:1970/Add 1" }


### PR DESCRIPTION
## Summary

Fixes two `Pubid::Iso::Parser` greediness bugs in the `part_matcher` rule, surfaced by parsing the [ISO Open Data deliverables dataset](https://www.iso.org/open-data.html) (~80k references):

- **Bug A — `ISO N/Add M` (no part, no year)** failed to parse. `part_matcher` greedily consumed `/A` as a single-letter part, leaving `dd M` unparseable downstream. The `/Amd N` and `/Cor N` variants worked because their tokens are blocked by `supplements.absent?`; `Add` is handled by the separate `addendum` rule and lacked the equivalent guard.
- **Bug B — `ISO/R 194-CS:1964`** (the user-reported case) failed because `roman_numerals >> digits.absent?` consumed the leading `C` of `CS` as a Roman numeral, leaving `S:1964` unparseable. The Roman branch now requires that the matched run is not immediately followed by another uppercase letter.

After the fix, **the ISO Open Data dataset has 50 fewer parser failures** (49 `ISO N/Add M` IDs + 1 `ISO/R 194-CS`). The same fix also unlocks all `Withdrawn N/Add M` rows that `relaton-iso` rewrites to `ISO N/Add M` upstream.

### Diff

```diff
     rule(:part_matcher) do
       year_digits.absent? >>
         supplements.absent? >>
-        staged_addenda.absent? >> ((roman_numerals >> digits.absent?) | match['[\dA-Z]'].repeat(1)).as(:part)
+        staged_addenda.absent? >>
+        (str("Add") | str("ADD")).absent? >>
+        ((roman_numerals >> digits.absent? >> match['[A-Z]'].absent?) | match['[\dA-Z]'].repeat(1)).as(:part)
     end
```

### Out of scope

The open-data sweep also surfaces ~64 other parser gaps (ISP type combined with draft stages, `WD Add` / `DIS Add` / `DAdd` / `PWI Add` / `DIS Cor` / `DIS Suppl` supplements, lowercase / wildcard part suffixes like `-5a` / `-Nxx`). These are distinct grammar problems and should be addressed in separate PRs.

There is also a latent semantic bug where `ISO 105-C:2010` round-trips as `ISO 105-100:2010` (Roman `C` → 100). It is not addressed here because no open-data reference exercises it (the dataset only uses `ISO 105-C<digits>` like `ISO 105-C06`, which already parses correctly), and the user scoped this PR to the two bugs above.

## Test plan

- [x] All 709 existing `pubid-iso` specs pass (`bundle exec rspec`).
- [x] Two new contexts added in `spec/pubid_iso/identifier_parsing_spec.rb`:
  - `ISO/R 194-CS:1964`
  - `ISO 1656/Add 1`
- [x] Open-data sweep: failure count drops from 257 → 64 (and from 114 → 64 after the upstream `Withdrawn → ISO` substitution).
- [x] Spot-checked round-tripping of pre-existing Roman-numeral and letter-part identifiers (`ISO/R 300/III-1968`, `ISO/R 657/IV`, `ISO 5807-II`, `ISO 105-A:2010`, `ISO 105-F:1982`, `ISO 105-C06:2010`, `ISO 1656-1/Add 1`, `ISO 1656:1980/Add 1`, `ISO 800/Amd 1`, `ISO 800/Cor 1`) — all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)