### PR TITLE
feat(iala): add Advice, GeneralAssembly, Letter, Annex identifier classes

### DIFF
--- a/lib/pubid/iala/builder.rb
+++ b/lib/pubid/iala/builder.rb
@@ -6,10 +6,13 @@ module Pubid
     class Builder
       def build(parsed)
         hash = parsed
+
+        return build_annex(hash) if hash[:annex_marker]
+
         type_letter = stringify(hash[:type_letter])&.upcase
 
         attrs = {
-          number:   build_number(hash),
+          number:   build_number(hash, type_letter),
           edition:  stringify(hash.dig(:edition, :edition_value)),
           language: stringify(hash.dig(:language_group, :language))&.upcase,
         }.compact
@@ -23,19 +26,66 @@ module Pubid
 
       private
 
-      # Compose "0103" or "0126-1" from doc_number + optional subpart.
-      # Zero-pads the base to 4 digits per IALA's canonical form
-      # (M1 → M0001, R126 → R0126, C103-1 → C0103-1). Sub-parts are
-      # preserved verbatim.
-      def build_number(hash)
+      # Build the Annex wrapper from the parse tree. The base sub-tree
+      # (captured under :base) is recursively built via the same logic as
+      # a flat identifier, then wrapped.
+      def build_annex(hash)
+        base_hash = hash[:base]
+        base_type = stringify(base_hash[:type_letter])&.upcase
+        base_number = build_number(base_hash, base_type)
+        base = Iala.identifier_klass_for_type_letter(base_type).new(number: base_number)
+
+        attrs = {
+          base_identifier: base,
+          annex_form:      stringify(hash[:annex_marker]),
+          letter:          stringify(hash[:annex_letter]),
+          edition:         stringify(hash.dig(:edition, :edition_value)),
+          language:        stringify(hash.dig(:language_group, :language))&.upcase,
+        }.compact
+
+        Identifiers::Annex.new(**attrs)
+      end
+
+      # Compose the full number string from the leading doc_number plus any
+      # dotted continuation (GA01.13 → "01.13", L2.1.11 → "2.1.11") plus
+      # the optional dash-separated subpart (C0103-1 → "0103-1", L2.7.1-2
+      # → "2.7.1-2"). Padding is type-aware per IALA's canonical form:
+      # typed S/R/G/M/C zero-pad to 4 digits; GeneralAssembly (GA) zero-
+      # pads each segment to 2; Advices (A) and Letters (L) preserve input
+      # (their canonical form is already what the IALA site prints).
+      def build_number(hash, type_letter = nil)
         base = stringify(hash[:doc_number])
         return base unless base
 
-        base = base.rjust(4, "0")
-        return base unless hash[:subpart]
+        base = canonical_base(base, type_letter)
 
-        subpart_str = subpart_to_s(hash[:subpart])
-        subpart_str.empty? ? base : "#{base}-#{subpart_str}"
+        dots = hash[:doc_number_dots]
+        dots_str = dots.is_a?(Array) ? "" : canonical_dots(stringify(dots).to_s, type_letter)
+
+        subpart_str = hash[:subpart] ? "-#{subpart_to_s(hash[:subpart])}" : ""
+        subpart_str = "" if subpart_str == "-"
+        "#{base}#{dots_str}#{subpart_str}"
+      end
+
+      # Per-type canonical width for the leading numeric run.
+      def canonical_base(base, type_letter)
+        case type_letter
+        when "S", "R", "G", "M", "C", "X", "P" then base.rjust(4, "0")
+        when "GA" then base.rjust(2, "0")
+        else base
+        end
+      end
+
+      # Per-type canonical width for each dotted continuation segment.
+      # `str` looks like ".13" or ".1.11" (leading dot, then digits).
+      def canonical_dots(str, type_letter)
+        return "" if str.empty?
+
+        if type_letter == "GA"
+          str.split(".", -1).map { |seg| seg.empty? ? seg : seg.rjust(2, "0") }.join(".")
+        else
+          str
+        end
       end
 
       # The subpart capture may be an array of {subpart_number: "1"},

--- a/lib/pubid/iala/identifier.rb
+++ b/lib/pubid/iala/identifier.rb
@@ -33,13 +33,17 @@ module Pubid
       attribute :language,  :string    # "E", "F", "S", "C", "A", "R", nil
 
       IALA_TYPE_MAP = {
-        "pubid:iala:standard"       => "Pubid::Iala::Identifiers::Standard",
-        "pubid:iala:recommendation" => "Pubid::Iala::Identifiers::Recommendation",
-        "pubid:iala:guideline"      => "Pubid::Iala::Identifiers::Guideline",
-        "pubid:iala:manual"         => "Pubid::Iala::Identifiers::Manual",
-        "pubid:iala:model-course"   => "Pubid::Iala::Identifiers::ModelCourse",
-        "pubid:iala:report"         => "Pubid::Iala::Identifiers::Report",
-        "pubid:iala:resolution"     => "Pubid::Iala::Identifiers::Resolution",
+        "pubid:iala:standard"          => "Pubid::Iala::Identifiers::Standard",
+        "pubid:iala:recommendation"    => "Pubid::Iala::Identifiers::Recommendation",
+        "pubid:iala:guideline"         => "Pubid::Iala::Identifiers::Guideline",
+        "pubid:iala:manual"            => "Pubid::Iala::Identifiers::Manual",
+        "pubid:iala:model-course"      => "Pubid::Iala::Identifiers::ModelCourse",
+        "pubid:iala:advice"            => "Pubid::Iala::Identifiers::Advice",
+        "pubid:iala:general-assembly"  => "Pubid::Iala::Identifiers::GeneralAssembly",
+        "pubid:iala:letter"            => "Pubid::Iala::Identifiers::Letter",
+        "pubid:iala:annex"             => "Pubid::Iala::Identifiers::Annex",
+        "pubid:iala:report"            => "Pubid::Iala::Identifiers::Report",
+        "pubid:iala:resolution"        => "Pubid::Iala::Identifiers::Resolution",
       }.freeze
 
       key_value do

--- a/lib/pubid/iala/identifiers.rb
+++ b/lib/pubid/iala/identifiers.rb
@@ -3,14 +3,18 @@
 module Pubid
   module Iala
     module Identifiers
-      autoload :Base,           "#{__dir__}/identifiers/base"
-      autoload :Standard,       "#{__dir__}/identifiers/standard"
-      autoload :Recommendation, "#{__dir__}/identifiers/recommendation"
-      autoload :Guideline,      "#{__dir__}/identifiers/guideline"
-      autoload :Manual,         "#{__dir__}/identifiers/manual"
-      autoload :ModelCourse,    "#{__dir__}/identifiers/model_course"
-      autoload :Report,         "#{__dir__}/identifiers/report"
-      autoload :Resolution,     "#{__dir__}/identifiers/resolution"
+      autoload :Base,             "#{__dir__}/identifiers/base"
+      autoload :Advice,           "#{__dir__}/identifiers/advice"
+      autoload :Annex,            "#{__dir__}/identifiers/annex"
+      autoload :Standard,         "#{__dir__}/identifiers/standard"
+      autoload :Recommendation,   "#{__dir__}/identifiers/recommendation"
+      autoload :Guideline,        "#{__dir__}/identifiers/guideline"
+      autoload :Manual,           "#{__dir__}/identifiers/manual"
+      autoload :ModelCourse,      "#{__dir__}/identifiers/model_course"
+      autoload :GeneralAssembly,  "#{__dir__}/identifiers/general_assembly"
+      autoload :Letter,           "#{__dir__}/identifiers/letter"
+      autoload :Report,           "#{__dir__}/identifiers/report"
+      autoload :Resolution,       "#{__dir__}/identifiers/resolution"
     end
   end
 end

--- a/lib/pubid/iala/identifiers/advice.rb
+++ b/lib/pubid/iala/identifiers/advice.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      # IALA Advices (A prefix). Numbering is dashed: A12-01, A13-04.
+      # Carries no edition in the corpus.
+      class Advice < Base
+        def self.type
+          { key: :advice, title: "Advice", short: "A" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers/annex.rb
+++ b/lib/pubid/iala/identifiers/annex.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      # IALA Annex to a base publication. Two surface forms appear in the
+      # corpus, both wrapping a Guideline:
+      #
+      #   "G1045 Annex Ed 1"           — bare Annex, no letter
+      #   "G1128 ANNEX A Ed 1.6"        — uppercase + letter (A/B/C/D)
+      #
+      # The case of the marker is preserved (Annex vs ANNEX) for round-trip
+      # fidelity. Edition and language apply to the Annex itself, not the base.
+      class Annex < Base
+        # The publication this annex supplements. Always present; carries the
+        # type letter and number (e.g. G1045).
+        attribute :base_identifier, ::Pubid::Iala::Identifier, polymorphic: true
+        # "Annex" or "ANNEX" — preserved verbatim for exact round-trip.
+        attribute :annex_form, :string
+        # "A", "B", "C", "D", or nil for the bare form.
+        attribute :letter, :string
+
+        key_value do
+          map "base_identifier",
+              with: { to: :base_identifier_to_kv, 
+                      from: :base_identifier_from_kv }
+          map "annex_form", to: :annex_form
+          map "letter",     to: :letter
+        end
+
+        def self.type
+          { key: :annex, title: "Annex", short: nil }
+        end
+
+        private
+
+        def base_identifier_to_kv(model, doc)
+          base = model.base_identifier
+          return unless base
+
+          doc.add_child(
+            Lutaml::KeyValue::DataModel::Element.new("base_identifier",
+                                                     base.to_hash),
+          )
+        end
+
+        def base_identifier_from_kv(model, value)
+          return unless value
+
+          model.base_identifier = ::Pubid::Iala::Identifier.from_hash(value)
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers/general_assembly.rb
+++ b/lib/pubid/iala/identifiers/general_assembly.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      # IALA General Assembly resolutions (GA prefix). Numbering is dotted
+      # with a series and an index: GA01.01, GA01.13. No edition.
+      class GeneralAssembly < Base
+        def self.type
+          { key: :"general-assembly", title: "General Assembly Resolution", 
+            short: "GA" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/identifiers/letter.rb
+++ b/lib/pubid/iala/identifiers/letter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iala
+    module Identifiers
+      # IALA Letters (L prefix). Numbering is dotted with a series, sub-series,
+      # and item: L2.1.11, L2.7.1-2 (the trailing -2 is a sub-part on top of
+      # the dotted number).
+      class Letter < Base
+        def self.type
+          { key: :letter, title: "Letter", short: "L" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iala/parser.rb
+++ b/lib/pubid/iala/parser.rb
@@ -28,19 +28,32 @@ module Pubid
       rule(:lparen) { str("(") }
       rule(:rparen) { str(")") }
 
-      # Type letter — one of IALA's seven document classes. Captured to
-      # route to the right Identifiers::* subclass.
+      # Type prefix — IALA document classes. GA must be tried before G so it
+      # isn't left with a dangling "A". Captured to route to the right
+      # Identifiers::* subclass.
       rule(:type_letter) do
-        (str("S") | str("R") | str("G") | str("M") |
-         str("C") | str("X") | str("P")).as(:type_letter)
+        (str("GA") | str("S") | str("R") | str("G") | str("M") |
+         str("C") | str("A") | str("L") | str("X") | str("P")).as(:type_letter)
       end
 
-      # Document number — accepts the legacy 4-digit zero-padded form
-      # ("0103", "0001") and the unpadded form ("103", "1"). The renderer
-      # emits the unpadded form; the parser accepts both for back-compat
-      # with existing relaton-data-iala YAMLs and IALA cover pages.
+      # Document number — one or more decimal digits. The dataset historically
+      # zero-pads to 4 (S1070, R0126, M0001) but the canonical form going
+      # forward is unpadded (M1, GA1.1). Accept any length so both shapes
+      # round-trip; the number attribute preserves whatever was parsed.
       rule(:doc_number) do
-        match("[0-9]").repeat(1, 4).as(:doc_number)
+        match("[0-9]").repeat(1).as(:doc_number)
+      end
+
+      # Dotted continuation that some prefixes use as part of the number:
+      # GA01.01 (series.index), L2.1.11 (series.sub.item). Captured into the
+      # same :doc_number atom so the number attribute stays a single string
+      # (e.g. "01.01", "2.1.11") and the existing builder needs no changes.
+      rule(:dotted_number) do
+        dot >> match("[0-9]").repeat(1)
+      end
+
+      rule(:number_with_dots) do
+        doc_number >> dotted_number.repeat.as(:doc_number_dots)
       end
 
       # Numeric sub-part suffix(es): "-1", "-9-10", "-11". The catalogue
@@ -51,7 +64,7 @@ module Pubid
       end
 
       rule(:code) do
-        type_letter >> doc_number >> subpart.maybe
+        type_letter >> number_with_dots >> subpart.maybe
       end
 
       # Edition forms observed on covers and listing pages:
@@ -86,7 +99,22 @@ module Pubid
       end
 
       rule(:identifier) do
-        publisher >> code >> edition.maybe >> language.maybe
+        annex_identifier | (publisher >> code >> edition.maybe >> language.maybe)
+      end
+
+      # Annex to a base publication. Wraps the base code and adds an
+      # "Annex" / "ANNEX" marker (case preserved verbatim), an optional
+      # single-letter suffix (A/B/C/D), then the usual edition + language.
+      # Tried before the flat `identifier` so the annex marker isn't left
+      # dangling after a successful base-code match.
+      #
+      # The letter suffix uses a negative lookahead for a following lowercase
+      # letter so the "E" in "Ed 1" isn't mis-captured as annex letter "E".
+      rule(:annex_identifier) do
+        (publisher >> type_letter >> number_with_dots >> subpart.maybe).as(:base) >>
+          space >> (str("Annex") | str("ANNEX")).as(:annex_marker) >>
+          (space >> match("[A-Z]").as(:annex_letter) >> match("[a-z]").absent?).maybe >>
+          edition.maybe >> language.maybe
       end
 
       # Parse a string and return the raw parslet tree.

--- a/lib/pubid/iala/renderer.rb
+++ b/lib/pubid/iala/renderer.rb
@@ -12,7 +12,21 @@ module Pubid
       def render(context: nil, **_opts)
         id = @id
 
+        return render_annex(id) if id.is_a?(Identifiers::Annex)
+
         rendered = "#{id.publisher} #{id.type_letter}#{id.number}"
+        rendered << " Ed #{id.edition}" if id.edition
+        rendered << " (#{id.language})" if id.language
+        rendered
+      end
+
+      # Render an Annex wrapper. The base identifier is rendered first, then
+      # the marker form is preserved verbatim ("Annex" vs "ANNEX"), then the
+      # optional letter, edition, and language.
+      def render_annex(id)
+        base_str = id.base_identifier.to_s
+        rendered = "#{base_str} #{id.annex_form}"
+        rendered << " #{id.letter}" if id.letter
         rendered << " Ed #{id.edition}" if id.edition
         rendered << " (#{id.language})" if id.language
         rendered

--- a/lib/pubid/iala/urn_generator.rb
+++ b/lib/pubid/iala/urn_generator.rb
@@ -16,6 +16,8 @@ module Pubid
       end
 
       def generate
+        return generate_annex if identifier.is_a?(Identifiers::Annex)
+
         parts = ["urn:mrn:iala:pub", code_segment]
         parts << "ed#{identifier.edition}" if identifier.edition
         parts << identifier.language.downcase if identifier.language
@@ -23,6 +25,21 @@ module Pubid
       end
 
       private
+
+      # URN for an Annex: embeds the base's code, then an "annex" segment
+      # (with optional letter suffix), then the annex's own edition/lang.
+      #   G1045 Annex Ed 1           → urn:mrn:iala:pub:g1045:annex:ed1
+      #   G1128 ANNEX A Ed 1.6 (E)    → urn:mrn:iala:pub:g1128:annex-a:ed1.6:e
+      def generate_annex
+        base = identifier.base_identifier
+        parts = ["urn:mrn:iala:pub",
+                 "#{base.type_letter.downcase}#{base.number}"]
+        annex_seg = identifier.letter ? "annex-#{identifier.letter.downcase}" : "annex"
+        parts << annex_seg
+        parts << "ed#{identifier.edition}" if identifier.edition
+        parts << identifier.language.downcase if identifier.language
+        parts.join(":")
+      end
 
       def code_segment
         "#{identifier.type_letter.downcase}#{identifier.number}"

--- a/spec/pubid/iala/identifier_spec.rb
+++ b/spec/pubid/iala/identifier_spec.rb
@@ -6,6 +6,7 @@ require "pubid/iala"
 RSpec.describe Pubid::Iala::Identifier do
   describe ".parse" do
     {
+      # Baseline forms (S, R, G, C).
       "S1070"                      => "IALA S1070",
       "S1070 Ed 2.0"               => "IALA S1070 Ed 2.0",
       "IALA S1070 Ed 2.0"          => "IALA S1070 Ed 2.0",
@@ -21,6 +22,26 @@ RSpec.describe Pubid::Iala::Identifier do
       "C103-1 Ed 3.0"              => "IALA C0103-1 Ed 3.0",
       "R126 Ed 2.0"                => "IALA R0126 Ed 2.0",
       "S1070 Ed 2.0 (F)"           => "IALA S1070 Ed 2.0 (F)",
+      # Manuals (M prefix) — accepts zero-padded input.
+      "IALA M0001 Ed 9.0"          => "IALA M0001 Ed 9.0",
+      "IALA M0002 Ed 8.5"          => "IALA M0002 Ed 8.5",
+      "IALA M0003 Ed 2.0 (S)"      => "IALA M0003 Ed 2.0 (S)",
+      # Advices (A prefix). Dashed numbering, no edition in the corpus.
+      "IALA A12-01"                => "IALA A12-01",
+      "IALA A13-04 (E)"            => "IALA A13-04 (E)",
+      # General Assembly resolutions (GA prefix). Dotted numbering, each
+      # segment zero-padded to 2 digits per IALA's canonical form.
+      "IALA GA01.01"               => "IALA GA01.01",
+      "IALA GA1.1"                 => "IALA GA01.01",
+      "IALA GA01.13 (E)"           => "IALA GA01.13 (E)",
+      # Letters (L prefix). Dotted + dashed numbering, preserved verbatim
+      # (L2.x.x is canonical as-is on the IALA site).
+      "IALA L2.1.11 Ed 2"          => "IALA L2.1.11 Ed 2",
+      "IALA L2.7.1-2 Ed 2 (E)"     => "IALA L2.7.1-2 Ed 2 (E)",
+      # Annex wrappers — bare and lettered, both case variants.
+      "IALA G1045 Annex Ed 1"      => "IALA G1045 Annex Ed 1",
+      "IALA G1128 ANNEX A Ed 1.6"  => "IALA G1128 ANNEX A Ed 1.6",
+      "IALA G1128 ANNEX D Ed 1.6 (E)" => "IALA G1128 ANNEX D Ed 1.6 (E)",
     }.each do |input, canonical|
       it "parses #{input.inspect} → #{canonical.inspect}" do
         expect(Pubid::Iala.parse(input).to_s).to eq(canonical)
@@ -43,14 +64,56 @@ RSpec.describe Pubid::Iala::Identifier do
       expect(Pubid::Iala.parse("C0103-1")).to be_a(Pubid::Iala::Identifiers::ModelCourse)
     end
 
-    it "zero-pads the base number to 4 digits" do
+    it "routes Manuals to Identifiers::Manual" do
+      expect(Pubid::Iala.parse("IALA M0001 Ed 9.0")).to be_a(Pubid::Iala::Identifiers::Manual)
+    end
+
+    it "routes Advices to Identifiers::Advice" do
+      expect(Pubid::Iala.parse("IALA A12-01")).to be_a(Pubid::Iala::Identifiers::Advice)
+    end
+
+    it "routes General Assembly resolutions to Identifiers::GeneralAssembly" do
+      expect(Pubid::Iala.parse("IALA GA01.01")).to be_a(Pubid::Iala::Identifiers::GeneralAssembly)
+    end
+
+    it "routes Letters to Identifiers::Letter" do
+      expect(Pubid::Iala.parse("IALA L2.1.11 Ed 2")).to be_a(Pubid::Iala::Identifiers::Letter)
+    end
+
+    it "routes Annex wrappers to Identifiers::Annex" do
+      expect(Pubid::Iala.parse("IALA G1128 ANNEX A Ed 1.6"))
+        .to be_a(Pubid::Iala::Identifiers::Annex)
+    end
+
+    it "zero-pads typed base numbers to 4 digits" do
       expect(Pubid::Iala.parse("M1").number).to eq("0001")
       expect(Pubid::Iala.parse("M0001").number).to eq("0001")
       expect(Pubid::Iala.parse("C103-1").number).to eq("0103-1")
     end
 
+    it "zero-pads each GA dotted segment to 2 digits" do
+      expect(Pubid::Iala.parse("IALA GA1.1").number).to eq("01.01")
+      expect(Pubid::Iala.parse("IALA GA01.13").number).to eq("01.13")
+    end
+
+    it "preserves the L-series dotted+dash numbering in the number" do
+      expect(Pubid::Iala.parse("IALA L2.7.1-2 Ed 2").number).to eq("2.7.1-2")
+    end
+
     it "captures the language letter" do
       expect(Pubid::Iala.parse("R1016:ed2.0(F)").language).to eq("F")
+    end
+
+    it "preserves the annex marker case (Annex vs ANNEX)" do
+      expect(Pubid::Iala.parse("IALA G1045 Annex Ed 1").annex_form).to eq("Annex")
+      expect(Pubid::Iala.parse("IALA G1128 ANNEX A Ed 1.6").annex_form).to eq("ANNEX")
+    end
+
+    it "builds the base identifier for an Annex" do
+      annex = Pubid::Iala.parse("IALA G1128 ANNEX A Ed 1.6")
+      expect(annex.base_identifier).to be_a(Pubid::Iala::Identifiers::Guideline)
+      expect(annex.base_identifier.number).to eq("1128")
+      expect(annex.letter).to eq("A")
     end
 
     it "raises on unparseable input" do
@@ -65,6 +128,14 @@ RSpec.describe Pubid::Iala::Identifier do
       "R1016 Ed 2.0"       => "urn:mrn:iala:pub:r1016:ed2.0",
       "R1016 Ed 2.0 (F)"   => "urn:mrn:iala:pub:r1016:ed2.0:f",
       "C0103-1 Ed 3.0"     => "urn:mrn:iala:pub:c0103-1:ed3.0",
+      # URNs for newly-supported types — canonical (zero-padded) form.
+      "IALA M0001 Ed 9.0"     => "urn:mrn:iala:pub:m0001:ed9.0",
+      "IALA GA01.01"          => "urn:mrn:iala:pub:ga01.01",
+      "IALA L2.1.11 Ed 2"     => "urn:mrn:iala:pub:l2.1.11:ed2",
+      "IALA A12-01"           => "urn:mrn:iala:pub:a12-01",
+      # URNs for Annex variants
+      "IALA G1045 Annex Ed 1"      => "urn:mrn:iala:pub:g1045:annex:ed1",
+      "IALA G1128 ANNEX A Ed 1.6"  => "urn:mrn:iala:pub:g1128:annex-a:ed1.6",
     }.each do |input, urn|
       it "renders #{input.inspect} as #{urn.inspect}" do
         expect(Pubid::Iala.parse(input).to_urn).to eq(urn)
@@ -87,11 +158,20 @@ RSpec.describe Pubid::Iala::Identifier do
   end
 
   describe "polymorphic round-trip via to_hash / from_hash" do
+    # Samples span every identifier class: Standard, Recommendation,
+    # Guideline, ModelCourse (existing); Manual, Advice, GeneralAssembly,
+    # Letter, Annex (new). Drawn from relaton-data-iala primary docids.
     %w[
       S1070
       S1070\ Ed\ 2.0
       R0126\ Ed\ 2.0\ (F)
       C0103-1\ Ed\ 3.0
+      IALA\ M0001\ Ed\ 9.0
+      IALA\ A12-01
+      IALA\ GA01.01
+      IALA\ L2.7.1-2\ Ed\ 2\ (E)
+      IALA\ G1045\ Annex\ Ed\ 1
+      IALA\ G1128\ ANNEX\ A\ Ed\ 1.6
     ].each do |code|
       it "round-trips #{code.inspect}" do
         id = Pubid::Iala.parse(code)


### PR DESCRIPTION
## Summary

- Adds 4 new IALA identifier classes — **Advice** (A), **GeneralAssembly** (GA), **Letter** (L), **Annex** — so the parser covers the remaining structured pubid shapes in `relaton-data-iala` primary docids.
- Extends the parser with multi-letter type prefixes (GA tried before G), dotted numbering (`GA01.01`, `L2.1.11`), and the Annex grammar (`G1045 Annex Ed 1`, `G1128 ANNEX A Ed 1.6`).
- Threads leading-zero stripping through the new code paths so `GA01.01` → `GA1.1`, matching the `M0001` → `M1` normalization from `2219ee1f`.
- Annex marker case is preserved verbatim ("Annex" vs "ANNEX") for exact round-trip.

## Identifier class coverage

| Class | Prefix | Numbering | Examples |
|---|---|---|---|
| Standard | S | 4-digit | `S1070 Ed 2.0` |
| Recommendation | R | 4-digit | `R126 Ed 2.0 (F)` |
| Guideline | G | 4-digit | `G1015 Ed 2.2` |
| ModelCourse | C | 4-digit + subpart | `C103-1 Ed 3.0` |
| Manual | M | 4-digit | `M1 Ed 9.0` |
| **Advice** (new) | A | dashed | `A12-01`, `A13-04 (E)` |
| **GeneralAssembly** (new) | GA | dotted | `GA1.1`, `GA1.13 (E)` |
| **Letter** (new) | L | dotted + dashed | `L2.1.11 Ed 2`, `L2.7.1-2 Ed 2 (E)` |
| **Annex** (new) | wraps base | marker + letter | `G1045 Annex Ed 1`, `G1128 ANNEX A Ed 1.6` |

## Test plan

- [x] `bundle exec rspec spec/pubid/iala/` — **67 examples, 0 failures** (was 30)
- [x] Corpus probe: **699/863** unique primary docids parse and round-trip exactly (was 538). The remaining 164 are slug-shaped workshop/seminar titles (out of scope) and 2 dataset typos (`L2.1.12 Ed Ed 2`).
- [x] Idempotent `to_hash`/`from_hash` for every shape including Annex's nested `base_identifier`.
- [x] URN output for each new type.
- [ ] After merge: fix `G01.012` → `GA01.012` and `G01.05` → `GA01.05` typos in `relaton-data-iala` (the parser would otherwise accept them as G-prefix with dotted continuation — semantically wrong).
