### PR TITLE
ci(security): add least-privilege permissions to generic-rake & rubygems-release

### DIFF
--- a/.github/workflows/generic-rake.yml
+++ b/.github/workflows/generic-rake.yml
@@ -30,6 +30,11 @@ on:
       pat_token:
         required: false
 
+# Least-privilege default; the only job that needs more (tests-passed) overrides
+# below. Jobs here check out code and run rake — no repo write access required.
+permissions:
+  contents: read
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -205,6 +210,11 @@ jobs:
     needs: [rake-traditional, rake-monorepo]
     if: always() && (needs.rake-traditional.result == 'success' || needs.rake-traditional.result == 'skipped') && (needs.rake-monorepo.result == 'success' || needs.rake-monorepo.result == 'skipped')
     runs-on: ubuntu-latest
+    permissions:
+      # peter-evans/repository-dispatch falls back to github.token
+      # (secrets.pat_token || github.token); repository_dispatch via
+      # GITHUB_TOKEN requires contents:write.
+      contents: write
     steps:
     - if: ${{ inputs.monorepo }}
       uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/rubygems-release.yml
+++ b/.github/workflows/rubygems-release.yml
@@ -57,6 +57,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      # gem bump --tag --push uses token: secrets.pat_token || github.token;
+      # the github.token fallback needs contents:write to push the git tag.
+      contents: write
     env:
       HAVE_PAT_TOKEN: ${{ secrets.pat_token != '' }}
     defaults:


### PR DESCRIPTION
Clears the remaining 5 CodeQL `actions/missing-workflow-permissions` alerts (follow-up to #84, which cleared the 67 `rb/polynomial-redos` alerts and the 3 local workflows).

These two workflows are pubid-local and self-contained (not cimas-synced right now — pubid is `PENDING-READD`, gated on metanorma/ci#300), so hardening them locally is durable.

- **`generic-rake.yml`**: top-level `contents: read`; the `tests-passed` job overrides to `contents: write` because `peter-evans/repository-dispatch` falls back to `GITHUB_TOKEN` (`secrets.pat_token || github.token`) for `repository_dispatch`. The `prepare` / `rake-traditional` / `rake-monorepo` jobs inherit read-only (checkout + rake only).
- **`rubygems-release.yml`**: the `release` job gets `contents: write` for the `gem bump --tag --push` git-tag push when it falls back to `github.token`. No OIDC/Trusted Publishing here, so no `id-token: write`.