### PR TITLE
Render URN for amendments/corrigenda without a base edition

### DIFF
--- a/gems/pubid-iso/lib/pubid/iso/identifier/amendment.rb
+++ b/gems/pubid-iso/lib/pubid/iso/identifier/amendment.rb
@@ -29,8 +29,6 @@ module Pubid::Iso
       end
 
       def urn
-        raise Errors::NoEditionError, "Base document must have edition" unless base_has_edition?
-
         Renderer::UrnAmendment.new(to_h(deep: false)).render
       end
     end

--- a/gems/pubid-iso/lib/pubid/iso/identifier/corrigendum.rb
+++ b/gems/pubid-iso/lib/pubid/iso/identifier/corrigendum.rb
@@ -30,8 +30,6 @@ module Pubid::Iso
       end
 
       def urn
-        raise Errors::NoEditionError, "Base document must have edition" unless base_has_edition?
-
         Renderer::UrnCorrigendum.new(to_h(deep: false)).render
       end
     end

--- a/gems/pubid-iso/spec/pubid_iso/identifier_parsing_spec.rb
+++ b/gems/pubid-iso/spec/pubid_iso/identifier_parsing_spec.rb
@@ -216,9 +216,7 @@ module Pubid::Iso
       let(:pubid) { "ISO 10231:2003/Amd 1:2015" }
       let(:urn) { "urn:iso:std:iso:10231:amd:2015:v1" }
 
-      it "should raise an error when converting to URN" do
-        expect { subject.urn }.to raise_exception(Errors::NoEditionError)
-      end
+      it_behaves_like "converts pubid to urn"
 
       it "shoud have type :amd" do
         expect(subject.type[:key]).to eq(:amd)
@@ -256,6 +254,7 @@ module Pubid::Iso
       let(:pubid) { "ISO 10360-1/Cor 1:2002" }
       let(:urn) { "urn:iso:std:iso:10360:-1:cor:2002:v1" }
 
+      it_behaves_like "converts pubid to urn"
       it_behaves_like "converts urn to pubid"
     end
 


### PR DESCRIPTION
## Summary

`Pubid::Iso::Identifier::Amendment#urn` and `Corrigendum#urn` raised
`Errors::NoEditionError` ("Base document must have edition") whenever the base
document had no edition — even though the URN renderer produces a perfectly valid
URN without one. For example `ISO 10231:2003/Amd 1:2015` renders to
`urn:iso:std:iso:10231:amd:2015:v1`, which the spec **already** declared as the
expected `urn` for that context while simultaneously asserting that `#urn` raises.

The parent `Supplement#urn` renders unconditionally; only these two subclasses
added the guard, so the behaviour was also inconsistent within the hierarchy.

### Why it matters

The raise breaks serialization of working-draft amendments whose base has no
edition (e.g. `ISO/IEC 23008-1/WD Amd 1`) in downstream consumers that render the
URN during round-trip serialization. Concretely, relaton-bib's `deep_clone`
(used by relaton-iso `to_most_recent_reference`) serializes the URN-typed
docidentifier and crashes with `NoEditionError`. Since `NoEditionError <
StandardError`, it escapes callers' `rescue ParseError` guards.

## Changes

- `gems/pubid-iso/lib/pubid/iso/identifier/amendment.rb` — drop the
  `NoEditionError` guard in `#urn`; render like the parent.
- `gems/pubid-iso/lib/pubid/iso/identifier/corrigendum.rb` — same.
- `gems/pubid-iso/spec/pubid_iso/identifier_parsing_spec.rb` — the amendment
  context that asserted the raise now asserts the round-trip URN (using its
  already-declared `let(:urn)`); added forward URN coverage to the editionless
  corrigendum context (`ISO 10360-1/Cor 1:2002`).

## Testing

`bundle exec rspec` in `gems/pubid-iso` — **742 examples, 0 failures.**

Verified downstream: with this change applied to the installed gem, relaton-iso's
previously-failing `fetch WD Amd` example (`ISO/IEC 23008-1/WD Amd 1`) passes and
no other examples regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)