### PR TITLE
fix(nist): logical equality ignores build artifacts + render trivia

### DIFF
--- a/lib/pubid/nist/components/edition.rb
+++ b/lib/pubid/nist/components/edition.rb
@@ -49,6 +49,22 @@ module Pubid
           end
         end
 
+        # Identity ignores original_prefix: it records how the edition was
+        # spelled in the source ("Rev. " vs "r") for round-trip rendering
+        # only. "r1" and "Rev. 1" are the same edition.
+        def ==(other)
+          return false unless other.is_a?(self.class)
+
+          type == other.type && id == other.id &&
+            additional_text == other.additional_text
+        end
+
+        alias eql? ==
+
+        def hash
+          [self.class, type, id, additional_text].hash
+        end
+
         private
 
         # Build short format: "e2", "e2.June1908", "e2.1908", "e2.50", "r1963", "-April1909", "r1a"

--- a/lib/pubid/nist/identifiers/base.rb
+++ b/lib/pubid/nist/identifiers/base.rb
@@ -84,6 +84,37 @@ module Pubid
           # See lib/pubid/nist/builder.rb lines 368-472 for compound number logic
         end
 
+        # Attributes that are build artifacts or rendering aliases, not part
+        # of an identifier's logical identity. They diverge between equally-
+        # valid spellings of the same id (e.g. long "Rev. 1" vs short "r1"):
+        #   - edition_component: redundant alias of :edition
+        #   - first_number/second_number: decomposed parts of the canonical
+        #     :number, retained from the parse for building
+        #   - parsed_format: records the input format for round-trip rendering
+        EQUALITY_IGNORED_ATTRS = %i[
+          edition_component first_number second_number parsed_format
+        ].freeze
+
+        # Logical identity comparison: equal when every attribute except the
+        # build artifacts/aliases above matches. (Edition#== already ignores
+        # its rendering-only original_prefix.)
+        def ==(other)
+          return false unless other.instance_of?(self.class)
+
+          self.class.attributes.each_key.all? do |name|
+            EQUALITY_IGNORED_ATTRS.include?(name) || send(name) == other.send(name)
+          end
+        end
+
+        alias eql? ==
+
+        def hash
+          vals = self.class.attributes.each_key.reject do |name|
+            EQUALITY_IGNORED_ATTRS.include?(name)
+          end.map { |name| send(name) }
+          [self.class, *vals].hash
+        end
+
         # Return a copy with the named attributes nil'd. Overrides
         # Pubid::Identifier#exclude because NIST's initialize is keyword-only
         # (initialize(**attributes)) while the inherited exclude rebuilds via


### PR DESCRIPTION
Long (`NIST SP 800-67 Rev. 1`) and short (`…r1`) notations parse into
objects that represent the same identifier but weren't `==`, blocking
index matching in relaton-nist. They differed only in non-identity
fields:

- `edition.original_prefix` (`" Rev. "` vs `nil`) — render-only hint
- `edition_component` (`nil` vs set) — redundant alias of `:edition`
- `second_number` (stray vs `nil`) — decomposed part of canonical `:number`

`Edition#==` now ignores `original_prefix`; `Base#==` ignores the build
artifacts/aliases (`edition_component`, `first_number`, `second_number`,
`parsed_format`), with matching `eql?`/`hash` so Set/Hash dedup is
consistent. NIST specs have no `not_to eq` and compare via `to_s`, so
widening `==` is safe — the 968-example NIST suite stays green.

Refs #60.