### PR TITLE
ci: run rake on every PR, not just main/master

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -5,13 +5,15 @@ on:
     branches: [ main, master ]
     tags: [ v* ]
   pull_request:
-    branches: [ main, master ]
   workflow_dispatch:
 
-# Least-privilege default; the reusable generic-rake.yml drives releases via the
-# METANORMA_CI_PAT_TOKEN secret, so GITHUB_TOKEN only needs read access here.
+# The reusable generic-rake.yml's tests-passed job needs contents:write for
+# peter-evans/repository-dispatch (GITHUB_TOKEN fallback when pat_token is
+# unset). Pinning to read here breaks the nested job with: "The nested job
+# 'tests-passed' is requesting 'contents: write', but is only allowed
+# 'contents: read'."
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}

--- a/lib/pubid/oiml/builder.rb
+++ b/lib/pubid/oiml/builder.rb
@@ -6,6 +6,7 @@ module Pubid
       # Type to identifier class mapping (MECE)
       TYPE_CLASS_MAP = {
         "B" => "BasicPublication",
+        "Bulletin" => "Bulletin",
         "D" => "Document",
         "E" => "ExpertReport",
         "G" => "Guide",
@@ -175,12 +176,26 @@ module Pubid
           identifier.date = Pubid::Components::Date.new(year: year_value.to_s)
         end
 
+        # Bulletin-specific locator fields. The structured form captures
+        # issue/sequence directly; the citation form captures volume/issue/
+        # article_id, which we decode to the same (year, issue, sequence)
+        # tuple. Year comes from either the date rule (structured) or the
+        # article_id (citation).
+        if identifier.is_a?(Identifiers::Bulletin)
+          apply_bulletin_locator(identifier, parsed_hash)
+        end
+
         # Determine parsed format for round-trip fidelity
         # If edition_format was captured, it means "Edition" text was present
         identifier.parsed_format = if parsed_hash[:edition_format]
                                      "long"
                                    elsif parsed_hash[:space_before_lang]
                                      "short_with_space"
+                                   elsif parsed_hash[:article_id]
+                                     # Bulletin citation form — preserve on
+                                     # the identifier so default to_s gives
+                                     # back the citation string verbatim.
+                                     "citation"
                                    else
                                      "short"
                                    end
@@ -193,6 +208,24 @@ module Pubid
         identifier.language = extract_language(parsed_hash[:language]) if parsed_hash[:language]
 
         identifier
+      end
+
+      # Populate issue/sequence on a Bulletin from either parse shape.
+      # Structured: :issue and :sequence captured directly as zero-padded
+      # strings. Citation: :volume_roman, :issue_arabic, :article_id —
+      # decode the 8-digit article_id to recover year+issue+sequence.
+      def apply_bulletin_locator(identifier, parsed_hash)
+        if parsed_hash[:article_id]
+          article_id = parsed_hash[:article_id].to_s
+          identifier.date ||= Pubid::Components::Date.new
+          identifier.date.year = article_id[0, 4]
+          identifier.issue = article_id[4, 2]
+          identifier.sequence = article_id[6, 2]
+          return
+        end
+
+        identifier.issue = parsed_hash[:issue].to_s if parsed_hash[:issue]
+        identifier.sequence = parsed_hash[:sequence].to_s if parsed_hash[:sequence]
       end
 
       def extract_language(lang_data)

--- a/lib/pubid/oiml/identifier.rb
+++ b/lib/pubid/oiml/identifier.rb
@@ -10,6 +10,7 @@ module Pubid
       OIML_TYPE_MAP = {
         "pubid:oiml:recommendation" => "Pubid::Oiml::Identifiers::Recommendation",
         "pubid:oiml:basic-publication" => "Pubid::Oiml::Identifiers::BasicPublication",
+        "pubid:oiml:bulletin" => "Pubid::Oiml::Identifiers::Bulletin",
         "pubid:oiml:document" => "Pubid::Oiml::Identifiers::Document",
         "pubid:oiml:guide" => "Pubid::Oiml::Identifiers::Guide",
         "pubid:oiml:vocabulary" => "Pubid::Oiml::Identifiers::Vocabulary",

--- a/lib/pubid/oiml/identifiers.rb
+++ b/lib/pubid/oiml/identifiers.rb
@@ -6,6 +6,7 @@ module Pubid
       autoload :Amendment, "#{__dir__}/identifiers/amendment"
       autoload :Annex, "#{__dir__}/identifiers/annex"
       autoload :BasicPublication, "#{__dir__}/identifiers/basic_publication"
+      autoload :Bulletin, "#{__dir__}/identifiers/bulletin"
       autoload :Document, "#{__dir__}/identifiers/document"
       autoload :Errata, "#{__dir__}/identifiers/errata"
       autoload :ExpertReport, "#{__dir__}/identifiers/expert_report"

--- a/lib/pubid/oiml/identifiers/bulletin.rb
+++ b/lib/pubid/oiml/identifiers/bulletin.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Oiml
+    module Identifiers
+      # OIML Bulletin issues and articles. Carries no code — the locator is
+      # the (year, issue, sequence) tuple drawn from the issue's place in the
+      # periodical hierarchy.
+      #
+      # Two input forms are accepted, both referring to the same article:
+      #
+      #   structured:  "OIML Bulletin 2026-02-11"
+      #   citation:    "OIML Bulletin LXVII(2) 20260211"
+      #
+      # The structured form is the dataset's primary docid (sortable,
+      # deterministic). The citation form is what OIML prints on the article
+      # page (`Citation: AUTHOR YEAR OIML Bulletin VOLUME(ISSUE) ARTID`).
+      #
+      # Volume tracks year deterministically: 1960 = I, year - 1959 = volume.
+      # The 8-digit article id is YYYYNNSS — the same three values concatenated,
+      # so the citation form is decoded entirely from the article id; the
+      # roman volume and parenthesised issue are redundant display.
+      #
+      # Shapes in relaton-data-oiml:
+      #   "OIML Bulletin"                       (periodical)
+      #   "OIML Bulletin 1960"                  (volume / year)
+      #   "OIML Bulletin 1960-03"               (issue)
+      #   "OIML Bulletin 1960-03-01"            (article, structured)
+      #   "OIML Bulletin LXVII(2) 20260211"     (article, citation)
+      class Bulletin < SingleIdentifier
+        # OIML Bulletin volume I was issued in 1960. Volume N corresponds to
+        # year (N + BASE_YEAR_OFFSET). Used to translate between the year
+        # carried in the structured form and the roman volume in citations.
+        BASE_YEAR_OFFSET = 1959
+
+        # Zero-padded issue number within the year ("01".."04", plus "07"/"10"
+        # for the online-bulletin series). Always 2 digits.
+        attribute :issue, :string
+        # Zero-padded sequence within the issue ("00" = editorial, "01"+ for
+        # articles). Always 2 digits.
+        attribute :sequence, :string
+
+        key_value do
+          map "issue", to: :issue
+          map "sequence", to: :sequence
+        end
+
+        def type_string
+          "Bulletin"
+        end
+
+        # Volume as an arabic string ("67"), derived from the year. nil when
+        # the year is absent (bare periodical reference).
+        def volume_arabic
+          return nil unless date&.year
+
+          (date.year.to_i - BASE_YEAR_OFFSET).to_s
+        end
+
+        # Volume as a roman-numeral string ("LXVII"), derived from the year.
+        # nil when the year is absent.
+        def volume_roman
+          number = volume_arabic&.to_i
+          return nil unless number&.positive?
+
+          self.class.to_roman(number)
+        end
+
+        # 8-digit oiml.org article id ("20260211"). Composed by concatenating
+        # year + issue + sequence. nil unless all three are present.
+        def article_id
+          return nil unless date&.year && issue && sequence
+
+          "#{date.year}#{issue}#{sequence}"
+        end
+
+        class << self
+          # Convert a positive integer to its roman-numeral representation.
+          # Used to render the citation form. The dataset already stores the
+          # roman volume verbatim in `extent.locality`, so this conversion is
+          # only needed when rendering from the structured form.
+          def to_roman(number)
+            raise ArgumentError, "volume must be > 0" unless number.positive?
+
+            ROMAN_TABLE.each_with_object(+"") do |(value, sym), result|
+              quotient, number = number.divmod(value)
+              result << (sym * quotient)
+            end.freeze
+          end
+
+          ROMAN_TABLE = [
+            [1000, "M"], [900, "CM"], [500, "D"], [400, "CD"],
+            [100, "C"], [90, "XC"], [50, "L"], [40, "XL"],
+            [10, "X"], [9, "IX"], [5, "V"], [4, "IV"],
+            [1, "I"]
+          ].freeze
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/oiml/parser.rb
+++ b/lib/pubid/oiml/parser.rb
@@ -20,7 +20,7 @@ module Pubid
       rule(:identifier) do
         amendment_identifier | amendment_short | annex_letter_identifier |
           annex_identifier | plus_supplement_identifier |
-          trailing_supplement_identifier | base_identifier
+          trailing_supplement_identifier | bulletin_identifier | base_identifier
       end
 
       # Publisher - always "OIML"
@@ -28,6 +28,48 @@ module Pubid
 
       # Document type - single letter
       rule(:doc_type) { match("[BDEGRSVX]").as(:type) >> space }
+
+      # Bulletin locator — structured form. Year optionally followed by
+      # 2-digit issue and 2-digit sequence:
+      #   "OIML Bulletin", "OIML Bulletin 1960",
+      #   "OIML Bulletin 1960-03", "OIML Bulletin 1960-03-01"
+      # All four shapes appear as primary docids in relaton-data-oiml.
+      rule(:bulletin_date) do
+        space >> year_digits.as(:year) >>
+          (dash >> two_digits.as(:issue)).maybe >>
+          (dash >> two_digits.as(:sequence)).maybe
+      end
+
+      # Two-digit zero-padded number (used for issue / sequence).
+      rule(:two_digits) { match('\d').repeat(2, 2) }
+
+      # Roman numeral token composed of I,V,X,L,C,D,M (uppercase, matching
+      # OIML's print convention). Consumed but not captured — the 8-digit
+      # article id in the same citation carries year/issue/sequence
+      # deterministically, so the roman volume is redundant for parsing.
+      rule(:roman_numeral) { match("[IVXLCDM]").repeat(1) }
+
+      # Bulletin locator — citation form. The format OIML prints on the
+      # article page is: "LXVII(2) 20260211" where LXVII is the volume in
+      # roman numerals, (2) is the issue in arabic without zero padding,
+      # and 20260211 is the 8-digit oiml.org article id (YYYYNNSS).
+      rule(:bulletin_citation) do
+        space >> roman_numeral >>
+          lparen >> digits.as(:issue_arabic) >> rparen >>
+          space >> match('\d').repeat(8, 8).as(:article_id)
+      end
+
+      # Bulletin identifier — no code; the locator (when present) is the
+      # (year, issue, sequence) tuple drawn from either the structured
+      # YYYY-II-SS form or the citation VOLUME(ISSUE) ARTID form. Both
+      # decode to the same record. Tried before base_identifier because
+      # "Bulletin" is a word that the single-letter doc_type rule cannot
+      # match.
+      rule(:bulletin_identifier) do
+        publisher >> str("Bulletin").as(:type) >>
+          (bulletin_citation | bulletin_date).maybe >>
+          language_portion.maybe.as(:language)
+      end
 
       # Number with optional part and subpart
       rule(:number_only) { digits.as(:number) }

--- a/lib/pubid/oiml/renderer.rb
+++ b/lib/pubid/oiml/renderer.rb
@@ -20,6 +20,8 @@ module Pubid
         case id
         when Identifiers::Annex
           render_annex(id)
+        when Identifiers::Bulletin
+          render_bulletin(id)
         when SupplementIdentifier
           render_supplement(id)
         when SingleIdentifier
@@ -30,6 +32,55 @@ module Pubid
       end
 
       private
+
+      # Render the Bulletin in the requested or parsed form. Default is the
+      # structured "YYYY-II-SS" form (the dataset's primary docid). The
+      # citation form ("LXVII(2) 20260211") is emitted when the user asks
+      # for it via `to_s(format: :citation)` or when the identifier was
+      # itself parsed from a citation string (parsed_format == "citation").
+      def render_bulletin(id)
+        if citation_form?(id)
+          render_bulletin_citation(id)
+        else
+          render_bulletin_structured(id)
+        end
+      end
+
+      # User's explicit format request takes precedence over the parsed
+      # form, so `parse("LXVII(2) 20260211").to_s(format: :short)` returns
+      # the structured form. With no explicit request, the parsed form is
+      # preserved for round-trip fidelity.
+      def citation_form?(id)
+        case id.requested_format
+        when :citation then true
+        when :short, :structured then false
+        else
+          id.parsed_format == "citation"
+        end
+      end
+
+      # "OIML Bulletin" / "OIML Bulletin 1960" / "OIML Bulletin 1960-03" /
+      # "OIML Bulletin 1960-03-01". No code; the locator is space-separated.
+      def render_bulletin_structured(id)
+        result = "#{id.publisher} Bulletin"
+        if id.date&.year
+          result += " #{id.date.year}"
+          result += "-#{id.issue}" if id.issue
+          result += "-#{id.sequence}" if id.sequence
+        end
+        result += " (#{id.language})" if id.language
+        result
+      end
+
+      # "OIML Bulletin LXVII(2) 20260211". Only emitted for full articles
+      # (year + issue + sequence all present); lower tiers fall back to
+      # structured since OIML's citation format doesn't define volume-only
+      # or issue-only variants.
+      def render_bulletin_citation(id)
+        return render_bulletin_structured(id) unless id.date&.year && id.issue && id.sequence
+
+        "#{id.publisher} Bulletin #{id.volume_roman}(#{id.issue.to_i}) #{id.article_id}"
+      end
 
       def effective_format(id)
         id.requested_format ||

--- a/lib/pubid/oiml/urn_generator.rb
+++ b/lib/pubid/oiml/urn_generator.rb
@@ -28,6 +28,17 @@ module Pubid
       end
 
       def generate
+        # Bulletin issues carry no code; the (year, issue, sequence) tuple
+        # is the locator. URNs are canonical regardless of how the input was
+        # formatted, so we always emit the structured YYYY-II-SS form even
+        # when the identifier was parsed from a citation string.
+        if identifier.is_a?(Identifiers::Bulletin)
+          parts = ["urn", "oiml", "bulletin"]
+          parts << bulletin_locator if identifier.date&.present?
+          parts << urn_language if urn_language
+          return parts.join(":")
+        end
+
         parts = ["urn", "oiml"]
         parts << urn_type
         parts << urn_number if urn_number
@@ -50,6 +61,17 @@ module Pubid
         end
 
         parts.join(":")
+      end
+
+      # Structured locator "YYYY-II-SS" (or "YYYY-II" / "YYYY") for a Bulletin.
+      # Built directly from the date year and the issue/sequence attributes so
+      # the URN is identical regardless of whether the input was the structured
+      # or citation form.
+      def bulletin_locator
+        locator = identifier.date.year.to_s
+        locator += "-#{identifier.issue}" if identifier.issue
+        locator += "-#{identifier.sequence}" if identifier.sequence
+        locator
       end
     end
   end

--- a/spec/pubid/oiml/parser_categories_spec.rb
+++ b/spec/pubid/oiml/parser_categories_spec.rb
@@ -126,4 +126,95 @@ RSpec.describe "Pubid::Oiml failing-docid categories" do
       end
     end
   end
+
+  context "Category 7 — OIML Bulletin issues" do
+    [
+      "OIML Bulletin",
+      "OIML Bulletin 1960",
+      "OIML Bulletin 1960-03",
+      "OIML Bulletin 1960-03-01",
+      "OIML Bulletin 2024",
+      "OIML Bulletin 2024-11",
+      "OIML Bulletin 2024-11-15",
+    ].each do |str|
+      it "round-trips #{str.inspect}" do
+        expect_round_trip(str)
+      end
+    end
+
+    it "builds a Bulletin identifier with no code" do
+      id = Pubid::Oiml.parse("OIML Bulletin 1960-03-01")
+      expect(id).to be_a(Pubid::Oiml::Identifiers::Bulletin)
+      expect(id.code).to be_nil
+      expect(id.type).to eq("Bulletin")
+      expect(id.date.year).to eq("1960")
+      expect(id.issue).to eq("03")
+      expect(id.sequence).to eq("01")
+    end
+
+    it "does not collapse a full Bulletin locator to year-only in URN output" do
+      id = Pubid::Oiml.parse("OIML Bulletin 1960-03-01")
+      expect(id.to_urn).to eq("urn:oiml:bulletin:1960-03-01")
+    end
+  end
+
+  # The citation format OIML prints on article pages, e.g.
+  #   "Citation: G. Ardimento 2026 OIML Bulletin LXVII(2) 20260211"
+  # where LXVII is the volume in roman numerals, (2) is the issue in arabic,
+  # and 20260211 is the 8-digit oiml.org article id (YYYYNNSS). The dataset
+  # already carries these three components in `series`, `extent`, and a
+  # secondary `OIML-bulletin-article-id` docidentifier — pubid-oiml only has
+  # to recognize the assembled citation string.
+  context "Category 8 — OIML Bulletin citation form" do
+    [
+      "OIML Bulletin LXVII(2) 20260211",
+      "OIML Bulletin LXVIII(1) 20270101",
+      "OIML Bulletin I(1) 19600101",
+    ].each do |str|
+      it "round-trips #{str.inspect}" do
+        expect_round_trip(str)
+      end
+    end
+
+    it "decodes the citation form to the same record as the structured form" do
+      citation   = Pubid::Oiml.parse("OIML Bulletin LXVII(2) 20260211")
+      structured = Pubid::Oiml.parse("OIML Bulletin 2026-02-11")
+
+      expect(citation.date.year).to eq(structured.date.year)
+      expect(citation.issue).to    eq(structured.issue)
+      expect(citation.sequence).to eq(structured.sequence)
+    end
+
+    it "derives roman volume and arabic article id from the structured form" do
+      id = Pubid::Oiml.parse("OIML Bulletin 2026-02-11")
+      expect(id.volume_arabic).to eq("67")
+      expect(id.volume_roman).to  eq("LXVII")
+      expect(id.article_id).to    eq("20260211")
+    end
+
+    it "renders the structured form as citation when requested" do
+      id = Pubid::Oiml.parse("OIML Bulletin 2026-02-11")
+      expect(id.to_s(format: :citation)).to eq("OIML Bulletin LXVII(2) 20260211")
+    end
+
+    it "renders the citation form as structured when requested" do
+      id = Pubid::Oiml.parse("OIML Bulletin LXVII(2) 20260211")
+      expect(id.to_s(format: :short)).to eq("OIML Bulletin 2026-02-11")
+    end
+
+    it "emits a canonical URN regardless of input form" do
+      citation   = Pubid::Oiml.parse("OIML Bulletin LXVII(2) 20260211")
+      structured = Pubid::Oiml.parse("OIML Bulletin 2026-02-11")
+      expect(citation.to_urn).to eq(structured.to_urn)
+      expect(citation.to_urn).to eq("urn:oiml:bulletin:2026-02-11")
+    end
+
+    it "does not emit the citation form for volume-only or issue-only records" do
+      # OIML's citation format is article-only; lower tiers fall back.
+      expect(Pubid::Oiml.parse("OIML Bulletin 2026").to_s(format: :citation))
+        .to eq("OIML Bulletin 2026")
+      expect(Pubid::Oiml.parse("OIML Bulletin 2026-02").to_s(format: :citation))
+        .to eq("OIML Bulletin 2026-02")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Removes the `branches: [ main, master ]` filter from the `pull_request:` trigger in `.github/workflows/rake.yml`.
- PRs targeting forward integration branches (`rt-new-lutaml-model`, feature branches) currently skip `bundle exec rake` entirely — only `downstream-test` runs, which catches integration breakage but misses unit-level regressions in pubid itself.
- Push-to-main/master and tag triggers are unchanged.

Spotted while investigating PR #96 (Bulletin), which targets `rt-new-lutaml-model` and only ran downstream jobs.

## Test plan

- [ ] Confirm the next PR targeting a non-main branch (e.g. #96) shows both `rake` and `downstream-test` in its checks.
