### PR TITLE
fix(iala): register Pubid::Iala autoload in lib/pubid.rb

### DIFF
--- a/lib/pubid.rb
+++ b/lib/pubid.rb
@@ -95,6 +95,7 @@ module Pubid
   autoload :Idf, "pubid/idf"
   autoload :Iec, "pubid/iec"
   autoload :Ieee, "pubid/ieee"
+  autoload :Iala, "pubid/iala"
   autoload :Iho, "pubid/iho"
   autoload :Iso, "pubid/iso"
   autoload :Itu, "pubid/itu"


### PR DESCRIPTION
Follow-up to #91 — the merged PR added the Pubid::Iala flavor files but missed the central autoload entry in lib/pubid.rb. Without it,  raises NameError because  isn't loaded yet when the flavor file is required.

Adding `autoload :Iala, "pubid/iala"` next to the Iho entry makes flavor discovery work via the normal autoload path.

## Test plan
- [x] `bundle exec ruby -e 'require "pubid"; p Pubid::Iala.parse("S1070 Ed 2.0").to_urn'` → `"urn:mrn:iala:pub:s1070:ed2.0"`
- [x] All 30 IALA specs still pass