### PR TITLE
fix(iso): parse stage-prefixed supplements and fix part_matcher misparse

### DIFF
--- a/gems/pubid-iso/lib/pubid/iso/parser.rb
+++ b/gems/pubid-iso/lib/pubid/iso/parser.rb
@@ -98,8 +98,13 @@ module Pubid::Iso
     rule(:part_matcher) do
       year_digits.absent? >>
         supplements.absent? >>
+        staged_supplement.absent? >>
         staged_addenda.absent? >>
         (str("Add") | str("ADD")).absent? >>
+        # Stage-prefixed supplements like `WD Amd`, `DIS Cor`, `PWI Add`
+        # must reach the supplement/addendum rules, not be greedily eaten
+        # here as a part code.
+        ((stage | typed_stage) >> space >> (supplements | str("Add") | str("ADD"))).absent? >>
         ((roman_numerals >> digits.absent? >> match['[A-Z]'].absent?) | match['[\dA-Z]'].repeat(1)).as(:part)
     end
 
@@ -132,7 +137,9 @@ module Pubid::Iso
 
     rule(:addendum) do
       (
-        (((str("/") >> (str("Add") | str("ADD")).as(:type)) | (str(" — ") >> str("Addendum").as(:type))) |
+        (((str("/") >> (stage.as(:typed_stage) >> space).maybe >>
+          (str("Add") | str("ADD")).as(:type)) |
+          (str(" — ") >> str("Addendum").as(:type))) |
          (str("/") >> staged_addenda.as(:typed_stage))) >>
           space >> digits.as(:number) >> (str(":") >> digits.as(:year)).maybe
       ).repeat(1).as(:supplements)

--- a/gems/pubid-iso/spec/pubid_iso/identifier_parsing_spec.rb
+++ b/gems/pubid-iso/spec/pubid_iso/identifier_parsing_spec.rb
@@ -934,6 +934,54 @@ module Pubid::Iso
       it_behaves_like "converts pubid to pubid"
     end
 
+    context "ISO 1151-1:1988/WD Add 1" do
+      let(:pubid) { "ISO 1151-1:1988/WD Add 1" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO 1750:1981/PWI Add 8" do
+      let(:pubid) { "ISO 1750:1981/PWI Add 8" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO 8327:1987/DIS Add 2" do
+      let(:original) { "ISO 8327:1987/DIS Add 2" }
+      let(:pubid) { "ISO 8327:1987/DAD 2" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO 8403:1991/DAdd 1" do
+      let(:original) { "ISO 8403:1991/DAdd 1" }
+      let(:pubid) { "ISO 8403:1991/DAD 1" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO/IEC Guide 98:1993/DIS Suppl 1.2" do
+      let(:original) { "ISO/IEC Guide 98:1993/DIS Suppl 1.2" }
+      let(:pubid) { "ISO/IEC Guide 98:1993/DSuppl 1.2" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO/IEC 19757-2:2003/Amd 1:2006/DIS Cor 1" do
+      let(:original) { "ISO/IEC 19757-2:2003/Amd 1:2006/DIS Cor 1" }
+      let(:pubid) { "ISO/IEC 19757-2:2003/Amd 1:2006/DCOR 1" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO 9000/WD Amd 1 — stage prefix on bare number" do
+      # Regression for the part_matcher misparse: pre-fix the stage `WD`
+      # was greedily eaten as a part code, yielding `ISO 9000-WD/Amd 1`.
+      let(:pubid) { "ISO 9000/WD Amd 1" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
     context "ISO/R 91-1970 — Addendum 1" do
       let(:original) { "ISO/R 91-1970 — Addendum 1" }
       let(:pubid) { "ISO/R 91:1970/Add 1" }

--- a/gems/pubid-iso/update_codes.yaml
+++ b/gems/pubid-iso/update_codes.yaml
@@ -11,3 +11,15 @@ ISO/NP 10303-2xx: ISO/NP 10303-2XX
 # with the publisher prefix preserved.
 "/^(ISO[\\w/]*) DIS (TR|TS|PAS|ISP) /": '\1 D\2 '
 "/^(ISO[\\w/]*) FDIS (TR|TS|PAS|ISP) /": '\1 FD\2 '
+# Long-form draft supplements (DIS Amd → DAM, DIS Cor → DCOR, DIS Suppl →
+# DSuppl, DIS Add → DAD; FDIS Amd → FDAM, FDIS Cor → FDCOR). Applies in
+# supplement position (after `/`), so the prefix has already been parsed.
+"//DIS Amd /": '/DAM '
+"//FDIS Amd /": '/FDAM '
+"//DIS Cor /": '/DCOR '
+"//FDIS Cor /": '/FDCOR '
+"//DIS Suppl /": '/DSuppl '
+"//DIS Add /": '/DAD '
+# `DAdd` is a legacy long-form spelling of the canonical `DAD` (Draft
+# Addendum) staged-addendum token.
+"//DAdd /": '/DAD '


### PR DESCRIPTION
## Summary

Closes the last 9 parser failures from the [ISO Open Data deliverables sweep](https://www.iso.org/open-data.html) — cumulative result across #56, #57, and this PR: **257 → 0**.

While fixing Group 2 I uncovered a latent `part_matcher` greediness bug that was producing *incorrect AST* (rather than a parse failure) for stage-prefixed supplements on identifiers with no part or year. Fixing it is part of this PR.

### Latent `part_matcher` misparse

`ISO 9000/WD Amd 1` was "parsing" today but with the stage `WD` greedily eaten as a part code — yielding the wrong AST and the wrong round-trip output `ISO 9000-WD/Amd 1`. The same shape with `Add` instead of `Amd` failed outright (since `Add` is not in `SUPPLEMENTS`, no later rule could recover).

`part_matcher` now has two new absence guards:

```diff
       year_digits.absent? >>
         supplements.absent? >>
+        staged_supplement.absent? >>
         staged_addenda.absent? >>
         (str("Add") | str("ADD")).absent? >>
+        ((stage | typed_stage) >> space >> (supplements | str("Add") | str("ADD"))).absent? >>
         ((roman_numerals >> digits.absent? >> match['[A-Z]'].absent?) | match['[\dA-Z]'].repeat(1)).as(:part)
```

Existing specs only used stage-prefixed supplements with a part or year (which routes around `part.maybe`), so the misparse was dormant. **No test regressions** — all 723 prior specs still pass.

### `addendum` rule extension

`Add` was the only supplement keyword without a stage-prefix path. Mirror the supplement rule's `(stage.as(:typed_stage) >> space).maybe` so `WD Add`, `PWI Add` parse natively:

```diff
-        ((str(\"/\") >> (str(\"Add\") | str(\"ADD\")).as(:type)) |
+        ((str(\"/\") >> (stage.as(:typed_stage) >> space).maybe >>
+          (str(\"Add\") | str(\"ADD\")).as(:type)) |
```

### `update_codes.yaml` normalizations

`DIS`/`FDIS` aren't valid standalone stages — they're typed-stages with canonical short equivalents (`DAM`, `DCOR`, `DSuppl`, `DAD`, `FDAM`, `FDCOR`). Same pattern as PR #57's `DIS TR → DTR` normalization, applied in supplement position:

```yaml
\"//DIS Amd /\":   '/DAM '
\"//FDIS Amd /\":  '/FDAM '
\"//DIS Cor /\":   '/DCOR '
\"//FDIS Cor /\":  '/FDCOR '
\"//DIS Suppl /\": '/DSuppl '
\"//DIS Add /\":   '/DAD '
\"//DAdd /\":      '/DAD '   # legacy long-form spelling of Draft Addendum
```

## Test plan

- [x] All 737 pubid-iso specs pass (`bundle exec rspec`) — 723 prior + 14 new.
- [x] Root integration tests pass.
- [x] Open-data sweep: 9 → 0 failures.
- [x] Eight new spec contexts cover the Group 2 cases plus a regression test (`ISO 9000/WD Amd 1`) for the misparse fix:
  - `ISO 1151-1:1988/WD Add 1` — basic-stage prefix on addendum
  - `ISO 1750:1981/PWI Add 8` — same
  - `ISO 8327:1987/DIS Add 2` → `ISO 8327:1987/DAD 2` — typed-stage normalization
  - `ISO 8403:1991/DAdd 1` → `ISO 8403:1991/DAD 1` — legacy spelling
  - `ISO/IEC Guide 98:1993/DIS Suppl 1.2` → `ISO/IEC Guide 98:1993/DSuppl 1.2`
  - `ISO/IEC 19757-2:2003/Amd 1:2006/DIS Cor 1` → `.../DCOR 1`
  - `ISO 9000/WD Amd 1` — regression test for the part_matcher misparse
- [x] Hand-verified that negative cases (`ISO 9000`, `ISO 9000/Amd 1`, `ISO 9000/DAD 1`, `ISO 10791-6:2014/PWI Amd 1`, `ISO/IEC 10646:2020/CD Amd 1`) still parse correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)