### PR TITLE
fix(iso): normalize long-form DIS/FDIS draft stages and supplements

### DIFF
--- a/data/iso/update_codes.yaml
+++ b/data/iso/update_codes.yaml
@@ -2,3 +2,20 @@ ISO/R 657/IV: ISO/R 657-4:1969
 ISO/IEC/IEEE 8802-22.2:2015/Amd.2:2017(E): ISO/IEC/IEEE 8802-22:2015/Amd.2:2017(E)
 ISO/TR 17716.2: ISO/TR 17716
 ISO/TR 17716.2(E): ISO/TR 17716(E)
+# Long-form draft typed stages (DIS TR, FDIS PAS, ...) → canonical short
+# typed-stage abbrs (DTR, FDPAS, ...). DIS/FDIS are typed-stages of the
+# IS class only — for TR/TS/PAS/ISP they have dedicated D<type>/FD<type>
+# typed-stage abbrs. Pattern matches at start of string with the
+# publisher prefix preserved.
+"/^(ISO[\\w/]*) DIS (TR|TS|PAS|ISP) /": '\1 D\2 '
+"/^(ISO[\\w/]*) FDIS (TR|TS|PAS|ISP) /": '\1 FD\2 '
+# Long-form draft supplements (DIS Amd → DAM, DIS Cor → DCOR, DIS Suppl
+# → DSuppl, DIS Add → DAD; FDIS Amd → FDAM, FDIS Cor → FDCOR). Applies
+# in supplement position (after `/`). FDIS Suppl is already the
+# canonical form so it is not rewritten.
+"//DIS Amd /": '/DAM '
+"//FDIS Amd /": '/FDAM '
+"//DIS Cor /": '/DCOR '
+"//FDIS Cor /": '/FDCOR '
+"//DIS Suppl /": '/DSuppl '
+"//DIS Add /": '/DAD '

--- a/spec/pubid/iso/update_codes_spec.rb
+++ b/spec/pubid/iso/update_codes_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Verifies the `data/iso/update_codes.yaml` regex normalizations applied
+# by `Pubid::Iso.parse` (via `Pubid::Iso::Scheme.parse`).
+#
+# `DIS` and `FDIS` are typed-stages of the IS class only — for TR/TS/PAS/ISP
+# they have dedicated `D<type>` / `FD<type>` typed-stage abbrs (e.g. `DTR`,
+# `FDPAS`, `DISP`). The long forms `DIS TR`, `FDIS PAS`, `DIS ISP` are
+# rewritten to those canonical short forms before parsing. Likewise for
+# supplement-position long forms (`DIS Cor` → `DCOR`, `DIS Suppl` → `DSuppl`,
+# `DIS Add` → `DAD`, etc.).
+RSpec.describe "ISO update_codes normalizations" do
+  shared_examples "normalizes to" do |original, canonical|
+    it "rewrites #{original.inspect} → #{canonical.inspect}" do
+      expect(Pubid::Iso.parse(original).to_s).to eq(canonical)
+    end
+  end
+
+  describe "DIS|FDIS <type> long forms" do
+    include_examples "normalizes to", "ISO/IEC DIS ISP 12060-6", "ISO/IEC DISP 12060-6"
+    include_examples "normalizes to", "ISO/IEC FDIS ISP 12060-6", "ISO/IEC FDISP 12060-6"
+    include_examples "normalizes to", "ISO/IEC DIS TR 14143-5", "ISO/IEC DTR 14143-5"
+    include_examples "normalizes to", "ISO/IEC DIS PAS 1", "ISO/IEC DPAS 1"
+    include_examples "normalizes to", "ISO/IEC FDIS PAS 1", "ISO/IEC FDPAS 1"
+    include_examples "normalizes to", "ISO/IEC DIS TS 5008", "ISO/IEC DTS 5008"
+  end
+
+  describe "DIS|FDIS <supplement-type> long forms" do
+    include_examples "normalizes to", "ISO 8327:1987/DIS Add 2", "ISO 8327:1987/DAD 2"
+    include_examples "normalizes to",
+                     "ISO/IEC Guide 98:1993/DIS Suppl 1.2",
+                     "ISO/IEC Guide 98:1993/DSuppl 1.2"
+    include_examples "normalizes to",
+                     "ISO/IEC 19757-2:2003/Amd 1:2006/DIS Cor 1",
+                     "ISO/IEC 19757-2:2003/AMD 1:2006/DCOR 1"
+  end
+
+  describe "negatives — must NOT be rewritten" do
+    # FDIS Suppl is itself a canonical typed-stage abbr (in TYPED_STAGES_SUPPLEMENTS)
+    # and gets rendered as the short form FDSuppl by the renderer, not by update_codes.
+    it "leaves canonical short forms untouched" do
+      expect(Pubid::Iso.parse("ISO/IEC ISP 12060-6").to_s).to eq("ISO/IEC ISP 12060-6")
+      expect(Pubid::Iso.parse("ISO/IEC WD ISP 11182-3").to_s).to eq("ISO/IEC WD ISP 11182-3")
+      expect(Pubid::Iso.parse("ISO 9000/Amd 1").to_s).to eq("ISO 9000/Amd 1")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Ports the `data/iso/update_codes.yaml` regex normalizations introduced in v1 PRs #57 and #58 to the v2 (`rt-new-lutaml-model`) branch.

Most cases that v1 needed to fix in those PRs are already handled natively by the v2 grammar (multi-prefix `<stage> <type>` combos, stage-prefixed basic-stage supplements like `WD Add`, lowercase part suffixes, `DAdd`, Roman-letter-prefix parts, the `WD Amd` part_matcher misparse). What remains is the same set of identifiers where `DIS`/`FDIS` is used as a long-form prefix for a type or supplement-type that has its own canonical short typed-stage abbr.

### Identifiers fixed (9 ISO Open Data IDs)

| Input | Rewritten to |
|---|---|
| `ISO/IEC DIS ISP 12060-6` | `ISO/IEC DISP 12060-6` |
| `ISO/IEC FDIS ISP 12060-6` | `ISO/IEC FDISP 12060-6` |
| `ISO/IEC DIS TR 14143-5` | `ISO/IEC DTR 14143-5` |
| `ISO/IEC DIS PAS 1` | `ISO/IEC DPAS 1` |
| `ISO/IEC FDIS PAS 1` | `ISO/IEC FDPAS 1` |
| `ISO/IEC DIS TS 5008` | `ISO/IEC DTS 5008` |
| `ISO 8327:1987/DIS Add 2` | `ISO 8327:1987/DAD 2` |
| `ISO/IEC Guide 98:1993/DIS Suppl 1.2` | `ISO/IEC Guide 98:1993/DSuppl 1.2` |
| `ISO/IEC 19757-2:2003/Amd 1:2006/DIS Cor 1` | `ISO/IEC 19757-2:2003/AMD 1:2006/DCOR 1` |

These all have dedicated `D<type>` / `FD<type>` typed-stages in `Pubid::Iso::Scheme` already (`DISP`, `FDISP`, `DTR`, `DPAS`, `FDPAS`, `DTS`, `DAD`, `DSuppl`, `DCOR`, `FDCOR`, `DAM`, `FDAM`), so the rewrites land on a form the parser already accepts. `FDIS Suppl` is itself the canonical form (in `TYPED_STAGES_SUPPLEMENTS`) and is intentionally not rewritten.

### Why update_codes and not grammar changes

`DIS` and `FDIS` are typed-stages of the IS class only — the parser would tokenize them as `:type_with_stage` but downstream `Stage.new(abbr: \"DIS\")` would (correctly) reject `DIS` as not being a stand-alone stage when paired with a non-IS type like TR or PAS. Normalizing to the canonical short form before parsing is the same approach v1 took in PR #57 and is consistent with the existing `data/iso/update_codes.yaml` mechanism.

### Resolves

The relaton-iso DataParser warnings `Failed to parse Pubid: <id>` for these 9 inputs.

## Test plan

- [x] Added `spec/pubid/iso/update_codes_spec.rb` — 10 examples covering each pattern plus a negative \"must NOT be rewritten\" group.
- [x] Full ISO spec suite: 2,983 / 2,983 pass.
- [x] Hand-verified the existing v2 spec `ISO 12345:2020/FDIS Suppl 1` still parses to `ISO 12345:2020/FDSuppl 1` (the new regex `//DIS Suppl /` does not match `/FDIS Suppl ` because of the leading `/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)