### PR TITLE
fix(iso): parse stage+type combos and ISO/NP draft placeholders

### DIFF
--- a/gems/pubid-iso/lib/pubid/iso/parser.rb
+++ b/gems/pubid-iso/lib/pubid/iso/parser.rb
@@ -190,8 +190,11 @@ module Pubid::Iso
 
     rule(:std_document_body) do
       (type | (stage.as(:stage) >> digits.as(:iteration).maybe)).maybe >>
-        # for ISO/IEC WD TS 25025
-        space? >> ((stage.as(:stage) | typed_stage.as(:stage) | type) >> space).maybe >>
+        # for ISO/IEC WD TS 25025 and ISO/IEC DIS ISP 12060-6 — both shapes
+        # `<stage> <type>` and `<typed_stage> <type>` need to fit before the
+        # number, so allow an optional stage/typed_stage followed by an
+        # optional type.
+        space? >> (((stage.as(:stage) | typed_stage.as(:stage)) >> space).maybe >> (type >> space).maybe) >>
         digits.as(:number) >>
         # for identifiers like ISO 5537/IDF 26
         (str("|") >> (str("IDF").as(:publisher) >> space >> digits.as(:number)).as(:joint_document)).maybe >>

--- a/gems/pubid-iso/spec/pubid_iso/identifier_parsing_spec.rb
+++ b/gems/pubid-iso/spec/pubid_iso/identifier_parsing_spec.rb
@@ -611,6 +611,53 @@ module Pubid::Iso
       it_behaves_like "converts urn to pubid", "ISO/IEC DTS 25025"
     end
 
+    context "ISO/IEC WD ISP 11182-3" do
+      let(:pubid) { "ISO/IEC WD ISP 11182-3" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO/IEC NP ISP 29110-4-2" do
+      let(:pubid) { "ISO/IEC NP ISP 29110-4-2" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO/IEC DIS ISP 12060-6" do
+      let(:original) { "ISO/IEC DIS ISP 12060-6" }
+      let(:pubid) { "ISO/IEC DISP 12060-6" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO/IEC DIS TR 14143-5" do
+      let(:original) { "ISO/IEC DIS TR 14143-5" }
+      let(:pubid) { "ISO/IEC DTR 14143-5" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO/IEC FDIS PAS 1" do
+      let(:original) { "ISO/IEC FDIS PAS 1" }
+      let(:pubid) { "ISO/IEC FDPAS 1" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO/NP 10303-5a" do
+      let(:original) { "ISO/NP 10303-5a" }
+      let(:pubid) { "ISO/NP 10303-5A" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO/NP 10303-2xx" do
+      let(:original) { "ISO/NP 10303-2xx" }
+      let(:pubid) { "ISO/NP 10303-2XX" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
     context "ISO 19110:2005/Amd 1:2011" do
       let(:original) { "ISO 19110:2005/Amd 1:2011 ED1" }
       let(:pubid) { "ISO 19110:2005/Amd 1:2011" }

--- a/gems/pubid-iso/update_codes.yaml
+++ b/gems/pubid-iso/update_codes.yaml
@@ -2,3 +2,12 @@ ISO/R 657/IV: ISO/R 657-4:1969
 ISO/IEC/IEEE 8802-22.2:2015/Amd.2:2017(E): ISO/IEC/IEEE 8802-22:2015/Amd.2:2017(E)
 ISO/TR 17716.2: ISO/TR 17716
 ISO/TR 17716.2(E): ISO/TR 17716(E)
+ISO/NP 10303-5a: ISO/NP 10303-5A
+ISO/NP 10303-5b: ISO/NP 10303-5B
+ISO/NP 10303-1xx: ISO/NP 10303-1XX
+ISO/NP 10303-2xx: ISO/NP 10303-2XX
+# Long-form draft typed stages (DIS TR, FDIS PAS, ...) → canonical short
+# typed-stage abbrs (DTR, FDPAS, ...). Pattern matches at start of string
+# with the publisher prefix preserved.
+"/^(ISO[\\w/]*) DIS (TR|TS|PAS|ISP) /": '\1 D\2 '
+"/^(ISO[\\w/]*) FDIS (TR|TS|PAS|ISP) /": '\1 FD\2 '


### PR DESCRIPTION
## Summary

Continues the ISO Open Data parsing work from #56. Fixes 55 more parser failures from the [ISO Open Data deliverables dump](https://www.iso.org/open-data.html), bringing the open-data sweep from 64 → 9 failures.

Three related changes, all driven by the same dataset:

### 1. Parser — multi-prefix `<stage> <type>` combos (parser.rb, slot 2 of `std_document_body`)

`<stage> <type> <num>` and `<typed_stage> <type> <num>` shapes were rejected because `std_document_body` only allowed a single prefix slot before the number. `ISO/IEC WD TR 14143-5` worked (`WD` in slot 1, `TR` in slot 2) but `ISO/IEC DIS TR 14143-5`, `ISO/IEC WD ISP 11182-3`, `ISO/IEC NP ISP 29110-4-2` did not.

Refactor slot 2 from a single-element alternation to two sequential optional slots: an optional stage/typed_stage, then an optional type.

```diff
-        space? >> ((stage.as(:stage) | typed_stage.as(:stage) | type) >> space).maybe >>
+        space? >> (((stage.as(:stage) | typed_stage.as(:stage)) >> space).maybe >> (type >> space).maybe) >>
```

### 2. `update_codes.yaml` — `DIS <type>` / `FDIS <type>` long forms

`DIS TR`, `FDIS PAS`, etc. are long-form spellings of canonical draft typed-stages (`DTR`, `FDPAS`, `DTS`, `FDTS`, `DISP`, `FDISP`). The downstream `Stage.new(abbr: \"DIS\")` would reject them as invalid stages, since `DIS`/`FDIS` are typed-stages of the IS class only — not of TR/TS/PAS/ISP, which have their own `D<type>` typed-stage abbrs.

Two regex entries rewrite to the canonical short form before parsing:

```yaml
\"/^(ISO[\\\\w/]*) DIS (TR|TS|PAS|ISP) /\": '\\1 D\\2 '
\"/^(ISO[\\\\w/]*) FDIS (TR|TS|PAS|ISP) /\": '\\1 FD\\2 '
```

### 3. `update_codes.yaml` — lowercase / `xx` part suffixes in `ISO/NP 10303-...`

Four NP-stage references use non-canonical lowercase spellings (`-5a`, `-5b`, `-1xx`, `-2xx`). The uppercase forms already parse; add explicit entries to normalize.

```yaml
ISO/NP 10303-5a: ISO/NP 10303-5A
ISO/NP 10303-5b: ISO/NP 10303-5B
ISO/NP 10303-1xx: ISO/NP 10303-1XX
ISO/NP 10303-2xx: ISO/NP 10303-2XX
```

## Out of scope (next PR)

The remaining 9 open-data failures are all stage-prefixed supplements:
- `WD Add`, `DIS Add`, `PWI Add`, `DAdd` — additions to the `addendum` rule
- `DIS Cor`, `DIS Suppl` — typed_stage prefix support in the `supplement` rule

These need targeted edits to the addendum/supplement grammar rules and will be addressed in a follow-up PR.

There is also a latent rendering bug where `ISO/IEC PRF ISP 11181-3` round-trips as `ISO/IEC ISP 11181-3` (PRF stage dropped on output). Pre-existing, unrelated to this change.

## Test plan

- [x] All 723 pubid-iso specs pass (`bundle exec rspec`), including 14 new examples (7 contexts):
  - `ISO/IEC WD ISP 11182-3` (parser fix, no normalization)
  - `ISO/IEC NP ISP 29110-4-2`
  - `ISO/IEC DIS ISP 12060-6` → `ISO/IEC DISP 12060-6`
  - `ISO/IEC DIS TR 14143-5` → `ISO/IEC DTR 14143-5`
  - `ISO/IEC FDIS PAS 1` → `ISO/IEC FDPAS 1`
  - `ISO/NP 10303-5a` → `ISO/NP 10303-5A`
  - `ISO/NP 10303-2xx` → `ISO/NP 10303-2XX`
- [x] Open-data sweep drops from 64 → 9 failures (the 9 remaining are Group 2 staged supplements).
- [x] Negative cases verified: `ISO 9000:2015/DIS Cor 1` (Group 2) still fails appropriately; `ISO 9000/Amd 1`, `ISO/IEC ISP 12060-6`, `ISO/IEC TR 14143-5`, `ISO/IEC WD TR 14143-5` continue to parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)