### PR TITLE
fix(iala): zero-pad base number to 4 digits (canonical IALA form)

### DIFF
--- a/lib/pubid/iala/builder.rb
+++ b/lib/pubid/iala/builder.rb
@@ -23,14 +23,15 @@ module Pubid
 
       private
 
-      # Compose "1070" or "126-1" from doc_number + optional subpart.
-      # Strips leading zeros from the base number per the IALA convention
-      # (M0001 → M1, R0101 → R101, C0103-1 → C103-1).
+      # Compose "0103" or "0126-1" from doc_number + optional subpart.
+      # Zero-pads the base to 4 digits per IALA's canonical form
+      # (M1 → M0001, R126 → R0126, C103-1 → C0103-1). Sub-parts are
+      # preserved verbatim.
       def build_number(hash)
         base = stringify(hash[:doc_number])
         return base unless base
 
-        base = base.sub(/\A0+(\d)/, '\1')
+        base = base.rjust(4, "0")
         return base unless hash[:subpart]
 
         subpart_str = subpart_to_s(hash[:subpart])

--- a/spec/pubid/iala/identifier_spec.rb
+++ b/spec/pubid/iala/identifier_spec.rb
@@ -9,19 +9,17 @@ RSpec.describe Pubid::Iala::Identifier do
       "S1070"                      => "IALA S1070",
       "S1070 Ed 2.0"               => "IALA S1070 Ed 2.0",
       "IALA S1070 Ed 2.0"          => "IALA S1070 Ed 2.0",
-      # Leading zeros are stripped on parse (M0001 → M1, R0126 → R126,
-      # C0103-1 → C103-1). The zero-padded form is accepted as input for
-      # back-compat with legacy YAMLs and IALA cover pages.
-      "R0126 Ed 2.0"               => "IALA R126 Ed 2.0",
-      "R126 Ed 2.0"                => "IALA R126 Ed 2.0",
-      "R0126:ed2.0"                => "IALA R126 Ed 2.0",
+      "R0126 Ed 2.0"               => "IALA R0126 Ed 2.0",
+      "R0126:ed2.0"                => "IALA R0126 Ed 2.0",
       "R1016:ed2.0(F)"             => "IALA R1016 Ed 2.0 (F)",
       "G1015 Ed 2.2"               => "IALA G1015 Ed 2.2",
-      "C0103-1 Ed 3.0"             => "IALA C103-1 Ed 3.0",
-      "C103-1 Ed 3.0"              => "IALA C103-1 Ed 3.0",
-      "C0103-1"                    => "IALA C103-1",
-      "M0001 Ed 9.0"               => "IALA M1 Ed 9.0",
-      "M1 Ed 9.0"                  => "IALA M1 Ed 9.0",
+      "C0103-1 Ed 3.0"             => "IALA C0103-1 Ed 3.0",
+      "C0103-1"                    => "IALA C0103-1",
+      # Short inputs are zero-padded to 4 digits (canonical IALA form).
+      "M1 Ed 9.0"                  => "IALA M0001 Ed 9.0",
+      "M0001 Ed 9.0"               => "IALA M0001 Ed 9.0",
+      "C103-1 Ed 3.0"              => "IALA C0103-1 Ed 3.0",
+      "R126 Ed 2.0"                => "IALA R0126 Ed 2.0",
       "S1070 Ed 2.0 (F)"           => "IALA S1070 Ed 2.0 (F)",
     }.each do |input, canonical|
       it "parses #{input.inspect} → #{canonical.inspect}" do
@@ -45,9 +43,10 @@ RSpec.describe Pubid::Iala::Identifier do
       expect(Pubid::Iala.parse("C0103-1")).to be_a(Pubid::Iala::Identifiers::ModelCourse)
     end
 
-    it "strips leading zeros from the base number" do
-      expect(Pubid::Iala.parse("C0103-1").number).to eq("103-1")
-      expect(Pubid::Iala.parse("M0001").number).to eq("1")
+    it "zero-pads the base number to 4 digits" do
+      expect(Pubid::Iala.parse("M1").number).to eq("0001")
+      expect(Pubid::Iala.parse("M0001").number).to eq("0001")
+      expect(Pubid::Iala.parse("C103-1").number).to eq("0103-1")
     end
 
     it "captures the language letter" do
@@ -65,7 +64,7 @@ RSpec.describe Pubid::Iala::Identifier do
       "S1070 Ed 2.0"       => "urn:mrn:iala:pub:s1070:ed2.0",
       "R1016 Ed 2.0"       => "urn:mrn:iala:pub:r1016:ed2.0",
       "R1016 Ed 2.0 (F)"   => "urn:mrn:iala:pub:r1016:ed2.0:f",
-      "C0103-1 Ed 3.0"     => "urn:mrn:iala:pub:c103-1:ed3.0",
+      "C0103-1 Ed 3.0"     => "urn:mrn:iala:pub:c0103-1:ed3.0",
     }.each do |input, urn|
       it "renders #{input.inspect} as #{urn.inspect}" do
         expect(Pubid::Iala.parse(input).to_urn).to eq(urn)
@@ -77,7 +76,7 @@ RSpec.describe Pubid::Iala::Identifier do
     %w[
       urn:mrn:iala:pub:s1070:ed2.0
       urn:mrn:iala:pub:r1016:ed2.0:f
-      urn:mrn:iala:pub:c103-1:ed3.0
+      urn:mrn:iala:pub:c0103-1:ed3.0
       urn:mrn:iala:pub:g1015
     ].each do |urn|
       it "round-trips #{urn.inspect} through the parser" do


### PR DESCRIPTION
Reverts the leading-zero stripping from PR #98. The canonical IALA form is 4-digit zero-padded (M0001, R0101, C0103-1, GA01.13). The previous change normalised these to M1, R101, C103-1, GA1.13 — that was wrong per the user's 2026-07-08 correction.

Parser still accepts the short form for back-compat; builder zero-pads on output.

## Test plan
- [x] 34 IALA specs pass
- [x] `Pubid::Iala.parse("M1").to_s == "IALA M0001"`
- [x] `Pubid::Iala.parse("M0001").to_s == "IALA M0001"`

Companion: relaton-data-iala revert in flight.