### PR TITLE
fix(nist): parse verbose Part N + numeric draft stages from pubs-export

### DIFF
--- a/lib/pubid/nist/parser.rb
+++ b/lib/pubid/nist/parser.rb
@@ -361,6 +361,12 @@ module Pubid
         # Fix verbose "Revision" format: " Revision (r)" → " r"
         cleaned = cleaned.gsub(/\s+Revision\s+\(r\)/, " r")
 
+        # Fix verbose "Part N" → short "ptN": "800-57 Part 2 Rev. 1" →
+        # "800-57pt2 Rev. 1". The grammar already accepts short "ptN" (and
+        # "ptN Rev. M"); only the verbose spelling was unsupported. Attaches
+        # to the preceding number so the existing part rule applies.
+        cleaned = cleaned.gsub(/\s+Part\s+(\d+)/, 'pt\1')
+
         # Fix verbose "rev YYYY" format: "126 rev 2013" → "126r2013"
         # Removes space between number and "rev", and converts to "r" prefix
         # Handles patterns like "NIST SP 260-126 rev 2013" → "NIST SP 260-126r2013"

--- a/lib/pubid/nist/parser.rb
+++ b/lib/pubid/nist/parser.rb
@@ -204,9 +204,12 @@ module Pubid
         # FIXED: Pattern must start with "v" or digit to avoid matching "rev 2013" as "v" + " 2013"
         # CRITICAL: Added word boundary \b to prevent matching "v" within "rev"
         # CRITICAL FIX: Use \b to ensure match starts at word boundary
-        cleaned = cleaned.gsub(/(\b(?:v|\d)[v\d]*[-A-Z]*)\s+(\d+)\s+(\d+)/, '\1.\2.\3') # Three parts
-        # CRITICAL FIX: Use \b to ensure match starts at word boundary
-        cleaned = cleaned.gsub(/(\b(?:v|\d)[v\d]*)\s+(\d+)/, '\1.\2') # Two parts
+        cleaned = cleaned.gsub(/(\b(?:v|\d)[v\d]*[-A-Z]*)\s+(\d+)(?!(?i:pd|wd|prd)\b)\s+(\d+)(?!(?i:pd|wd|prd)\b)/, '\1.\2.\3') # Three parts
+        # CRITICAL FIX: Use \b to ensure match starts at word boundary.
+        # Negative lookahead: don't swallow the digit of a numeric draft
+        # stage ("189 2pd" must stay split, not become "189.2pd"); letter
+        # stages ("ipd") already don't match the trailing \d+.
+        cleaned = cleaned.gsub(/(\b(?:v|\d)[v\d]*)\s+(\d+)(?!(?i:pd|wd|prd)\b)/, '\1.\2') # Two parts
 
         # Fix update patterns: ensure space before -upd or /upd (not just at end)
         # Enhanced to handle optional digits after upd: -upd, -upd1, /upd, /upd1


### PR DESCRIPTION
NIST pubs-export draft entries (which carry no DOI) fall back to the
verbose docidentifier, e.g. `SP 800-57 Part 2 Rev. 1` and stages like
`2pd`/`3pd`. Two parser defects kept those drafts from round-tripping,
so relaton-nist couldn't resolve them:

1. **Verbose `Part N`** — the grammar accepted short `ptN`/`ptN Rev. M`
   but not the verbose `Part N` spelling. Normalize ` Part N` → `ptN`.
2. **Numeric draft stage** — the two/three-part number-join
   preprocessing (`v1 1` → `v1.1`) swallowed the leading digit of a
   numeric stage: `800-189 2pd` → `800-189.2pd`, which then misparsed.
   Add a negative lookahead so the join skips a digit immediately
   followed by a draft marker (pd/wd/prd). Letter stages (`ipd`) were
   already unaffected.

Both verbose forms now round-trip to short and compare `==` their short
equivalents. `spec/pubid/nist` stays green (968 examples).

Refs #60.