### PR TITLE
fix(iala): strip leading zeros from document numbers

### DIFF
--- a/lib/pubid.rb
+++ b/lib/pubid.rb
@@ -95,6 +95,7 @@ module Pubid
   autoload :Idf, "pubid/idf"
   autoload :Iec, "pubid/iec"
   autoload :Ieee, "pubid/ieee"
+  autoload :Iala, "pubid/iala"
   autoload :Iho, "pubid/iho"
   autoload :Iso, "pubid/iso"
   autoload :Itu, "pubid/itu"

--- a/lib/pubid/iala/builder.rb
+++ b/lib/pubid/iala/builder.rb
@@ -23,9 +23,14 @@ module Pubid
 
       private
 
-      # Compose "1070" or "0126-1" from doc_number + optional subpart.
+      # Compose "1070" or "126-1" from doc_number + optional subpart.
+      # Strips leading zeros from the base number per the IALA convention
+      # (M0001 → M1, R0101 → R101, C0103-1 → C103-1).
       def build_number(hash)
         base = stringify(hash[:doc_number])
+        return base unless base
+
+        base = base.sub(/\A0+(\d)/, '\1')
         return base unless hash[:subpart]
 
         subpart_str = subpart_to_s(hash[:subpart])

--- a/lib/pubid/iala/parser.rb
+++ b/lib/pubid/iala/parser.rb
@@ -35,9 +35,12 @@ module Pubid
          str("C") | str("X") | str("P")).as(:type_letter)
       end
 
-      # 4-digit document number, e.g. "1070", "0126".
+      # Document number — accepts the legacy 4-digit zero-padded form
+      # ("0103", "0001") and the unpadded form ("103", "1"). The renderer
+      # emits the unpadded form; the parser accepts both for back-compat
+      # with existing relaton-data-iala YAMLs and IALA cover pages.
       rule(:doc_number) do
-        match("[0-9]").repeat(4, 4).as(:doc_number)
+        match("[0-9]").repeat(1, 4).as(:doc_number)
       end
 
       # Numeric sub-part suffix(es): "-1", "-9-10", "-11". The catalogue

--- a/spec/pubid/iala/identifier_spec.rb
+++ b/spec/pubid/iala/identifier_spec.rb
@@ -9,12 +9,19 @@ RSpec.describe Pubid::Iala::Identifier do
       "S1070"                      => "IALA S1070",
       "S1070 Ed 2.0"               => "IALA S1070 Ed 2.0",
       "IALA S1070 Ed 2.0"          => "IALA S1070 Ed 2.0",
-      "R0126 Ed 2.0"               => "IALA R0126 Ed 2.0",
-      "R0126:ed2.0"                => "IALA R0126 Ed 2.0",
+      # Leading zeros are stripped on parse (M0001 → M1, R0126 → R126,
+      # C0103-1 → C103-1). The zero-padded form is accepted as input for
+      # back-compat with legacy YAMLs and IALA cover pages.
+      "R0126 Ed 2.0"               => "IALA R126 Ed 2.0",
+      "R126 Ed 2.0"                => "IALA R126 Ed 2.0",
+      "R0126:ed2.0"                => "IALA R126 Ed 2.0",
       "R1016:ed2.0(F)"             => "IALA R1016 Ed 2.0 (F)",
       "G1015 Ed 2.2"               => "IALA G1015 Ed 2.2",
-      "C0103-1 Ed 3.0"             => "IALA C0103-1 Ed 3.0",
-      "C0103-1"                    => "IALA C0103-1",
+      "C0103-1 Ed 3.0"             => "IALA C103-1 Ed 3.0",
+      "C103-1 Ed 3.0"              => "IALA C103-1 Ed 3.0",
+      "C0103-1"                    => "IALA C103-1",
+      "M0001 Ed 9.0"               => "IALA M1 Ed 9.0",
+      "M1 Ed 9.0"                  => "IALA M1 Ed 9.0",
       "S1070 Ed 2.0 (F)"           => "IALA S1070 Ed 2.0 (F)",
     }.each do |input, canonical|
       it "parses #{input.inspect} → #{canonical.inspect}" do
@@ -38,8 +45,9 @@ RSpec.describe Pubid::Iala::Identifier do
       expect(Pubid::Iala.parse("C0103-1")).to be_a(Pubid::Iala::Identifiers::ModelCourse)
     end
 
-    it "preserves the subpart verbatim in the number" do
-      expect(Pubid::Iala.parse("C0103-1").number).to eq("0103-1")
+    it "strips leading zeros from the base number" do
+      expect(Pubid::Iala.parse("C0103-1").number).to eq("103-1")
+      expect(Pubid::Iala.parse("M0001").number).to eq("1")
     end
 
     it "captures the language letter" do
@@ -57,7 +65,7 @@ RSpec.describe Pubid::Iala::Identifier do
       "S1070 Ed 2.0"       => "urn:mrn:iala:pub:s1070:ed2.0",
       "R1016 Ed 2.0"       => "urn:mrn:iala:pub:r1016:ed2.0",
       "R1016 Ed 2.0 (F)"   => "urn:mrn:iala:pub:r1016:ed2.0:f",
-      "C0103-1 Ed 3.0"     => "urn:mrn:iala:pub:c0103-1:ed3.0",
+      "C0103-1 Ed 3.0"     => "urn:mrn:iala:pub:c103-1:ed3.0",
     }.each do |input, urn|
       it "renders #{input.inspect} as #{urn.inspect}" do
         expect(Pubid::Iala.parse(input).to_urn).to eq(urn)
@@ -69,7 +77,7 @@ RSpec.describe Pubid::Iala::Identifier do
     %w[
       urn:mrn:iala:pub:s1070:ed2.0
       urn:mrn:iala:pub:r1016:ed2.0:f
-      urn:mrn:iala:pub:c0103-1:ed3.0
+      urn:mrn:iala:pub:c103-1:ed3.0
       urn:mrn:iala:pub:g1015
     ].each do |urn|
       it "round-trips #{urn.inspect} through the parser" do


### PR DESCRIPTION
Per the user's 2026-07-08 directive: codes display without zero-padding (M0001 → M1, R0101 → R101, C0103-1 → C103-1, GA01.13 → GA1.13).

Parser accepts both padded and unpadded forms for back-compat with legacy YAMLs and IALA cover pages; the builder normalises to unpadded on output.

## Test plan
- [x] 34 IALA specs pass (was 30; added 4 covering the normalisation + both input forms)
- [x] `Pubid::Iala.parse("M0001").to_s == "IALA M1"`
- [x] `Pubid::Iala.parse("M1").to_s == "IALA M1"`
- [x] Full pubid suite still green

Companion: relaton-data-iala data backfill (in flight).