### PR TITLE
fix(iso): derive URN document type from class, not stamped stage

### DIFF
--- a/lib/pubid/iso/builder.rb
+++ b/lib/pubid/iso/builder.rb
@@ -32,6 +32,16 @@ module Pubid
           return Identifiers::TcDocument
         end
 
+        # An explicit document type (e.g. from a URN's `:tr:`/`:ts:` token) pins
+        # the class regardless of the stage. The stage and type are separate URN
+        # fields, but the stage is later folded into `:type_with_stage` (e.g.
+        # "WDA" for 90.93), which would otherwise mis-resolve the class to the
+        # stage's owning type (IS). Consume the hint here, before assign_attributes.
+        if (doc_type = parsed_hash.delete(:document_type))
+          type_stage = locate_typed_stage(doc_type)
+          return Pubid::Iso.locate_type(type_stage.type_code) if type_stage
+        end
+
         # Check the `:type_with_stage` to determine the identifier class
         # 1. :type_with_stage will be nil if:
         # a) It is an IS.

--- a/lib/pubid/iso/urn_generator.rb
+++ b/lib/pubid/iso/urn_generator.rb
@@ -254,12 +254,28 @@ module Pubid
         publishers.map(&:body).map(&:downcase).join("-")
       end
 
+      # The document type code is owned by the identifier's *class*, not by the
+      # attached typed_stage. In a URN, type and stage are separate fields
+      # (e.g. `:tr:` and `:stage-90.93`), so a stage stamped from another type
+      # — e.g. the shared harmonized stage 90.93, which only exists as the
+      # IS-typed "WDA" stage — must not change the rendered document type.
+      # Falls back to the typed_stage's type_code for classes that declare no
+      # document type (e.g. BundledIdentifier).
+      def document_type_code
+        klass = identifier.class
+        if klass.respond_to?(:type) && klass.type.is_a?(Hash) && klass.type[:key]
+          klass.type[:key]
+        else
+          identifier.typed_stage&.type_code
+        end
+      end
+
       # Generate type component
       # RFC 5141-bis: supports extended document types (dir, dir-sup, iwa-sup)
       def type_component
         return nil unless identifier.typed_stage
 
-        type_code = identifier.typed_stage.type_code
+        type_code = document_type_code
         # International Standard is default (skip it)
         return nil if !type_code || type_code.to_s == "is"
 
@@ -294,12 +310,12 @@ module Pubid
         return nil if !stage_code || stage_code == :published
 
         # Try combined stage+type code first (e.g., "cdts" for CD+TS)
-        # This handles typed stages where stage_code differs from the full typed stage code
+        # This handles typed stages where stage_code differs from the full typed stage code.
+        # Use the class-owned document type so a cross-type stage can't mislabel it.
         combined_key = nil
-        if identifier.typed_stage.type_code &&
-            identifier.typed_stage.type_code != "is" &&
-            identifier.typed_stage.type_code.to_s != ""
-          combined_key = :"#{stage_code}#{identifier.typed_stage.type_code}"
+        dtc = document_type_code&.to_s
+        if dtc && dtc != "is" && dtc != ""
+          combined_key = :"#{stage_code}#{dtc}"
         end
 
         stage_abbr = if combined_key && TYPED_STAGE_MAP.key?(combined_key)
@@ -385,7 +401,7 @@ module Pubid
         urn_override = identifier.urn_supplement_type
         return urn_override if urn_override
 
-        identifier.typed_stage.type_code.to_s
+        document_type_code.to_s
       end
 
       # Generate supplement year/version components

--- a/lib/pubid/iso/urn_parser.rb
+++ b/lib/pubid/iso/urn_parser.rb
@@ -336,6 +336,11 @@ module Pubid
         # Add type_with_stage if type_code is present
         if type_code && type_code != :is
           base_hash[:type_with_stage] = type_code.to_s.upcase
+          # Pin the document class to the explicit URN type token. The stage
+          # block below may overwrite :type_with_stage with the stage's abbr
+          # (e.g. "WDA" for 90.93, which only exists as an IS-typed stage), so
+          # the builder needs this hint to keep e.g. TR a TechnicalReport.
+          base_hash[:document_type] = type_code.to_s.upcase
         end
 
         # Add stage if present

--- a/spec/pubid/iso/urn_spec.rb
+++ b/spec/pubid/iso/urn_spec.rb
@@ -273,6 +273,64 @@ RSpec.describe "ISO URN Generation and Parsing" do
     end
   end
 
+  # --- Regression: document type vs. stage (relaton-iso #184) ---
+  #
+  # The document type is owned by the identifier class; in a URN, type and
+  # stage are separate fields. A stage stamped from a shared harmonized code
+  # (e.g. 90.93, which only exists as the IS-typed "WDA" stage) must not drop
+  # or change the document type token. relaton-iso stamps the authoritative
+  # stage from ISO Open Data's `currentStage` by assigning such a typed_stage,
+  # which previously turned `iso-iec:tr:...` into `iso-iec:...` (lost `tr`).
+  describe "document type is independent of stamped stage" do
+    # The only typed stage covering harmonized 90.93 is the IS-typed "WDA".
+    let(:withdrawal_stage) do
+      Pubid::Iso.all_typed_stages.find do |s|
+        Array(s.harmonized_stages).include?("90.93")
+      end
+    end
+
+    {
+      "ISO/IEC TR 12382:1992" => "urn:iso:std:iso-iec:tr:12382:stage-90.93",
+      "ISO/IEC TS 17021" => "urn:iso:std:iso-iec:ts:17021:stage-90.93",
+      "ISO/IEC PAS 12345" => "urn:iso:std:iso-iec:pas:12345:stage-90.93",
+      "ISO/IEC Guide 99" => "urn:iso:std:iso-iec:guide:99:stage-90.93",
+      "ISO/R 102:1959" => "urn:iso:std:iso:r:102:stage-90.93",
+    }.each do |ref, expected_urn|
+      it "keeps the type token for #{ref} when a 90.93 stage is stamped" do
+        id = Pubid::Iso.parse(ref)
+        id.typed_stage = withdrawal_stage
+        expect(id.to_urn).to eq(expected_urn)
+      end
+    end
+
+    it "renders the reported #184 identifier with the tr token" do
+      id = Pubid::Iso.parse("ISO/IEC TR 12382")
+      id.typed_stage = withdrawal_stage
+      expect(id.to_urn).to eq("urn:iso:std:iso-iec:tr:12382:stage-90.93")
+    end
+  end
+
+  describe "round-trips a typed URN carrying a cross-type stage" do
+    {
+      "urn:iso:std:iso-iec:tr:12382:stage-90.93" =>
+        Pubid::Iso::Identifiers::TechnicalReport,
+      "urn:iso:std:iso-iec:ts:17021:stage-90.93" =>
+        Pubid::Iso::Identifiers::TechnicalSpecification,
+      "urn:iso:std:iso-iec:pas:12345:stage-90.93" =>
+        Pubid::Iso::Identifiers::Pas,
+      "urn:iso:std:iso:guide:99:stage-90.93" =>
+        Pubid::Iso::Identifiers::Guide,
+      "urn:iso:std:iso:r:102:stage-90.93" =>
+        Pubid::Iso::Identifiers::Recommendation,
+    }.each do |urn, klass|
+      it "parses #{urn} as #{klass.name.split('::').last} and round-trips" do
+        id = Pubid::Iso.parse_urn(urn)
+        expect(id).to be_a(klass)
+        expect(id.to_urn).to eq(urn)
+      end
+    end
+  end
+
   # --- RFC 5141 examples ---
   describe "RFC 5141 examples" do
     # These examples are from RFC 5141 §2.4.2


### PR DESCRIPTION
## Summary

Fixes the ISO/IEC TR (and TS/PAS/Guide/Recommendation) **URN type-token loss** behind [relaton/relaton-iso#184](https://github.com/relaton/relaton-iso/issues/184).

An ISO identifier's document type is owned by its **class** — verified invariant: every identifier class's `type[:key]` equals the `type_code` in its `TYPED_STAGES`. But the URN generator and parser treated `typed_stage.type_code` as authoritative. In a URN, **type and stage are separate fields** (`:tr:` and `:stage-90.93`), so stamping a stage from a *shared harmonized code* (e.g. `90.93`, which only exists as the IS-typed `WDA` stage) dropped the real type token:

| | URN for ISO/IEC TR 12382 @ stage 90.93 |
|---|---|
| before | `urn:iso:std:iso-iec:12382:stage-90.93` ❌ (`tr` lost) |
| after | `urn:iso:std:iso-iec:tr:12382:stage-90.93` ✅ |

This is exactly what relaton-iso's `DataParser#apply_harmonized_stage` triggers when stamping ISO Open Data's `currentStage` onto a parsed TR — the bug that surfaced in metanorma CI.

## Changes

- **`urn_generator.rb`** — new `document_type_code` helper derives the doctype from `identifier.class.type[:key]` (falling back to `typed_stage.type_code` for typeless classes like `BundledIdentifier`). Used in `type_component`, the `stage_component` combined-key, and `supplement_type_component`.
- **`urn_parser.rb` + `builder.rb`** — the parser passes a `:document_type` hint from the explicit URN type token; `locate_identifier_klass` consumes it (before `assign_attributes`) to pin the class, so the stage abbr can no longer mis-resolve `urn:…:tr:…:stage-90.93` to an `InternationalStandard`.
- **`spec/pubid/iso/urn_spec.rb`** — 11 regression specs: the relaton-mutation scenario (stamp 90.93 onto TR/TS/PAS/Guide/R → type token survives), the exact #184 identifier, and typed+staged URN parse round-trips.

## Why class-based (and why behaviour-preserving)

Because `type[:key] == type_code` for every class, deriving the type from the class is identical to the old behaviour for all legitimate data; it only diverges in the bug scenario, where a cross-type stage has been attached. The URN/surface asymmetry is intentional: URNs keep type and stage separate, so the type must never depend on the stage.

## Testing

- `rake test:all`: **6509 examples, 0 failures**
- ISO suite (`spec/pubid/iso/`): 3041, 0 failures; URN spec: 56, 0 failures (incl. 11 new)
- Integration: **16 failures with and without this change** — zero new regressions (pre-existing BSI/IEEE only)
- `validation:classify[iso]` could not run due to a **pre-existing, unrelated** syntax error in `spec/fixtures/classify_fixtures.rb` (untouched here)

## Follow-up (out of scope, not pubid code)

- The stale URN in `relaton-data-iso` corrects only after relaton-iso bumps pubid and **regenerates** the dataset.
- The human surface form (`to_s`) of a withdrawn TR still renders `ISO/IEC WDA 12382` (type + stage share one slot in human form, and no TR-specific withdrawal abbreviation exists). This affects neither the URN nor relaton's primary docid; filling per-type withdrawal abbreviations is a separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)