### PR TITLE
fix annotated rendering crash on staged identifiers: https://github.com/metanorma/pubid/issues/69

### DIFF
--- a/gems/pubid-core/lib/pubid/core/renderer/base.rb
+++ b/gems/pubid-core/lib/pubid/core/renderer/base.rb
@@ -88,7 +88,15 @@ module Pubid::Core::Renderer
                    else
                      value
                    end
-        rendered = annotate_value(key, rendered) if opts[:annotated] && rendered
+        # Only annotate values that have been rendered to their final String
+        # form here. Some flavors (e.g. Pubid::Iso) defer rendering of certain
+        # keys to a second phase in their overridden #render_identifier: their
+        # render_<key> returns the domain object (e.g. a Stage) unchanged so it
+        # can be inspected and rendered later. Wrapping such an object in a span
+        # now would (a) stringify it prematurely and (b) replace the object with
+        # a String, breaking the second phase (which calls Stage methods like
+        # #empty_abbr?). Those keys are annotated by the subclass in phase two.
+        rendered = annotate_value(key, rendered) if opts[:annotated] && rendered.is_a?(String)
         [key, rendered]
       end.compact.to_h
     end

--- a/gems/pubid-iso/spec/pubid_iso/renderer/annotated_spec.rb
+++ b/gems/pubid-iso/spec/pubid_iso/renderer/annotated_spec.rb
@@ -41,6 +41,55 @@ module Pubid::Iso
       end
     end
 
+    # Identifiers carrying a stage (DIS, FDIS, CD, ...) exercise the ISO
+    # renderer's two-phase stage handling: render_stage returns the Stage
+    # object unchanged in the prerender phase, and postrender_stage renders it
+    # in render_identifier. Annotation must not collapse the Stage object into
+    # a String during prerender, or the second phase raises NoMethodError on
+    # Stage#empty_abbr?. See pubid-iso annotated-stage regression.
+    describe "ISO identifier with stage" do
+      subject { Identifier.parse("ISO/DIS 10303-62").to_s(annotated: true) }
+
+      it "annotates the stage in its own span" do
+        expect(subject).to eq(
+          '<span class="publisher">ISO</span>/<span class="stage">DIS</span>' \
+          ' <span class="docnumber">10303</span>-<span class="part">62</span>'
+        )
+      end
+    end
+
+    describe "ISO identifier with stage, part and year" do
+      subject { Identifier.parse("ISO/FDIS 1234-1:2013").to_s(annotated: true) }
+
+      it "annotates stage alongside all other components" do
+        expect(subject).to eq(
+          '<span class="publisher">ISO</span>/<span class="stage">FDIS</span>' \
+          ' <span class="docnumber">1234</span>-<span class="part">1</span>' \
+          ':<span class="year">2013</span>'
+        )
+      end
+    end
+
+    describe "ISO identifier with committee-draft stage" do
+      subject { Identifier.parse("ISO/CD 1234").to_s(annotated: true) }
+
+      it "annotates the stage" do
+        expect(subject).to eq(
+          '<span class="publisher">ISO</span>/<span class="stage">CD</span>' \
+          ' <span class="docnumber">1234</span>'
+        )
+      end
+    end
+
+    describe "ISO identifier with stage and type prefix" do
+      subject { Identifier.parse("ISO/DTR 1234").to_s(annotated: true) }
+
+      it "renders without raising and annotates the document number" do
+        expect { subject }.not_to raise_error
+        expect(subject).to include('<span class="docnumber">1234</span>')
+      end
+    end
+
     describe "without annotation (default)" do
       subject { Identifier.parse("ISO 1234-1:2013").to_s }
 


### PR DESCRIPTION
Fixes https://github.com/metanorma/pubid/issues/69

## Problem

`to_s(annotated: true)` raised `NoMethodError: undefined method 'empty_abbr?' for an instance of String` for every ISO identifier carrying a **stage** (`ISO/DIS`, `ISO/CD`, `ISO/FDIS`, `ISO/NP`, `ISO/WD`, `ISO/AWI`, `ISO/DTR`, …). Published and pure-type (`TR`/`TS`) identifiers were unaffected.

## Cause

`Pubid::Core::Renderer::Base#prerender_params` annotated **every** rendered param. The ISO renderer renders `:stage` in two phases — `render_stage` returns the `Stage` object unchanged during prerender, and `postrender_stage` renders it later in `render_identifier`. With `annotated: true`, the prerender phase stringified the `Stage` into a `<span>` String, so phase two's `stage.empty_abbr?` crashed. Full analysis in #69.

## Fix

Guard the prerender-phase annotation to values already rendered to their final `String`; deferred domain objects (the `Stage`) pass through untouched and are annotated by the ISO renderer's existing phase-two code.

```ruby
rendered = annotate_value(key, rendered) if opts[:annotated] && rendered.is_a?(String)
```

Smallest behaviour-preserving fix. #69 lists more general framings (explicit deferred-key declaration, or a single core annotation site) — your call whether to generalise.

## Tests

Adds stage regression coverage to `pubid-iso` `annotated_spec` (`ISO/DIS`, `ISO/FDIS`, `ISO/CD`, `ISO/DTR`). These fail with `NoMethodError` on `main` and pass with the fix.

- `pubid-core`: 176 examples, 0 failures
- `pubid-iso`: 741 examples, 1 failure (pre-existing, unrelated — `iso-pubid-russian.txt` parse example, fails on `main` too)

The new tests close only the staged-identifier gap; #69 notes the annotation feature would benefit from broader coverage (amendments/corrigendums, addenda, copublisher+stage, URN/supplement renderers).

## Downstream

Surfaced via metanorma/metanorma-iso#1555: `isodoc#std_docid_semantic_parse` calls `parsed.to_s(annotated: true)` and `metanorma-iso` opts in, so any bibliography entry citing an ISO draft crashed a production document's presentation build.

🤖

