### PR TITLE
Make 6 more flavors round-trip through to_hash/from_hash

### DIFF
--- a/lib/pubid/amca/identifiers/base.rb
+++ b/lib/pubid/amca/identifiers/base.rb
@@ -14,14 +14,6 @@ module Pubid
         raise "Failed to parse ACMA identifier '#{identifier}': #{e.message}"
       end
 
-      # Override base_hash to handle AMCA-specific copublisher format (string, not array)
-      def base_hash
-        hash = super
-        # AMCA's copublisher is a string, not an array, so remove it from copublishers
-        hash.delete(:copublishers) if hash[:copublishers]
-        hash
-      end
-
       # Stored as a plain string (always "AMCA") so it round-trips through
       # to_hash/from_hash. Was a `def publisher` method, which made lutaml
       # serialize a String against the Components::Publisher attribute and raise.
@@ -32,8 +24,45 @@ module Pubid
       attribute :suffix, :string
       attribute :reaffirmed, :string
 
+      # Explicit key_value mapping: only these keys serialize (the inherited
+      # Pubid::Identifier attributes — including :type, which subclasses expose
+      # as a class-metadata Hash via `self.type` — are intentionally dropped).
+      # code/year are flattened to their scalar value and rebuilt on load, since
+      # the Builder may store them as either a String or a component.
+      key_value do
+        map "_type", to: :_type
+        map "publisher", to: :publisher
+        map "copublisher", to: :copublisher
+        map "code", with: { to: :code_to_kv, from: :code_from_kv }
+        map "year", with: { to: :year_to_kv, from: :year_from_kv }
+        map "suffix", to: :suffix
+        map "reaffirmed", to: :reaffirmed
+      end
+
       def to_urn
         UrnGenerator.new(self).generate
+      end
+
+      def code_to_kv(model, doc)
+        v = model.code.is_a?(::Pubid::Components::Code) ? model.code.value : model.code
+        return if v.nil? || v.to_s.empty?
+
+        doc.add_child(Lutaml::KeyValue::DataModel::Element.new("code", v.to_s))
+      end
+
+      def code_from_kv(model, value)
+        model.code = ::Pubid::Components::Code.new(value: value.to_s)
+      end
+
+      def year_to_kv(model, doc)
+        y = model.year.is_a?(::Pubid::Components::Date) ? model.year.year : model.year
+        return if y.nil? || y.to_s.empty?
+
+        doc.add_child(Lutaml::KeyValue::DataModel::Element.new("year", y.to_s))
+      end
+
+      def year_from_kv(model, value)
+        model.year = ::Pubid::Components::Date.new(year: value.to_s)
       end
     end
 

--- a/lib/pubid/amca/identifiers/interpretation.rb
+++ b/lib/pubid/amca/identifiers/interpretation.rb
@@ -24,10 +24,6 @@ reaffirmed: nil, interpretation_code: nil)
         def self.type
           { key: :interpretation, title: "Interpretation", short: "Interp" }
         end
-
-        def type
-          Interpretation.type
-        end
       end
     end
   end

--- a/lib/pubid/amca/identifiers/publication.rb
+++ b/lib/pubid/amca/identifiers/publication.rb
@@ -24,10 +24,6 @@ reaffirmed: nil, revision: nil)
         def self.type
           { key: :publication, title: "Publication", short: nil }
         end
-
-        def type
-          Publication.type
-        end
       end
     end
   end

--- a/lib/pubid/amca/identifiers/standard.rb
+++ b/lib/pubid/amca/identifiers/standard.rb
@@ -12,10 +12,6 @@ module Pubid
         def self.type
           { key: :standard, title: "Standard", short: nil }
         end
-
-        def type
-          Standard.type
-        end
       end
     end
   end

--- a/lib/pubid/amca/renderer.rb
+++ b/lib/pubid/amca/renderer.rb
@@ -31,7 +31,7 @@ module Pubid
       def render_base(id)
         parts = []
         parts << id.copublisher if id.copublisher
-        t = id.class.attributes.key?(:type) ? id.type : nil
+        t = id.class.respond_to?(:type) ? id.class.type : nil
         if t.is_a?(Hash) && t[:title]
           parts << t[:title].to_s
         end

--- a/lib/pubid/amca/urn_generator.rb
+++ b/lib/pubid/amca/urn_generator.rb
@@ -28,7 +28,8 @@ module Pubid
       end
 
       def urn_type
-        identifier.type&.to_s&.downcase
+        (identifier.class.respond_to?(:type) ? identifier.class.type : nil)
+          &.to_s&.downcase
       end
 
       def generate

--- a/lib/pubid/api/builder.rb
+++ b/lib/pubid/api/builder.rb
@@ -26,6 +26,10 @@ module Pubid
 
       def cast(key, value)
         case key
+        # `:type` is consumed only by select_class for dispatch; it is not an
+        # identifier attribute (the concrete class is pinned by `_type`). Drop it
+        # so the raw Parslet::Slice never lands in the inherited :type attribute.
+        when :type then nil
         when :number then Components::Code.new(value: value.to_s)
         when :reaffirmation
           value.is_a?(Hash) ? (value[:year] || value).to_s : value.to_s

--- a/lib/pubid/api/identifiers/base.rb
+++ b/lib/pubid/api/identifiers/base.rb
@@ -3,19 +3,9 @@
 module Pubid
   module Api
     module Identifiers
+      # Base class for all API identifiers.
+      # Inherits common attributes from SingleIdentifier.
       class Base < SingleIdentifier
-        # Base class for all API identifiers
-        # Inherits common attributes from SingleIdentifier
-
-        # Include type_string in serialization for round-trip compatibility
-        def base_hash
-          hash = super
-          if self.class.attributes.key?(:type_string) && type_string
-            hash[:type] =
-              type_string
-          end
-          hash
-        end
       end
     end
   end

--- a/lib/pubid/cie/single_identifier.rb
+++ b/lib/pubid/cie/single_identifier.rb
@@ -18,10 +18,10 @@ module Pubid
     # - Identical (identical to ISO publications)
     # - TutorialBundle (tutorial bundles)
     class SingleIdentifier < Identifier
-      # CIE uses a fixed publisher string
-      def publisher
-        "CIE"
-      end
+      # Stored as a plain string (always "CIE") so it round-trips through
+      # to_hash/from_hash. Was a `def publisher` method, which made lutaml
+      # serialize a String against the Components::Publisher attribute and raise.
+      attribute :publisher, :string, default: -> { "CIE" }
 
       attribute :year, :string
       attribute :date_separator, :string # "dash" or "colon"

--- a/lib/pubid/etsi/components/code.rb
+++ b/lib/pubid/etsi/components/code.rb
@@ -18,10 +18,15 @@ module Pubid
         attribute :minor, :string # Optional minor part
         attribute :parts, :string, collection: true # Parts array
 
-        def initialize(number:, minor: nil, parts: nil)
-          @number = number
-          @minor = minor
-          @parts = parts || []
+        # Args are optional and assigned via lutaml setters (with `super()`) so
+        # the component's attributes are tracked and round-trip through
+        # to_hash/from_hash — lutaml deserializes by calling `.new` with no args
+        # and then assigning attributes.
+        def initialize(number: nil, minor: nil, parts: nil, **opts)
+          super(**opts)
+          self.number = number
+          self.minor = minor
+          self.parts = parts || []
         end
 
         # Render code with space for minor and dash-separated parts

--- a/lib/pubid/etsi/components/version.rb
+++ b/lib/pubid/etsi/components/version.rb
@@ -13,9 +13,14 @@ module Pubid
           false
         } # true for ed.N format
 
-        def initialize(version:, is_edition: false)
-          @version = version
-          @is_edition = is_edition
+        # Args are optional and assigned via lutaml setters (with `super()`) so
+        # the component's attributes are tracked and round-trip through
+        # to_hash/from_hash — lutaml deserializes by calling `.new` with no args
+        # and then assigning attributes.
+        def initialize(version: nil, is_edition: false, **opts)
+          super(**opts)
+          self.version = version
+          self.is_edition = is_edition
         end
 
         def to_s

--- a/lib/pubid/ieee/identifiers/base.rb
+++ b/lib/pubid/ieee/identifiers/base.rb
@@ -95,13 +95,29 @@ module Pubid
         end
       end
 
-      # Override accessors to return component objects
+      # Override accessors to return component objects.
       def code
         code_obj
       end
 
       def draft
         draft_obj
+      end
+
+      # Lazily rebuild the parsed component objects from the underlying string
+      # attributes. After from_hash, lutaml restores the :code/:draft strings
+      # (@code/@draft) but not these objects; the renderer reads code_obj/
+      # draft_obj directly, so rebuild on demand to render a deserialized
+      # identifier identically to the parsed one. On the parse path code_obj/
+      # draft_obj are already set, so the `||=` returns them unchanged.
+      def code_obj
+        @code_obj ||=
+          (Components::Code.parse(@code.to_s) unless @code.nil? || @code.to_s.empty?)
+      end
+
+      def draft_obj
+        @draft_obj ||=
+          (Components::Draft.parse(@draft.to_s) unless @draft.nil? || @draft.to_s.empty?)
       end
 
       # Expose numeric month from draft if available

--- a/lib/pubid/itu/components/code.rb
+++ b/lib/pubid/itu/components/code.rb
@@ -17,10 +17,13 @@ module Pubid
         attribute :subseries, :string
         attribute :parts, :string, collection: true
 
-        def initialize(number:, subseries: nil, parts: nil)
-          @number = number
-          @subseries = subseries
-          @parts = parts || []
+        # Optional args + `super()` + setters so the attributes are lutaml-tracked
+        # and round-trip through to_hash/from_hash.
+        def initialize(number: nil, subseries: nil, parts: nil, **opts)
+          super(**opts)
+          self.number = number
+          self.subseries = subseries
+          self.parts = parts || []
         end
 
         def to_s

--- a/lib/pubid/itu/components/sector.rb
+++ b/lib/pubid/itu/components/sector.rb
@@ -12,12 +12,19 @@ module Pubid
 
         VALID_SECTORS = %w[R T D].freeze
 
-        def initialize(sector:)
-          unless VALID_SECTORS.include?(sector.to_s.upcase)
+        # Optional arg + `super()` + setter so the attribute is lutaml-tracked
+        # and round-trips through to_hash/from_hash (lutaml deserializes via an
+        # argless `.new` then attribute assignment).
+        def initialize(sector: nil, **opts)
+          super(**opts)
+          return if sector.nil?
+
+          normalized = sector.to_s.upcase
+          unless VALID_SECTORS.include?(normalized)
             raise ArgumentError, "Invalid sector: #{sector}. Must be R, T, or D"
           end
 
-          @sector = sector.to_s.upcase
+          self.sector = normalized
         end
 
         def to_s

--- a/lib/pubid/itu/components/series.rb
+++ b/lib/pubid/itu/components/series.rb
@@ -10,8 +10,11 @@ module Pubid
       class Series < Lutaml::Model::Serializable
         attribute :series, :string # e.g., BO, V, X, R, SG1, OB
 
-        def initialize(series:)
-          @series = series
+        # Optional arg + `super()` + setter so the attribute is lutaml-tracked
+        # and round-trips through to_hash/from_hash.
+        def initialize(series: nil, **opts)
+          super(**opts)
+          self.series = series
         end
 
         def to_s

--- a/lib/pubid/itu/identifiers/base.rb
+++ b/lib/pubid/itu/identifiers/base.rb
@@ -45,18 +45,6 @@ module Pubid
       #
       # @return [String] URN representation
 
-      # Override base_hash to handle ITU-specific attributes
-      def base_hash
-        hash = super
-        # ITU Series has a 'series' attribute, not 'number'
-        if hash[:series].is_a?(Hash) && series
-          hash[:series] = series.series
-        end
-        # Add sector (ITU-specific, has a 'sector' attribute)
-        hash[:sector] = sector.sector if sector
-        hash
-      end
-
       # Stored as a plain string (always "ITU") so it round-trips through
       # to_hash/from_hash. Was a `def publisher` method, which made lutaml
       # serialize a String against the Components::Publisher attribute.

--- a/spec/pubid/identifier_roundtrip_spec.rb
+++ b/spec/pubid/identifier_roundtrip_spec.rb
@@ -53,12 +53,6 @@ RSpec.describe "Identifier to_hash/from_hash round-trip" do
   # (code/version/sector/series/type/year objects) still need per-flavor
   # key_value mappings to round-trip. Tracked here; identity (is_a?) works.
   PENDING_ROUND_TRIP = {
-    "Pubid::Amca" => "custom component round-trip: `type` Hash not rebuilt by from_hash",
-    "Pubid::Api"  => "custom component round-trip: `type` Parslet::Slice not rebuilt by from_hash",
-    "Pubid::Cie"  => "publisher String vs Components::Publisher; needs publisher/component mapping",
-    "Pubid::Etsi" => "custom component round-trip: code/version dropped by from_hash",
-    "Pubid::Itu"  => "base_hash series/sector transform not reversed by from_hash",
-    "Pubid::Ieee" => "lossy rebuild: code/year stored as objects, dropped on from_hash",
   }.freeze
 
   ROUND_TRIP_SAMPLES.each do |flavor_const, sample|
@@ -75,11 +69,20 @@ RSpec.describe "Identifier to_hash/from_hash round-trip" do
   end
 
   # CSA's general forms round-trip (covered above), but the CAN/CSA adoption +
-  # revision form does not yet. Tracked separately so the working forms stay
-  # protected while this specific form is fixed in Phase 3.
-  describe "CSA CAN/CSA adoption+revision form (Phase 3 fix)" do
+  # revision form does not yet. It is a WrapperIdentifier (a plain
+  # Lutaml::Model::Serializable, not a Pubid::Identifier) whose nested
+  # `wrapped_identifier` is an attr_accessor — invisible to serialization, so it
+  # is nil after from_hash. Making it a polymorphic lutaml attribute is the right
+  # shape, but it needs (a) cross-flavor `_type` dispatch for the nested id
+  # (CanadianAdopted wraps CSA, CsaAdopted wraps ISO/IEC/CISPR), which the
+  # static class_map doesn't resolve cleanly, and (b) a fix for
+  # CanadianAdopted#to_s, which references `original_reaffirmation_4digit` on
+  # itself (it lives on the wrapped id). Tracked separately; the working CSA
+  # forms stay protected by the suite above.
+  describe "CSA CAN/CSA adoption+revision form" do
     it "round-trips CAN/CSA-A123.2-03 (R2023)" do
-      pending "from_hash raises NoMethodError (nil.attributes) on the (Ryyyy) revision form"
+      pending "wrapped_identifier (attr_accessor on a Lutaml wrapper) is not " \
+              "serialized; needs polymorphic nested-id dispatch + a to_s fix"
       id = Pubid::Csa.parse("CAN/CSA-A123.2-03 (R2023)")
       restored = id.class.from_hash(id.to_hash)
       expect(restored.to_s).to eq(id.to_s)


### PR DESCRIPTION
## Context

Follow-up to the identifier-hierarchy unification (#82). That PR left **7 flavors `pending`** in `spec/pubid/identifier_roundtrip_spec.rb` — identity (`is_a?`) worked, but `id.class.from_hash(id.to_hash).to_s != id.to_s`. This PR fixes **6 of the 7**.

## Fixes

- **Cie** — `def publisher` returned a `String` and shadowed the `Components::Publisher` attribute (lutaml raised on serialize). Replaced with `attribute :publisher, :string`.
- **Amca** — `def type` returned a class-metadata `Hash` that shadowed the `:type` attribute. Removed it (renderer/URN now read `id.class.type`) and added a `key_value` block with `code`/`year` converters.
- **Api** — the parsed `:type` (a `Parslet::Slice`, used only for class dispatch) leaked into the `:type` attribute. Filtered it in the builder; removed the dead `base_hash` override.
- **Etsi / Itu** — their custom components (`Code`/`Version`, `Sector`/`Series`/`Code`) defined `initialize` **without `super`**, so lutaml never tracked the fields and `to_hash` dropped them. Made the components proper Serializables (optional args + `super(**opts)` + setters); deleted Itu's one-way `base_hash` transform.
- **Ieee** — `code`/`year` are stored as objects via `code_obj`/`draft_obj`, which `from_hash` didn't repopulate (the renderer reads them directly). Added lazy readers that rebuild from the restored string attributes.

## Still pending

- **Csa** CAN/CSA adoption form — `wrapped_identifier` is an `attr_accessor` on a `Lutaml::Model` wrapper (not a `Pubid::Identifier`). Making it a polymorphic attribute is the right shape but needs cross-flavor nested `_type` dispatch (CanadianAdopted wraps CSA; CsaAdopted wraps ISO/IEC/CISPR) plus a fix to `CanadianAdopted#to_s` (which references `original_reaffirmation_4digit` on itself). Left explicitly `pending` with the reason documented in the spec.

## Tests

- Full suite: **7276 examples, 0 failures, 1 pending** (was 7 pending)
- Integration: **184 examples, 0 failures**
- Per-flavor spec trees for all six fixed flavors stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)