### PR TITLE
fix(nist): attach version with no leading space (match edition)

### DIFF
--- a/lib/pubid/nist/identifiers/base.rb
+++ b/lib/pubid/nist/identifiers/base.rb
@@ -349,11 +349,14 @@ module Pubid
             end
           end
 
-          # V2: Use version_component if available, else use version string
+          # V2: Use version_component if available, else use version string.
+          # Attach directly (no leading space) to match edition rendering
+          # (e.g. "800-53r5"), so version reads "800-45ver2" not
+          # "800-45 ver2".
           if version_component
-            result += " #{version_component.to_s(:short)}"
+            result += version_component.to_s(:short)
           elsif version
-            result += " Ver. #{version}"
+            result += "ver#{version}"
           end
 
           # Add supplement with date range support - FIX: proper spacing

--- a/spec/pubid/nist/identifiers/special_publication_spec.rb
+++ b/spec/pubid/nist/identifiers/special_publication_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe Pubid::Nist::Identifiers::SpecialPublication do
         end
 
         it "normalizes to ver notation" do
-          expect(parsed.to_s).to eq("NIST SP 500-268 ver1.1")
+          expect(parsed.to_s).to eq("NIST SP 500-268ver1.1")
         end
 
         it "parses version_component" do
@@ -292,7 +292,7 @@ RSpec.describe Pubid::Nist::Identifiers::SpecialPublication do
         end
 
         it "normalizes to ver2.0" do
-          expect(parsed.to_s).to eq("NIST SP 800-60 ver2.0")
+          expect(parsed.to_s).to eq("NIST SP 800-60ver2.0")
         end
 
         it "parses version_component" do

--- a/spec/pubid/nist/version_normalization_spec.rb
+++ b/spec/pubid/nist/version_normalization_spec.rb
@@ -10,28 +10,28 @@ RSpec.describe "NIST Version Normalization" do
 
     it "normalizes short v format to verbose ver format" do
       identifier = Pubid::Nist.parse("NIST SP 500-268v1.1")
-      expect(identifier.to_s).to eq("NIST SP 500-268 ver1.1")
+      expect(identifier.to_s).to eq("NIST SP 500-268ver1.1")
     end
 
     it "normalizes Ver. with period to ver format" do
       identifier = Pubid::Nist.parse("NIST SP 800-60 Ver. 2.0")
-      expect(identifier.to_s).to eq("NIST SP 800-60 ver2.0")
+      expect(identifier.to_s).to eq("NIST SP 800-60ver2.0")
     end
 
     it "preserves already-normalized ver format" do
       identifier = Pubid::Nist.parse("NIST SP 800-53ver1.1")
-      expect(identifier.to_s).to eq("NIST SP 800-53 ver1.1")
+      expect(identifier.to_s).to eq("NIST SP 800-53ver1.1")
     end
 
     it "handles multi-digit versions" do
       identifier = Pubid::Nist.parse("NIST SP 800-60ver2.0")
-      expect(identifier.to_s).to eq("NIST SP 800-60 ver2.0")
+      expect(identifier.to_s).to eq("NIST SP 800-60ver2.0")
     end
   end
 
   describe "round-trip fidelity for normalized versions" do
     it "maintains format through parse-serialize-parse cycle" do
-      original = "NIST SP 500-268 ver1.1"
+      original = "NIST SP 500-268ver1.1"
       first = Pubid::Nist.parse(original)
       serialized = first.to_s
       second = Pubid::Nist.parse(serialized)
@@ -41,7 +41,7 @@ RSpec.describe "NIST Version Normalization" do
     end
 
     it "maintains format for Ver.-normalized versions" do
-      original = "NIST SP 800-60 ver2.0"
+      original = "NIST SP 800-60ver2.0"
       first = Pubid::Nist.parse(original)
       serialized = first.to_s
       second = Pubid::Nist.parse(serialized)


### PR DESCRIPTION
NIST short-form rendering was internally inconsistent:

```
edition:  "NIST SP 800-53r5"      ← no space
version:  "NIST SP 800-45 ver2"   ← leading space
```

Attach `version` directly to the number like `edition` does, so it
renders `NIST SP 800-45ver2` — consistent with edition and with NIST's
actual short citation style. Updates the version_normalization /
special_publication spec expectations that asserted the spaced form.

Fixes 2 relaton-nist integration failures (specific-version short/long
notation). `spec/pubid/nist` stays green (968 examples).