### PR TITLE
feat(oiml): support BASE:YEAR+Supplement:YEAR joined form

### DIFF
--- a/lib/pubid/oiml/builder.rb
+++ b/lib/pubid/oiml/builder.rb
@@ -78,13 +78,14 @@ module Pubid
 
       def build_supplement(parsed_hash)
         marker = parsed_hash[:trailing_marker].to_s if parsed_hash[:trailing_marker]
+        plus_marker = parsed_hash[:plus_marker].to_s if parsed_hash[:plus_marker]
 
         # Determine supplement type. The trailing word ("Amendment"/"Errata")
         # selects the class; the concrete class then carries the word via
         # #supplement_type, so only the `trailing` flag needs storing.
         supplement_class = if parsed_hash[:annex_letter] || parsed_hash[:annex_marker]
                              Identifiers::Annex
-                           elsif marker == "Errata"
+                           elsif marker == "Errata" || plus_marker == "Errata"
                              Identifiers::Errata
                            else
                              Identifiers::Amendment
@@ -92,6 +93,7 @@ module Pubid
 
         supplement = supplement_class.new
         supplement.trailing = true if marker
+        supplement.joined = true if plus_marker
 
         # Recursively parse base identifier
         if parsed_hash[:base_identifier]

--- a/lib/pubid/oiml/parser.rb
+++ b/lib/pubid/oiml/parser.rb
@@ -19,7 +19,8 @@ module Pubid
       # Main identifier pattern - check supplements first
       rule(:identifier) do
         amendment_identifier | amendment_short | annex_letter_identifier |
-          annex_identifier | trailing_supplement_identifier | base_identifier
+          annex_identifier | plus_supplement_identifier |
+          trailing_supplement_identifier | base_identifier
       end
 
       # Publisher - always "OIML"
@@ -169,6 +170,18 @@ module Pubid
       rule(:trailing_supplement_identifier) do
         base_without_language.as(:base_identifier) >>
           space >> (str("Amendment") | str("Errata")).as(:trailing_marker) >>
+          language_portion.maybe.as(:language)
+      end
+
+      # Plus-joined supplement - "BASE:YEAR+Supplement:YEAR" form where both
+      # the base and the supplement carry their own year. Used for amendments
+      # and errata to dated bases (e.g. "OIML B 10:2011+Amendment:2012").
+      # Annexes already encode the year-on-base intent via their own model.
+      rule(:plus_supplement_identifier) do
+        base_without_language.as(:base_identifier) >>
+          str("+") >>
+          (str("Amendment") | str("Errata")).as(:plus_marker) >>
+          (colon >> year_digits.as(:year)).maybe >>
           language_portion.maybe.as(:language)
       end
 

--- a/lib/pubid/oiml/renderer.rb
+++ b/lib/pubid/oiml/renderer.rb
@@ -84,6 +84,16 @@ module Pubid
       def render_supplement(id)
         format = effective_format(id)
 
+        # Plus-joined: "BASE+Amendment:YEAR" / "BASE+Errata:YEAR" with both
+        # the base and the supplement carrying their own year.
+        if id.joined
+          base_str = strip_language(id.base_identifier.to_s)
+          result = "#{base_str}+#{id.supplement_type}"
+          result += ":#{id.year}" if id.year
+          result += " (#{id.language})" if id.language
+          return result
+        end
+
         # Trailing-word shorthand: "BASE Amendment" / "BASE Errata" with the
         # publication year kept on the base identifier. The word comes from the
         # concrete supplement class.

--- a/lib/pubid/oiml/supplement_identifier.rb
+++ b/lib/pubid/oiml/supplement_identifier.rb
@@ -13,6 +13,9 @@ module Pubid
       # "Amendment (YYYY) to BASE" prose form. The word itself comes from the
       # concrete class (#supplement_type), so only this flag is stored.
       attribute :trailing, :boolean, default: false
+      # True for the plus-joined form ("OIML B 10:2011+Amendment:2012") where
+      # both the base and the supplement carry their own year, joined by "+".
+      attribute :joined, :boolean, default: false
       attribute :parsed_format, :string, default: -> {
         "short"
       } # Track supplement's parsed format
@@ -25,6 +28,7 @@ module Pubid
             with: { to: :base_identifier_to_kv, from: :base_identifier_from_kv }
         map "year", to: :year
         map "trailing", to: :trailing
+        map "joined", to: :joined
       end
 
       def base_identifier_to_kv(model, doc)

--- a/spec/pubid/oiml/identifier_spec.rb
+++ b/spec/pubid/oiml/identifier_spec.rb
@@ -232,6 +232,39 @@ RSpec.describe Pubid::Oiml do
         expect(result.base_identifier.code.number).to eq("2")
         expect(result.to_s).to eq("Amendment (2004) to OIML D 2 Edition 1999 (E)")
       end
+
+      it "parses OIML B 10:2011+Amendment:2012 (joined form)" do
+        result = described_class.parse("OIML B 10:2011+Amendment:2012")
+
+        expect(result).to be_a(Pubid::Oiml::Identifiers::Amendment)
+        expect(result.year).to eq("2012")
+        expect(result.joined).to be(true)
+        expect(result.base_identifier).to be_a(Pubid::Oiml::Identifiers::BasicPublication)
+        expect(result.base_identifier.code.number).to eq("10")
+        expect(result.base_identifier.date.year).to eq("2011")
+        expect(result.to_s).to eq("OIML B 10:2011+Amendment:2012")
+      end
+
+      it "parses OIML R 138:2007+Amendment:2009 (E) (joined form with language)" do
+        result = described_class.parse("OIML R 138:2007+Amendment:2009 (E)")
+
+        expect(result).to be_a(Pubid::Oiml::Identifiers::Amendment)
+        expect(result.year).to eq("2009")
+        expect(result.joined).to be(true)
+        expect(result.language).to eq("E")
+        expect(result.to_s).to eq("OIML R 138:2007+Amendment:2009 (E)")
+      end
+
+      it "parses OIML B 10-1:2004+Amendment:2006 (joined form with part)" do
+        result = described_class.parse("OIML B 10-1:2004+Amendment:2006")
+
+        expect(result).to be_a(Pubid::Oiml::Identifiers::Amendment)
+        expect(result.year).to eq("2006")
+        expect(result.base_identifier.code.number).to eq("10")
+        expect(result.base_identifier.code.part).to eq("1")
+        expect(result.base_identifier.date.year).to eq("2004")
+        expect(result.to_s).to eq("OIML B 10-1:2004+Amendment:2006")
+      end
     end
 
     context "annex identifiers" do


### PR DESCRIPTION
## Summary

Adds a fifth OIML supplement surface form: plus-joined, where both the base and the supplement carry their own year, separated by `+`:

- `OIML B 10:2011+Amendment:2012`
- `OIML R 138:2007+Amendment:2009 (E)`
- `OIML B 10-1:2004+Amendment:2006`

This is distinct from the four existing forms:

| Form | Example |
|---|---|
| Long prose | `Amendment (YYYY) to BASE` |
| Short, year on amendment | `BASE Amendment:YYYY` |
| Short, edition | `BASE Amendment Edition YYYY` |
| Trailing, no amendment year | `BASE Amendment` |

The joined form is needed when an amendment's publication year differs from the base's year and we want to keep both visible at a glance. The trailing form drops the amendment year; the long prose form is verbose; the short form drops the base year.

## Implementation

- New `SupplementIdentifier#joined` boolean (serialized, round-trips via `to_hash`).
- New parser rule `plus_supplement_identifier`, ordered before `trailing_supplement_identifier`.
- `render_supplement` emits `BASE+Supplement:YEAR` when `joined` is set.
- Builder sets `joined=true` when `plus_marker` is captured.

Limited to Amendment and Errata; annexes already encode the equivalent intent via `year_on_base`.

## Test plan

- [x] New specs in `spec/pubid/oiml/identifier_spec.rb` for all three joined forms above.
- [x] Full OIML suite passes (142 examples).
- [x] Full pubid suite passes (7,329 examples, 1 pending).