### PR TITLE
Remove no-op to_s overrides (TODO 13) + fix ETSI/ITU component round-trip

### DIFF
--- a/lib/pubid/api/identifiers/mpms.rb
+++ b/lib/pubid/api/identifiers/mpms.rb
@@ -12,10 +12,6 @@ module Pubid
           "MPMS"
         end
 
-        def to_s
-          render(format: :human)
-        end
-
         private
 
         def code_portion

--- a/lib/pubid/api/identifiers/typeless_standard.rb
+++ b/lib/pubid/api/identifiers/typeless_standard.rb
@@ -5,9 +5,6 @@ module Pubid
     module Identifiers
       class TypelessStandard < Base
         # No type_string method - renders without type
-        def to_s
-          render(format: :human)
-        end
       end
     end
   end

--- a/lib/pubid/api/single_identifier.rb
+++ b/lib/pubid/api/single_identifier.rb
@@ -17,10 +17,6 @@ module Pubid
       attribute :year, :string
       attribute :reaffirmation, :string
 
-      def to_s
-        render(format: :human)
-      end
-
       private
 
       def code_portion

--- a/lib/pubid/bsi/identifiers/addendum_document.rb
+++ b/lib/pubid/bsi/identifiers/addendum_document.rb
@@ -21,10 +21,6 @@ module Pubid
           ":"
         } # Separator before Addendum (":" or " ")
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
-
         def publisher
           base_identifier&.publisher
         end

--- a/lib/pubid/bsi/identifiers/adopted_european_norm.rb
+++ b/lib/pubid/bsi/identifiers/adopted_european_norm.rb
@@ -25,10 +25,6 @@ module Pubid
           nil
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
-
         # Delegate common methods to adopted identifier
         def number
           adopted_identifier&.number

--- a/lib/pubid/bsi/identifiers/adopted_international_standard.rb
+++ b/lib/pubid/bsi/identifiers/adopted_international_standard.rb
@@ -25,10 +25,6 @@ module Pubid
           nil
         end
 
-        def to_s
-          render(format: :human)
-        end
-
         # Delegate common methods to adopted identifier
         def number
           adopted_identifier&.number

--- a/lib/pubid/bsi/identifiers/aerospace_standard.rb
+++ b/lib/pubid/bsi/identifiers/aerospace_standard.rb
@@ -59,9 +59,6 @@ module Pubid
             short: "BS" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/amendment.rb
+++ b/lib/pubid/bsi/identifiers/amendment.rb
@@ -11,10 +11,6 @@ module Pubid
         attribute :amendment_year, :integer
         attribute :separator, :string, default: -> { "+" }
 
-        def to_s
-          render(format: :human)
-        end
-
         def publisher
           base_identifier&.publisher
         end

--- a/lib/pubid/bsi/identifiers/british_industrial_practice.rb
+++ b/lib/pubid/bsi/identifiers/british_industrial_practice.rb
@@ -16,9 +16,6 @@ module Pubid
           }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/bundled_identifier.rb
+++ b/lib/pubid/bsi/identifiers/bundled_identifier.rb
@@ -18,10 +18,6 @@ module Pubid
         attribute :common_year, Bsi::Components::Date # Year applied to all if present
         attribute :bundle_type, :string # "Parts", "Sections", or nil for regular bundles
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
-
         def <=>(other)
           return nil unless other.is_a?(BundledIdentifier)
 

--- a/lib/pubid/bsi/identifiers/bundled_identifier.rb
+++ b/lib/pubid/bsi/identifiers/bundled_identifier.rb
@@ -12,7 +12,8 @@ module Pubid
       #   BS SP 13; 14; 15 and 16:1949
       #   BS 4048:Parts 1 and 2:1966
       class BundledIdentifier < SingleIdentifier
-        attribute :identifiers, ::Pubid::Identifier, collection: true, polymorphic: true
+        attribute :identifiers, ::Pubid::Identifier, collection: true, 
+                                                     polymorphic: true
         attribute :separators, :string, collection: true # Separators between identifiers
         attribute :common_year, Bsi::Components::Date # Year applied to all if present
         attribute :bundle_type, :string # "Parts", "Sections", or nil for regular bundles

--- a/lib/pubid/bsi/identifiers/committee_document.rb
+++ b/lib/pubid/bsi/identifiers/committee_document.rb
@@ -29,9 +29,6 @@ module Pubid
           { key: :committee_document, title: "Committee Document", short: "DC" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/consolidated_identifier.rb
+++ b/lib/pubid/bsi/identifiers/consolidated_identifier.rb
@@ -6,7 +6,8 @@ module Pubid
       # Consolidated Identifier - contains base document plus supplements
       # Example: "BS 4592-0:2006+A1:2012" = [BS 4592-0:2006, Amendment 1:2012]
       class ConsolidatedIdentifier < SingleIdentifier
-        attribute :identifiers, ::Pubid::Identifier, polymorphic: true, collection: true
+        attribute :identifiers, ::Pubid::Identifier, polymorphic: true, 
+                                                     collection: true
 
         def to_s(lang: :en, lang_single: false)
           render(format: :human, lang: lang, lang_single: lang_single)

--- a/lib/pubid/bsi/identifiers/consolidated_identifier.rb
+++ b/lib/pubid/bsi/identifiers/consolidated_identifier.rb
@@ -9,10 +9,6 @@ module Pubid
         attribute :identifiers, ::Pubid::Identifier, polymorphic: true, 
                                                      collection: true
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
-
         def to_urn
           base = identifiers&.first
           return nil unless base

--- a/lib/pubid/bsi/identifiers/corrigendum.rb
+++ b/lib/pubid/bsi/identifiers/corrigendum.rb
@@ -11,10 +11,6 @@ module Pubid
         attribute :corrigendum_year, :integer
         attribute :separator, :string, default: -> { "+" }
 
-        def to_s
-          render(format: :human)
-        end
-
         def publisher
           base_identifier&.publisher
         end

--- a/lib/pubid/bsi/identifiers/detailed_specification.rb
+++ b/lib/pubid/bsi/identifiers/detailed_specification.rb
@@ -27,9 +27,6 @@ module Pubid
           }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/disc.rb
+++ b/lib/pubid/bsi/identifiers/disc.rb
@@ -21,9 +21,6 @@ module Pubid
           { key: :disc, title: "DISC", short: "DISC" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/draft_document.rb
+++ b/lib/pubid/bsi/identifiers/draft_document.rb
@@ -21,9 +21,6 @@ module Pubid
             web: :draft_document, title: "Draft Document", short: "DD" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/electronic_book.rb
+++ b/lib/pubid/bsi/identifiers/electronic_book.rb
@@ -10,9 +10,6 @@ module Pubid
             web: :electronic_book, title: "Electronic Publication", short: "EP" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/expert_commentary.rb
+++ b/lib/pubid/bsi/identifiers/expert_commentary.rb
@@ -14,10 +14,6 @@ module Pubid
         attribute :format, :string # "full", "abbr", "abbr_with_topic"
         attribute :topic, :string # e.g., "Fire"
 
-        def to_s
-          render(format: :human)
-        end
-
         def publisher
           base_identifier&.publisher
         end

--- a/lib/pubid/bsi/identifiers/explanatory_supplement.rb
+++ b/lib/pubid/bsi/identifiers/explanatory_supplement.rb
@@ -29,9 +29,6 @@ module Pubid
           }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/flex.rb
+++ b/lib/pubid/bsi/identifiers/flex.rb
@@ -20,9 +20,6 @@ module Pubid
           { key: :flex, title: "BSI Flex", short: "BSI Flex" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/handbook.rb
+++ b/lib/pubid/bsi/identifiers/handbook.rb
@@ -19,9 +19,6 @@ module Pubid
           }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/index.rb
+++ b/lib/pubid/bsi/identifiers/index.rb
@@ -24,9 +24,6 @@ module Pubid
           { key: :index, title: "Index", short: "Index" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/method.rb
+++ b/lib/pubid/bsi/identifiers/method.rb
@@ -29,9 +29,6 @@ module Pubid
           { key: :method, title: "Method", short: "Method" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/national_annex.rb
+++ b/lib/pubid/bsi/identifiers/national_annex.rb
@@ -42,9 +42,6 @@ module Pubid
           base_doc&.subpart || super
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/practice_guide.rb
+++ b/lib/pubid/bsi/identifiers/practice_guide.rb
@@ -16,9 +16,6 @@ module Pubid
           }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/publicly_available_specification.rb
+++ b/lib/pubid/bsi/identifiers/publicly_available_specification.rb
@@ -21,9 +21,6 @@ module Pubid
             web: :publicly_available_specification, title: "Publicly Available Specification", short: "PAS" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/published_document.rb
+++ b/lib/pubid/bsi/identifiers/published_document.rb
@@ -21,9 +21,6 @@ module Pubid
             web: :published_document, title: "Published Document", short: "PD" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/section.rb
+++ b/lib/pubid/bsi/identifiers/section.rb
@@ -26,9 +26,6 @@ module Pubid
           { key: :section, title: "Section", short: "Section" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/set.rb
+++ b/lib/pubid/bsi/identifiers/set.rb
@@ -13,7 +13,8 @@ module Pubid
       #   BS ISO 20400 + BS ISO 44001+BS ISO 44002
       #   BS ISO 9001+BS ISO 14001
       class Set < SingleIdentifier
-        attribute :identifiers, ::Pubid::Identifier, collection: true, polymorphic: true
+        attribute :identifiers, ::Pubid::Identifier, collection: true, 
+                                                     polymorphic: true
         attribute :separators, :string, collection: true # Should all be " + "
 
         def to_s(lang: :en, lang_single: false)

--- a/lib/pubid/bsi/identifiers/set.rb
+++ b/lib/pubid/bsi/identifiers/set.rb
@@ -17,10 +17,6 @@ module Pubid
                                                      polymorphic: true
         attribute :separators, :string, collection: true # Should all be " + "
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
-
         def <=>(other)
           return nil unless other.is_a?(Set)
 

--- a/lib/pubid/bsi/identifiers/standalone_amendment.rb
+++ b/lib/pubid/bsi/identifiers/standalone_amendment.rb
@@ -25,9 +25,6 @@ module Pubid
           { key: :standalone_amendment, title: "Amendment", short: "AMD" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/supplement_document.rb
+++ b/lib/pubid/bsi/identifiers/supplement_document.rb
@@ -20,10 +20,6 @@ module Pubid
           ":"
         } # Separator before Supplement (":" or " ")
 
-        def to_s
-          render(format: :human)
-        end
-
         def publisher
           base_identifier&.publisher
         end

--- a/lib/pubid/bsi/identifiers/supplementary_index.rb
+++ b/lib/pubid/bsi/identifiers/supplementary_index.rb
@@ -29,9 +29,6 @@ module Pubid
           }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/technical_specification.rb
+++ b/lib/pubid/bsi/identifiers/technical_specification.rb
@@ -28,9 +28,6 @@ module Pubid
             web: :technical_specification, title: "Technical Specification", short: "TS" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/test_method.rb
+++ b/lib/pubid/bsi/identifiers/test_method.rb
@@ -29,9 +29,6 @@ module Pubid
           { key: :test_method, title: "Test Method", short: "BS" }
         end
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
       end
     end
   end

--- a/lib/pubid/bsi/identifiers/value_added_publication.rb
+++ b/lib/pubid/bsi/identifiers/value_added_publication.rb
@@ -15,10 +15,6 @@ module Pubid
         attribute :base_identifier, ::Pubid::Identifier, polymorphic: true
         attribute :format, :string, values: ["PDF", "TC", "BOOK"]
 
-        def to_s(lang: :en, lang_single: false)
-          render(format: :human, lang: lang, lang_single: lang_single)
-        end
-
         # Delegate common attributes to base_identifier
         def publisher
           base_identifier&.publisher

--- a/lib/pubid/bsi/single_identifier.rb
+++ b/lib/pubid/bsi/single_identifier.rb
@@ -49,10 +49,6 @@ module Pubid
       attribute :explicit_publisher, :boolean, default: -> { false }
       attribute :space_separated_part, :boolean, default: -> { false }
 
-      def to_s(lang: :en, lang_single: false)
-        render(format: :human, lang: lang, lang_single: lang_single)
-      end
-
       def <=>(other)
         return nil unless other.is_a?(Pubid::Bsi::Identifier)
 

--- a/lib/pubid/cen_cenelec/identifiers/adopted_european_norm.rb
+++ b/lib/pubid/cen_cenelec/identifiers/adopted_european_norm.rb
@@ -19,10 +19,6 @@ module Pubid
           nil
         end
 
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
-
         # Delegate common methods to adopted identifier
         def number
           adopted_identifier&.number

--- a/lib/pubid/cen_cenelec/identifiers/amendment.rb
+++ b/lib/pubid/cen_cenelec/identifiers/amendment.rb
@@ -10,10 +10,6 @@ module Pubid
         attribute :amendment_number, :string
         attribute :amendment_year, :integer
 
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
-
         def publisher
           base_identifier&.publisher
         end

--- a/lib/pubid/cen_cenelec/identifiers/base.rb
+++ b/lib/pubid/cen_cenelec/identifiers/base.rb
@@ -20,10 +20,6 @@ module Pubid
         attribute :adopted_identifier, Base, polymorphic: true # Nested identifier object (ISO, IEC, etc.)
         attribute :edition, :string # Edition number
 
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
-
         def ==(other)
           return false unless other.is_a?(Base)
 

--- a/lib/pubid/cen_cenelec/identifiers/consolidated_identifier.rb
+++ b/lib/pubid/cen_cenelec/identifiers/consolidated_identifier.rb
@@ -8,10 +8,6 @@ module Pubid
       class ConsolidatedIdentifier < Base
         attribute :identifiers, Base, polymorphic: true, collection: true
 
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
-
         # Delegate to first identifier (base document)
         def publisher
           identifiers&.first&.publisher

--- a/lib/pubid/cen_cenelec/identifiers/corrigendum.rb
+++ b/lib/pubid/cen_cenelec/identifiers/corrigendum.rb
@@ -11,10 +11,6 @@ module Pubid
         attribute :corrigendum_year, :integer
         attribute :corrigendum_month, :string
 
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
-
         def publisher
           base_identifier&.publisher
         end

--- a/lib/pubid/cen_cenelec/identifiers/european_prestandard.rb
+++ b/lib/pubid/cen_cenelec/identifiers/european_prestandard.rb
@@ -25,9 +25,6 @@ module Pubid
             web: :european_prestandard, title: "European Prestandard", short: "ENV" }
         end
 
-        def to_s(lang: :en, lang_single: false, **opts)
-          render(format: :human, lang: lang, lang_single: lang_single, **opts)
-        end
       end
     end
   end

--- a/lib/pubid/cen_cenelec/identifiers/fragment.rb
+++ b/lib/pubid/cen_cenelec/identifiers/fragment.rb
@@ -9,10 +9,6 @@ module Pubid
         attribute :base_identifier, Amendment
         attribute :fragment_number, :string
 
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
-
         def publisher
           base_identifier&.base_identifier&.publisher
         end

--- a/lib/pubid/csa/identifiers/base.rb
+++ b/lib/pubid/csa/identifiers/base.rb
@@ -4,9 +4,6 @@ module Pubid
   module Csa
     module Identifiers
       class Base < SingleIdentifier
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
       end
     end
   end

--- a/lib/pubid/csa/identifiers/cec.rb
+++ b/lib/pubid/csa/identifiers/cec.rb
@@ -20,10 +20,6 @@ module Pubid
 
           @code ||= Components::Code.new(value: "#{cec_part.value}-#{no_number.value}")
         end
-
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
       end
     end
   end

--- a/lib/pubid/csa/identifiers/series.rb
+++ b/lib/pubid/csa/identifiers/series.rb
@@ -17,10 +17,6 @@ module Pubid
       class Series < Base
         # Series prefix (MH, RV, etc.) - optional
         attribute :series_prefix, :string
-
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
       end
     end
   end

--- a/lib/pubid/etsi/components/code.rb
+++ b/lib/pubid/etsi/components/code.rb
@@ -16,18 +16,7 @@ module Pubid
       class Code < Lutaml::Model::Serializable
         attribute :number, :string # Main number
         attribute :minor, :string # Optional minor part
-        attribute :parts, :string, collection: true # Parts array
-
-        # Args are optional and assigned via lutaml setters (with `super()`) so
-        # the component's attributes are tracked and round-trip through
-        # to_hash/from_hash — lutaml deserializes by calling `.new` with no args
-        # and then assigning attributes.
-        def initialize(number: nil, minor: nil, parts: nil, **opts)
-          super(**opts)
-          self.number = number
-          self.minor = minor
-          self.parts = parts || []
-        end
+        attribute :parts, :string, collection: true, default: [] # Parts array
 
         # Render code with space for minor and dash-separated parts
         def to_s

--- a/lib/pubid/etsi/components/version.rb
+++ b/lib/pubid/etsi/components/version.rb
@@ -13,16 +13,6 @@ module Pubid
           false
         } # true for ed.N format
 
-        # Args are optional and assigned via lutaml setters (with `super()`) so
-        # the component's attributes are tracked and round-trip through
-        # to_hash/from_hash — lutaml deserializes by calling `.new` with no args
-        # and then assigning attributes.
-        def initialize(version: nil, is_edition: false, **opts)
-          super(**opts)
-          self.version = version
-          self.is_edition = is_edition
-        end
-
         def to_s
           if is_edition
             "ed.#{version}"

--- a/lib/pubid/etsi/identifiers/base.rb
+++ b/lib/pubid/etsi/identifiers/base.rb
@@ -23,10 +23,6 @@ module Pubid
       # raise on to_hash.
       attribute :publisher, :string, default: -> { "ETSI" }
 
-      def to_s
-        render(format: :human)
-      end
-
       def ==(other)
         return false unless other.is_a?(Pubid::Etsi::Identifier)
 

--- a/lib/pubid/etsi/identifiers/supplement_identifier.rb
+++ b/lib/pubid/etsi/identifiers/supplement_identifier.rb
@@ -26,9 +26,6 @@ module Pubid
         end
 
         # Render via renderer
-        def to_s
-          render(format: :human)
-        end
 
         # Recursively collect supplement notations from the supplement chain
         def collect_supplement_notations(current_supplement, notations)

--- a/lib/pubid/iec/identifiers/base.rb
+++ b/lib/pubid/iec/identifiers/base.rb
@@ -20,10 +20,6 @@ module Pubid
           map "database", to: :database, render_default: false
         end
 
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
-
         def number_portion
           return "" unless number
 

--- a/lib/pubid/iec/identifiers/consolidated_identifier.rb
+++ b/lib/pubid/iec/identifiers/consolidated_identifier.rb
@@ -35,10 +35,6 @@ module Pubid
           end
         end
 
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
-
         # Delegate common attributes to first identifier (base document)
         def publisher
           identifiers&.first&.publisher

--- a/lib/pubid/iec/identifiers/fragment_identifier.rb
+++ b/lib/pubid/iec/identifiers/fragment_identifier.rb
@@ -38,7 +38,7 @@ module Pubid
           return unless base
 
           doc.add_child(Lutaml::KeyValue::DataModel::Element.new("base",
-                                                                base.to_hash))
+                                                                 base.to_hash))
         end
 
         def base_from_kv(model, value)
@@ -116,10 +116,6 @@ module Pubid
         def self.type
           { key: :frag,
             web: :fragment_identifier, title: "Fragment", short: "FRAG" }
-        end
-
-        def to_s(**opts)
-          render(format: :human, **opts)
         end
 
         # Delegate common attributes to base_identifier

--- a/lib/pubid/iec/identifiers/sheet_identifier.rb
+++ b/lib/pubid/iec/identifiers/sheet_identifier.rb
@@ -27,15 +27,11 @@ module Pubid
           return unless base
 
           doc.add_child(Lutaml::KeyValue::DataModel::Element.new("base",
-                                                                base.to_hash))
+                                                                 base.to_hash))
         end
 
         def base_from_kv(model, value)
           model.base_identifier = ::Pubid::Iec::Identifier.from_hash(value) if value
-        end
-
-        def to_s(**opts)
-          render(format: :human, **opts)
         end
 
         # Delegate common attributes to base_identifier

--- a/lib/pubid/iec/identifiers/test_report_form.rb
+++ b/lib/pubid/iec/identifiers/test_report_form.rb
@@ -40,9 +40,6 @@ module Pubid
         end
 
         # TRF uses special rendering via the Renderer
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
       end
     end
   end

--- a/lib/pubid/iec/identifiers/vap_identifier.rb
+++ b/lib/pubid/iec/identifiers/vap_identifier.rb
@@ -27,7 +27,7 @@ module Pubid
           return unless base
 
           doc.add_child(Lutaml::KeyValue::DataModel::Element.new("base",
-                                                                base.to_hash))
+                                                                 base.to_hash))
         end
 
         def base_from_kv(model, value)
@@ -41,10 +41,6 @@ module Pubid
           "RLV" => "Redline Version (shows changes)",
           "SER" => "Serial version",
         }.freeze
-
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
 
         # Delegate common attributes to base_identifier
         def publisher

--- a/lib/pubid/iec/identifiers/working_document.rb
+++ b/lib/pubid/iec/identifiers/working_document.rb
@@ -42,10 +42,6 @@ module Pubid
 
           @stage ||= ::Pubid::Components::Stage.new(stage_code: stage_code)
         end
-
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
       end
     end
   end

--- a/lib/pubid/ieee/identifiers/adopted_standard.rb
+++ b/lib/pubid/ieee/identifiers/adopted_standard.rb
@@ -15,10 +15,6 @@ module Pubid
         attribute :adopted_identifiers, Base, polymorphic: true,
                                               collection: true
 
-        def to_s
-          render(format: :human)
-        end
-
         def publisher
           ieee_identifier&.publisher || "IEEE"
         end

--- a/lib/pubid/ieee/identifiers/base.rb
+++ b/lib/pubid/ieee/identifiers/base.rb
@@ -241,10 +241,6 @@ module Pubid
         builder.original_input = input
         builder.build(parsed)
       end
-
-      def to_s
-        render(format: :human)
-      end
     end
 
     module Identifiers

--- a/lib/pubid/ieee/identifiers/conformance_identifier.rb
+++ b/lib/pubid/ieee/identifiers/conformance_identifier.rb
@@ -19,10 +19,6 @@ module Pubid
             stage_code: "published",
           ),
         ].freeze
-
-        def to_s
-          render(format: :human)
-        end
       end
     end
   end

--- a/lib/pubid/ieee/identifiers/corrigendum.rb
+++ b/lib/pubid/ieee/identifiers/corrigendum.rb
@@ -19,10 +19,6 @@ module Pubid
             stage_code: "published",
           ),
         ].freeze
-
-        def to_s
-          render(format: :human)
-        end
       end
     end
   end

--- a/lib/pubid/ieee/identifiers/csa_dual_published.rb
+++ b/lib/pubid/ieee/identifiers/csa_dual_published.rb
@@ -32,10 +32,6 @@ module Pubid
           ieee_identifier.typed_stage
         end
 
-        def to_s
-          render(format: :human)
-        end
-
         def self.parse(string)
           Base.parse(string)
         end

--- a/lib/pubid/ieee/identifiers/dual_identifier.rb
+++ b/lib/pubid/ieee/identifiers/dual_identifier.rb
@@ -8,10 +8,6 @@ module Pubid
       class DualIdentifier < Base
         attribute :first_identifier, Base, polymorphic: true
         attribute :second_identifier, Base, polymorphic: true
-
-        def to_s
-          render(format: :human)
-        end
       end
     end
   end

--- a/lib/pubid/ieee/identifiers/dual_published.rb
+++ b/lib/pubid/ieee/identifiers/dual_published.rb
@@ -14,10 +14,6 @@ module Pubid
         # Second organization's identifier
         attribute :second_identifier, Base, polymorphic: true
 
-        def to_s
-          render(format: :human)
-        end
-
         def publisher
           # Return array of both publishers
           [first_identifier&.publisher, second_identifier&.publisher].compact

--- a/lib/pubid/ieee/identifiers/iec_ieee_copublished.rb
+++ b/lib/pubid/ieee/identifiers/iec_ieee_copublished.rb
@@ -12,10 +12,6 @@ module Pubid
         attribute :draft_info, :string          # Draft information like "/D5"
         attribute :iec_year, :string            # IEC year like "2013"
         attribute :date_info, :string           # Date information like "(10/07)"
-
-        def to_s
-          render(format: :human)
-        end
       end
     end
   end

--- a/lib/pubid/ieee/identifiers/interpretation_identifier.rb
+++ b/lib/pubid/ieee/identifiers/interpretation_identifier.rb
@@ -18,10 +18,6 @@ module Pubid
             stage_code: "published",
           ),
         ].freeze
-
-        def to_s
-          render(format: :human)
-        end
       end
     end
   end

--- a/lib/pubid/ieee/identifiers/multi_numbered_identifier.rb
+++ b/lib/pubid/ieee/identifiers/multi_numbered_identifier.rb
@@ -16,10 +16,6 @@ module Pubid
         # Secondary identifier (additional number for same document)
         attr_accessor :secondary_identifier
 
-        def to_s
-          render(format: :human)
-        end
-
         def publisher
           primary_identifier&.publisher
         end

--- a/lib/pubid/ieee/identifiers/parenthetical_identifier.rb
+++ b/lib/pubid/ieee/identifiers/parenthetical_identifier.rb
@@ -8,10 +8,6 @@ module Pubid
       class ParentheticalIdentifier < Base
         attribute :base_identifier, Base, polymorphic: true
         attribute :parenthetical_identifier, Base, polymorphic: true
-
-        def to_s
-          render(format: :human)
-        end
       end
     end
   end

--- a/lib/pubid/ieee/identifiers/redlined_standard.rb
+++ b/lib/pubid/ieee/identifiers/redlined_standard.rb
@@ -17,10 +17,6 @@ module Pubid
         # Redline flag (always true for this class)
         attribute :redline, :boolean, default: -> { true }
 
-        def to_s
-          render(format: :human)
-        end
-
         def publisher
           base_identifier&.publisher || "IEEE"
         end

--- a/lib/pubid/ieee/identifiers/si_standard.rb
+++ b/lib/pubid/ieee/identifiers/si_standard.rb
@@ -29,10 +29,6 @@ module Pubid
 
         # Use proper Draft component (Lutaml::Model object)
         attr_accessor :draft_obj
-
-        def to_s
-          render(format: :human)
-        end
       end
     end
   end

--- a/lib/pubid/iho/identifiers/base.rb
+++ b/lib/pubid/iho/identifiers/base.rb
@@ -63,12 +63,6 @@ module Pubid
 
       # from_hash is the shared polymorphic dispatch on Pubid::Identifier.
       # IHO_TYPE_MAP remains as the key_value polymorphic_map.
-
-      # Render the identifier as a string in canonical IHO form.
-      # @return [String]
-      def to_s
-        render(format: :human)
-      end
     end
 
     module Identifiers

--- a/lib/pubid/iso/single_identifier.rb
+++ b/lib/pubid/iso/single_identifier.rb
@@ -3,10 +3,6 @@
 module Pubid
   module Iso
     class SingleIdentifier < Identifier
-      def to_s(**opts)
-        render(format: :human, **opts)
-      end
-
       private
 
       def build_rendering_context(_renderer, format:, with_edition: false,

--- a/lib/pubid/itu/components/code.rb
+++ b/lib/pubid/itu/components/code.rb
@@ -15,16 +15,7 @@ module Pubid
       class Code < Lutaml::Model::Serializable
         attribute :number, :string
         attribute :subseries, :string
-        attribute :parts, :string, collection: true
-
-        # Optional args + `super()` + setters so the attributes are lutaml-tracked
-        # and round-trip through to_hash/from_hash.
-        def initialize(number: nil, subseries: nil, parts: nil, **opts)
-          super(**opts)
-          self.number = number
-          self.subseries = subseries
-          self.parts = parts || []
-        end
+        attribute :parts, :string, collection: true, default: []
 
         def to_s
           result = number.to_s

--- a/lib/pubid/itu/components/sector.rb
+++ b/lib/pubid/itu/components/sector.rb
@@ -12,16 +12,20 @@ module Pubid
 
         VALID_SECTORS = %w[R T D].freeze
 
-        # Optional arg + `super()` + setter so the attribute is lutaml-tracked
-        # and round-trips through to_hash/from_hash (lutaml deserializes via an
-        # argless `.new` then attribute assignment).
-        def initialize(sector: nil, **opts)
-          super(**opts)
-          return if sector.nil?
+        # Accept either a positional Hash (lutaml-model's call style:
+        # `Sector.new({lutaml_register: :default})` then attribute assignment)
+        # or a literal `sector:` kwarg (`Sector.new(sector: "R")`). Both call
+        # paths funnel through the same validate-then-set flow so the attribute
+        # stays lutaml-tracked and round-trips through to_hash/from_hash.
+        def initialize(attrs = {}, options = {})
+          super
+          sector_val = attrs[:sector] || attrs["sector"]
+          return if sector_val.nil?
 
-          normalized = sector.to_s.upcase
+          normalized = sector_val.to_s.upcase
           unless VALID_SECTORS.include?(normalized)
-            raise ArgumentError, "Invalid sector: #{sector}. Must be R, T, or D"
+            raise ArgumentError,
+                  "Invalid sector: #{sector_val}. Must be R, T, or D"
           end
 
           self.sector = normalized

--- a/lib/pubid/itu/components/series.rb
+++ b/lib/pubid/itu/components/series.rb
@@ -10,13 +10,6 @@ module Pubid
       class Series < Lutaml::Model::Serializable
         attribute :series, :string # e.g., BO, V, X, R, SG1, OB
 
-        # Optional arg + `super()` + setter so the attribute is lutaml-tracked
-        # and round-trips through to_hash/from_hash.
-        def initialize(series: nil, **opts)
-          super(**opts)
-          self.series = series
-        end
-
         def to_s
           series
         end

--- a/lib/pubid/jcgm/identifiers/amendment.rb
+++ b/lib/pubid/jcgm/identifiers/amendment.rb
@@ -20,10 +20,6 @@ module Pubid
         def self.type
           { key: :amendment, title: "Amendment", short: "Amd" }
         end
-
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
       end
     end
   end

--- a/lib/pubid/jcgm/identifiers/gum_guide.rb
+++ b/lib/pubid/jcgm/identifiers/gum_guide.rb
@@ -22,10 +22,6 @@ module Pubid
           { key: :gum_guide, title: "GUM Guide", short: "GUM" }
         end
 
-        def to_s(**opts)
-          render(format: :human, **opts)
-        end
-
         private
 
         def language_portion

--- a/lib/pubid/jcgm/single_identifier.rb
+++ b/lib/pubid/jcgm/single_identifier.rb
@@ -35,10 +35,6 @@ module Pubid
           ")",
         ].join
       end
-
-      def to_s
-        render(format: :human)
-      end
     end
   end
 end

--- a/lib/pubid/plateau/identifiers/handbook.rb
+++ b/lib/pubid/plateau/identifiers/handbook.rb
@@ -13,10 +13,6 @@ module Pubid
           "Handbook"
         end
 
-        def to_s
-          render(format: :human)
-        end
-
         def formatted_edition
           "第#{edition}版"
         end

--- a/lib/pubid/plateau/identifiers/technical_report.rb
+++ b/lib/pubid/plateau/identifiers/technical_report.rb
@@ -10,10 +10,6 @@ module Pubid
         def type_string
           "Technical Report"
         end
-
-        def to_s
-          render(format: :human)
-        end
       end
     end
   end

--- a/lib/pubid/plateau/supplement_identifier.rb
+++ b/lib/pubid/plateau/supplement_identifier.rb
@@ -19,10 +19,6 @@ module Pubid
         raise NotImplementedError, "Subclasses must implement supplement_string"
       end
 
-      def to_s
-        render(format: :human)
-      end
-
       # Override base_hash to extract edition, type, and annex from base_identifier
       def base_hash
         hash = super


### PR DESCRIPTION
## Summary

Two independent improvements layered on top of `rt-new-lutaml-model`:

- **TODO 13 phase 1 cleanup**: ~70 identifier classes defined `def to_s; render(format: :human); end` that exactly duplicated the inherited `Pubid::Identifier#to_s`. All removed so the parent method is used directly. No behavior change.
- **Bug fix follow-up to #83**: ETSI Code/Version and ITU Sector/Series/Code had custom `initialize(**opts)` signatures that lutaml-model's deserializer cannot call (`model_class.new({lutaml_register: :default})` — positional hash, but Ruby 3 rejects for `**opts`-only signatures). `to_hash` → `from_hash` round-trip raised `wrong number of arguments (given 1, expected 0)`. Fixed by deleting the custom initializer for components without validation (lutaml auto-generates a compatible one) and using `(attrs = {}, options = {})` for ITU Sector (which has VALID_SECTORS validation). Resolves the two pre-existing failures in `spec/pubid/identifier_roundtrip_spec.rb` (`ETSI EG 200 053 V1.5.1`, `ITU-T G.711`).

## Test plan

- [x] `bundle exec rake test:all` — 7092 examples, 0 failures, 1 pending (CSA CanadianAdopted, pre-existing)
- [x] `bundle exec rubocop` on changed files — no new offenses introduced (pre-existing long-line warnings predate this branch)
- [x] No AI attribution in any commit message
