### PR TITLE
feat(iala): add Pubid::Iala flavor

### DIFF
--- a/lib/pubid/iala.rb
+++ b/lib/pubid/iala.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    autoload :Builder,      "#{__dir__}/iala/builder"
+    autoload :Identifier,   "#{__dir__}/iala/identifier"
+    autoload :Identifiers,  "#{__dir__}/iala/identifiers"
+    autoload :Parser,       "#{__dir__}/iala/parser"
+    autoload :Renderer,     "#{__dir__}/iala/renderer"
+    autoload :UrnGenerator, "#{__dir__}/iala/urn_generator"
+    autoload :UrnParser,    "#{__dir__}/iala/urn_parser"
+
+    # Parse an IALA identifier string into an identifier object.
+    # @param identifier [String] The IALA identifier string to parse
+    # @return [Pubid::Iala::Identifier]
+    def self.parse(identifier)
+      Identifier.parse(identifier)
+    end
+
+    # Per-flavor format registry: inherits global formats, overrides :human
+    Identifiers::Base.format_registry = FormatRegistry.new(parent: ::Pubid::Identifier.format_registry)
+    Identifiers::Base.format_registry.register(:human, renderer: Iala::Renderer)
+
+    # Auto-discover all identifier types from the Identifiers namespace.
+    # @return [Array<Class>] identifier classes (Pubid::Identifier subclasses)
+    def self.identifier_types
+      @identifier_types ||= Identifiers.constants
+        .filter_map { |c| begin; Identifiers.const_get(c); rescue NameError; nil; end }
+        .select { |c| c.is_a?(Class) && c < Pubid::Identifier }
+        .reject { |c| c == Identifiers::Base }
+    end
+
+    # Build typed stage index from identifier types
+    # @return [Array<Pubid::Components::TypedStage>]
+    def self.all_typed_stages
+      @all_typed_stages ||= identifier_types.flat_map do |klass|
+        klass.const_defined?(:TYPED_STAGES) ? klass.const_get(:TYPED_STAGES) : []
+      end
+    end
+
+    # Lookup: type code -> identifier class
+    # @param code [String, Symbol]
+    # @return [Class, nil]
+    def self.locate_type(code)
+      identifier_types.find { |t| t.type[:key].to_s == code.to_s }
+    end
+
+    # Lookup: abbreviation -> typed stage
+    # @param abbr [String, Symbol]
+    # @return [Pubid::Components::TypedStage, nil]
+    def self.locate_stage(abbr)
+      abbr_str = abbr.to_s.upcase
+      all_typed_stages.find { |s| s.abbr.any? { |a| a.to_s.upcase == abbr_str } }
+    end
+
+    # Look up an identifier class by its IALA type letter (S, R, G, M, C, X, P).
+    # @param letter [String]
+    # @return [Class<Identifiers::Base>]
+    def self.identifier_klass_for_type_letter(letter)
+      @by_letter ||= identifier_types.to_h { |klass| [klass.type[:short], klass] }
+      @by_letter.fetch(letter.to_s.upcase)
+    end
+  end
+end
+
+Pubid::Registry.register(:iala, Pubid::Iala)

--- a/lib/pubid/iala/builder.rb
+++ b/lib/pubid/iala/builder.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    # Builds an IALA identifier object from the Parslet parse tree.
+    class Builder
+      def build(parsed)
+        hash = parsed
+        type_letter = stringify(hash[:type_letter])&.upcase
+
+        attrs = {
+          number:   build_number(hash),
+          edition:  stringify(hash.dig(:edition, :edition_value)),
+          language: stringify(hash.dig(:language_group, :language))&.upcase,
+        }.compact
+
+        Iala.identifier_klass_for_type_letter(type_letter).new(**attrs)
+      end
+
+      def self.build(parsed)
+        new.build(parsed)
+      end
+
+      private
+
+      # Compose "1070" or "0126-1" from doc_number + optional subpart.
+      def build_number(hash)
+        base = stringify(hash[:doc_number])
+        return base unless hash[:subpart]
+
+        subpart_str = subpart_to_s(hash[:subpart])
+        subpart_str.empty? ? base : "#{base}-#{subpart_str}"
+      end
+
+      # The subpart capture may be an array of {subpart_number: "1"},
+      # {subpart_number: "9"}, … (repeated matches). Join with "-".
+      def subpart_to_s(subpart)
+        return stringify(subpart).to_s unless subpart.is_a?(Array)
+
+        subpart.filter_map { |h| h.is_a?(Hash) ? stringify(h[:subpart_number]) : nil }.join("-")
+      end
+
+      def stringify(value)
+        return nil if value.nil?
+
+        str = value.to_s
+        str.empty? ? nil : str
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/identifier.rb
+++ b/lib/pubid/iala/identifier.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    # Base class for all IALA identifiers. Canonical name
+    # Pubid::Iala::Identifier; every concrete IALA identifier
+    # (Identifiers::*) descends from it, and Identifiers::Base — aliased
+    # at the foot of identifiers/base.rb — points back to it.
+    #
+    # IALA identifiers have the form:
+    #   [IALA ]{S|R|G|M|C|X|P}<4-digit number>[-<subpart>][ Ed <edition>][ (<LangLetter>)]
+    #
+    # Examples:
+    #   S1070
+    #   IALA S1070 Ed 2.0
+    #   R1016:ed2.0(F)
+    #   C0103-1 Ed 3.0
+    class Identifier < ::Pubid::Identifier
+      # Parse an IALA identifier string into an identifier object.
+      # @param identifier [String]
+      # @return [Pubid::Iala::Identifier]
+      # @raise [Parslet::ParseFailed] If parsing fails
+      def self.parse(identifier)
+        parsed = Parser.parse(identifier)
+        Builder.build(parsed)
+      rescue Parslet::ParseFailed => e
+        raise "Failed to parse IALA identifier '#{identifier}': #{e.message}"
+      end
+
+      attribute :publisher, :string, default: "IALA"
+      attribute :number,    :string    # "1070", "0126", "0103-1"
+      attribute :edition,   :string    # "2.0", "1.3", nil
+      attribute :language,  :string    # "E", "F", "S", "C", "A", "R", nil
+
+      IALA_TYPE_MAP = {
+        "pubid:iala:standard"       => "Pubid::Iala::Identifiers::Standard",
+        "pubid:iala:recommendation" => "Pubid::Iala::Identifiers::Recommendation",
+        "pubid:iala:guideline"      => "Pubid::Iala::Identifiers::Guideline",
+        "pubid:iala:manual"         => "Pubid::Iala::Identifiers::Manual",
+        "pubid:iala:model-course"   => "Pubid::Iala::Identifiers::ModelCourse",
+        "pubid:iala:report"         => "Pubid::Iala::Identifiers::Report",
+        "pubid:iala:resolution"     => "Pubid::Iala::Identifiers::Resolution",
+      }.freeze
+
+      key_value do
+        map "_type",    to: :_type, polymorphic_map: IALA_TYPE_MAP
+        map "number",   to: :number
+        map "edition",  to: :edition
+        map "language", to: :language
+      end
+
+      def to_urn
+        UrnGenerator.new(self).generate
+      end
+
+      # Single-letter type code (S, R, G, …) — convenience accessor used
+      # by Renderer and UrnGenerator.
+      def type_letter
+        self.class.type[:short]
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers.rb
+++ b/lib/pubid/iala/identifiers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      autoload :Base,           "#{__dir__}/identifiers/base"
+      autoload :Standard,       "#{__dir__}/identifiers/standard"
+      autoload :Recommendation, "#{__dir__}/identifiers/recommendation"
+      autoload :Guideline,      "#{__dir__}/identifiers/guideline"
+      autoload :Manual,         "#{__dir__}/identifiers/manual"
+      autoload :ModelCourse,    "#{__dir__}/identifiers/model_course"
+      autoload :Report,         "#{__dir__}/identifiers/report"
+      autoload :Resolution,     "#{__dir__}/identifiers/resolution"
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers/base.rb
+++ b/lib/pubid/iala/identifiers/base.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Backward-compatible alias: IALA's base class used to be
+# Pubid::Iala::Identifiers::Base. It is now Pubid::Iala::Identifier
+# (defined in identifier.rb), which is loaded by the parent autoload.
+require_relative "../identifier" unless defined?(Pubid::Iala::Identifier)
+
+module Pubid
+  module Iala
+    module Identifiers
+      Base = Pubid::Iala::Identifier
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers/guideline.rb
+++ b/lib/pubid/iala/identifiers/guideline.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      # IALA Guidelines (G series).
+      # Examples: G1015 Ed 2.2, G1078 Ed 2.1.
+      class Guideline < Base
+        def self.type
+          { key: :guideline, title: "Guideline", short: "G" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers/manual.rb
+++ b/lib/pubid/iala/identifiers/manual.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      # IALA Manuals (M prefix, planned).
+      # Today manuals carry no code (NAVGUIDE, VTS Manual, …); M is
+      # reserved for future numbered manuals.
+      class Manual < Base
+        def self.type
+          { key: :manual, title: "Manual", short: "M" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers/model_course.rb
+++ b/lib/pubid/iala/identifiers/model_course.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      # IALA Model Courses (C series).
+      # Examples: C0103-1 Ed 3.0, C2001-1 Ed 1.0.
+      class ModelCourse < Base
+        def self.type
+          { key: :"model-course", title: "Model Course", short: "C" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers/recommendation.rb
+++ b/lib/pubid/iala/identifiers/recommendation.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      # IALA Recommendations (R series).
+      # Examples: R0103 Ed 3.1, R0126 Ed 2.0, R1024 Ed 1.0.
+      class Recommendation < Base
+        def self.type
+          { key: :recommendation, title: "Recommendation", short: "R" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers/report.rb
+++ b/lib/pubid/iala/identifiers/report.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      # IALA Reports & Proceedings (X prefix, planned).
+      # Today reports carry no code; X is reserved for future numbered
+      # reports.
+      class Report < Base
+        def self.type
+          { key: :report, title: "Report", short: "X" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers/resolution.rb
+++ b/lib/pubid/iala/identifiers/resolution.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      # IALA Resolutions and other Council publications (P prefix,
+      # planned). Today resolutions carry no code; P is reserved for
+      # future numbered resolutions.
+      class Resolution < Base
+        def self.type
+          { key: :resolution, title: "Resolution", short: "P" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers/standard.rb
+++ b/lib/pubid/iala/identifiers/standard.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      # IALA Standards (S series).
+      # Examples: S1010, S1020 Ed 2.0, S1070 Ed 2.0.
+      class Standard < Base
+        def self.type
+          { key: :standard, title: "Standard", short: "S" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/parser.rb
+++ b/lib/pubid/iala/parser.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "parslet"
+
+module Pubid
+  module Iala
+    # Parslet grammar for IALA identifiers.
+    #
+    # Accepts every shape that appears on the IALA website or cover page:
+    #
+    #   S1070
+    #   S1070 Ed 2.0
+    #   IALA S1070 Ed 2.0
+    #   S1070 Ed 2.0 (F)
+    #   R1016:ed2.0(F)
+    #   C0103-1
+    #   C0103-1 Ed 3.0
+    class Parser < Parslet::Parser
+      include ::Pubid::Parser::CommonParseRules
+
+      root :identifier
+
+      rule(:space)  { str(" ") }
+      rule(:space?) { space.maybe }
+      rule(:dash)   { str("-") }
+      rule(:colon)  { str(":") }
+      rule(:dot)    { str(".") }
+      rule(:lparen) { str("(") }
+      rule(:rparen) { str(")") }
+
+      # Type letter — one of IALA's seven document classes. Captured to
+      # route to the right Identifiers::* subclass.
+      rule(:type_letter) do
+        (str("S") | str("R") | str("G") | str("M") |
+         str("C") | str("X") | str("P")).as(:type_letter)
+      end
+
+      # 4-digit document number, e.g. "1070", "0126".
+      rule(:doc_number) do
+        match("[0-9]").repeat(4, 4).as(:doc_number)
+      end
+
+      # Numeric sub-part suffix(es): "-1", "-9-10", "-11". The catalogue
+      # uses ranges like R0124-9-10 & 11 — that compound is captured
+      # verbatim and resolved by the caller, not here.
+      rule(:subpart) do
+        (dash >> digits.as(:subpart_number)).repeat(1).as(:subpart)
+      end
+
+      rule(:code) do
+        type_letter >> doc_number >> subpart.maybe
+      end
+
+      # Edition forms observed on covers and listing pages:
+      #   " Ed 2.0"      — cover-page human form
+      #   ":ed2.0"       — listing-page compact form
+      rule(:edition_human) do
+        (space >> str("Ed") >> space >> edition_value).as(:edition)
+      end
+
+      rule(:edition_compact) do
+        (colon >> str("ed") >> edition_value).as(:edition)
+      end
+
+      rule(:edition_value) do
+        (digits >> (dot >> digits).repeat).as(:edition_value)
+      end
+
+      rule(:edition) do
+        edition_human | edition_compact
+      end
+
+      # Language is a single uppercase letter inside parens: (E), (F), …
+      rule(:language) do
+        (space? >> lparen >>
+          (str("E") | str("F") | str("S") | str("C") | str("A") | str("R")).as(:language) >>
+          rparen).as(:language_group)
+      end
+
+      # Optional "IALA " prefix.
+      rule(:publisher) do
+        (str("IALA") >> space).maybe
+      end
+
+      rule(:identifier) do
+        publisher >> code >> edition.maybe >> language.maybe
+      end
+
+      # Parse a string and return the raw parslet tree.
+      # @param string [String]
+      # @return [Hash]
+      def self.parse(string)
+        raise ArgumentError, "IALA identifier string exceeds maximum length" if string.length > ::Pubid::MAX_INPUT_LENGTH
+
+        new.parse(string.strip)
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/renderer.rb
+++ b/lib/pubid/iala/renderer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    # Human-readable renderer for IALA identifiers.
+    #
+    # Produces strings like:
+    #   "IALA S1070"
+    #   "IALA S1070 Ed 2.0"
+    #   "IALA R1016 Ed 2.0 (F)"
+    class Renderer < ::Pubid::Renderers::Base
+      def render(context: nil, **_opts)
+        id = @id
+
+        rendered = "#{id.publisher} #{id.type_letter}#{id.number}"
+        rendered << " Ed #{id.edition}" if id.edition
+        rendered << " (#{id.language})" if id.language
+        rendered
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/urn_generator.rb
+++ b/lib/pubid/iala/urn_generator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    # Generates URN strings for IALA identifiers using the Maritime Resource
+    # Name (MRN) namespace that IALA prints on its cover pages.
+    #
+    # Format: urn:mrn:iala:pub:<type-lower><number>[:ed<edition>][:<lang-lower>]
+    # Example: urn:mrn:iala:pub:s1070:ed2.0
+    #          urn:mrn:iala:pub:r1016:ed2.0:f
+    class UrnGenerator
+      attr_reader :identifier
+
+      def initialize(identifier)
+        @identifier = identifier
+      end
+
+      def generate
+        parts = ["urn:mrn:iala:pub", code_segment]
+        parts << "ed#{identifier.edition}" if identifier.edition
+        parts << identifier.language.downcase if identifier.language
+        parts.join(":")
+      end
+
+      private
+
+      def code_segment
+        "#{identifier.type_letter.downcase}#{identifier.number}"
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/urn_parser.rb
+++ b/lib/pubid/iala/urn_parser.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    # Parses IALA MRN URNs back into identifiers.
+    #
+    # UrnGenerator emits:
+    #   urn:mrn:iala:pub:<type-lower><number>[:ed<edition>][:<lang-lower>]
+    #
+    # Examples:
+    #   urn:mrn:iala:pub:s1070:ed2.0          → IALA S1070 Ed 2.0
+    #   urn:mrn:iala:pub:r1016:ed2.0:f        → IALA R1016 Ed 2.0 (F)
+    #   urn:mrn:iala:pub:c0103-1              → IALA C0103-1
+    class UrnParser < Pubid::UrnParser::Base
+      PREFIX = "urn:mrn:iala:pub:".freeze
+
+      def parse_urn(urn)
+        body = strip_namespace(urn)
+        parts = split_parts(body)
+        code = parts.fetch(0)
+
+        edition = nil
+        language = nil
+        parts.drop(1).each do |seg|
+          if seg.start_with?("ed")
+            edition = seg.sub(/\Aed/, "")
+          elsif seg.length == 1 && seg.match?(/\A[a-z]\z/i)
+            language = seg.upcase
+          end
+        end
+
+        text = "IALA #{code.upcase}"
+        text += " Ed #{edition}" if edition
+        text += " (#{language})" if language
+        flavor_parse(text)
+      end
+
+      private
+
+      def strip_namespace(urn)
+        unless urn.downcase.start_with?(PREFIX)
+          raise Pubid::UrnParser::Errors::ParseError,
+                "Invalid IALA URN: #{urn.inspect}"
+        end
+
+        urn[PREFIX.length..]
+      end
+    end
+  end
+end

--- a/spec/pubid/iala/identifier_spec.rb
+++ b/spec/pubid/iala/identifier_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pubid/iala"
+
+RSpec.describe Pubid::Iala::Identifier do
+  describe ".parse" do
+    {
+      "S1070"                      => "IALA S1070",
+      "S1070 Ed 2.0"               => "IALA S1070 Ed 2.0",
+      "IALA S1070 Ed 2.0"          => "IALA S1070 Ed 2.0",
+      "R0126 Ed 2.0"               => "IALA R0126 Ed 2.0",
+      "R0126:ed2.0"                => "IALA R0126 Ed 2.0",
+      "R1016:ed2.0(F)"             => "IALA R1016 Ed 2.0 (F)",
+      "G1015 Ed 2.2"               => "IALA G1015 Ed 2.2",
+      "C0103-1 Ed 3.0"             => "IALA C0103-1 Ed 3.0",
+      "C0103-1"                    => "IALA C0103-1",
+      "S1070 Ed 2.0 (F)"           => "IALA S1070 Ed 2.0 (F)",
+    }.each do |input, canonical|
+      it "parses #{input.inspect} → #{canonical.inspect}" do
+        expect(Pubid::Iala.parse(input).to_s).to eq(canonical)
+      end
+    end
+
+    it "routes Standards to Identifiers::Standard" do
+      expect(Pubid::Iala.parse("S1070")).to be_a(Pubid::Iala::Identifiers::Standard)
+    end
+
+    it "routes Recommendations to Identifiers::Recommendation" do
+      expect(Pubid::Iala.parse("R0126 Ed 2.0")).to be_a(Pubid::Iala::Identifiers::Recommendation)
+    end
+
+    it "routes Guidelines to Identifiers::Guideline" do
+      expect(Pubid::Iala.parse("G1015")).to be_a(Pubid::Iala::Identifiers::Guideline)
+    end
+
+    it "routes Model Courses to Identifiers::ModelCourse" do
+      expect(Pubid::Iala.parse("C0103-1")).to be_a(Pubid::Iala::Identifiers::ModelCourse)
+    end
+
+    it "preserves the subpart verbatim in the number" do
+      expect(Pubid::Iala.parse("C0103-1").number).to eq("0103-1")
+    end
+
+    it "captures the language letter" do
+      expect(Pubid::Iala.parse("R1016:ed2.0(F)").language).to eq("F")
+    end
+
+    it "raises on unparseable input" do
+      expect { Pubid::Iala.parse("XYZ123-BAD") }.to raise_error(StandardError)
+    end
+  end
+
+  describe "#to_urn" do
+    {
+      "S1070"              => "urn:mrn:iala:pub:s1070",
+      "S1070 Ed 2.0"       => "urn:mrn:iala:pub:s1070:ed2.0",
+      "R1016 Ed 2.0"       => "urn:mrn:iala:pub:r1016:ed2.0",
+      "R1016 Ed 2.0 (F)"   => "urn:mrn:iala:pub:r1016:ed2.0:f",
+      "C0103-1 Ed 3.0"     => "urn:mrn:iala:pub:c0103-1:ed3.0",
+    }.each do |input, urn|
+      it "renders #{input.inspect} as #{urn.inspect}" do
+        expect(Pubid::Iala.parse(input).to_urn).to eq(urn)
+      end
+    end
+  end
+
+  describe "URN round-trip" do
+    %w[
+      urn:mrn:iala:pub:s1070:ed2.0
+      urn:mrn:iala:pub:r1016:ed2.0:f
+      urn:mrn:iala:pub:c0103-1:ed3.0
+      urn:mrn:iala:pub:g1015
+    ].each do |urn|
+      it "round-trips #{urn.inspect} through the parser" do
+        id = Pubid::Iala::UrnParser.parse(urn)
+        expect(id.to_urn).to eq(urn)
+      end
+    end
+  end
+
+  describe "polymorphic round-trip via to_hash / from_hash" do
+    %w[
+      S1070
+      S1070\ Ed\ 2.0
+      R0126\ Ed\ 2.0\ (F)
+      C0103-1\ Ed\ 3.0
+    ].each do |code|
+      it "round-trips #{code.inspect}" do
+        id = Pubid::Iala.parse(code)
+        restored = Pubid::Iala::Identifier.from_hash(id.to_hash)
+        expect(restored.to_s).to eq(id.to_s)
+        expect(restored.class).to eq(id.class)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds the IALA (International Organization for Marine Aids to Navigation) flavor to pubid v2. Mirrors the OIML/IHO pattern: `Identifier` base, 7 `Identifiers::*` subclasses (one per document type), parslet `Parser`, `Builder`, `Renderer`, `UrnGenerator`, `UrnParser`.

## Identifier shapes supported

| Form                              | Example                            |
|-----------------------------------|------------------------------------|
| Bare catalogue code               | `S1070`, `R0126`, `C0103-1`        |
| Human form with edition           | `IALA S1070 Ed 2.0`                |
| Compact listing form              | `R1016:ed2.0(F)`                   |
| MRN URN                           | `urn:mrn:iala:pub:s1070:ed2.0`     |

Type letters: S (standard), R (recommendation), G (guideline), M (manual), C (model-course), X (report, reserved), P (resolution, reserved).

URN convention: IALA uses MRN (`urn:mrn:iala:pub:...`), not the relaton-standard `urn:iala:...`. The UrnParser overrides `strip_namespace` to handle the prefix.

## Files added

- lib/pubid/iala.rb — module entry, registers with Pubid::Registry
- lib/pubid/iala/identifier.rb — base class
- lib/pubid/iala/identifiers.rb + identifiers/ — 7 subclasses + base alias
- lib/pubid/iala/parser.rb — parslet grammar
- lib/pubid/iala/builder.rb — builds Identifier from parslet tree
- lib/pubid/iala/renderer.rb — human form
- lib/pubid/iala/urn_generator.rb — MRN URN generator
- lib/pubid/iala/urn_parser.rb — MRN URN parser
- spec/pubid/iala/identifier_spec.rb — 30 examples

## Test plan

- [x] `bundle exec rspec spec/pubid/iala/` — 30 examples, 0 failures
- [x] Full pubid suite still green (7356 examples, 0 failures, 1 pre-existing pending)
- [x] `Pubid::Iala.parse("S1070 Ed 2.0").to_urn == "urn:mrn:iala:pub:s1070:ed2.0"`
- [x] Round-trip: `UrnParser.parse(urn).to_urn == urn`
- [x] Polymorphic `from_hash` / `to_hash` round-trip

## Companion PRs

- relaton/relaton#20 — Relaton::Iala flavor (uses Pubid::Iala in Docidentifier)
- relaton/relaton-data-iala#1 — scraper + dataset (uses Pubid::Iala for index-v2)