### PR TITLE
test(iso): pin ISO/R roman-letter alphabetic part parsing (#56 behavior)

### DIFF
--- a/spec/pubid/iso/identifiers/recommendation_spec.rb
+++ b/spec/pubid/iso/identifiers/recommendation_spec.rb
@@ -67,6 +67,42 @@ RSpec.describe Pubid::Iso::Identifiers::Recommendation do
         expect(parsed.to_urn).to eq(urn)
       end
     end
+
+    # Legacy ISO Recommendations can carry an *alphabetic* part code whose
+    # first letter is a Roman numeral (C, D, I, L, M, V, X) followed by a
+    # non-Roman letter, e.g. "CS". Such a part must stay an alphabetic code
+    # ("CS"), NOT be misread as a Roman-numeral part — the guard that
+    # pubid 1.x added in #56 (fixing ~50 ISO Open Data deliverables).
+    # Pinned here so the behaviour survives the pubid 2.x rewrite.
+    describe "ISO/R 194-CS:1964 (alphabetic part, Roman first letter)" do
+      subject { "ISO/R 194-CS:1964" }
+
+      let(:parsed) { Pubid::Iso.parse(subject) }
+
+      it "parses publisher" do
+        expect(parsed.publisher.publisher).to eq("ISO")
+      end
+
+      it "parses number" do
+        expect(parsed.number.value).to eq("194")
+      end
+
+      it "keeps the alphabetic part code (not folded to a Roman numeral)" do
+        expect(parsed.part.value).to eq("CS")
+      end
+
+      it "parses date" do
+        expect(parsed.date.year).to eq("1964")
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq(subject)
+      end
+
+      it "provides type code" do
+        expect(parsed.typed_stage.type_code).to eq("rec")
+      end
+    end
   end
 
   # Test normal undated recommendation


### PR DESCRIPTION
## What

Adds a regression spec pinning how v2 parses a legacy ISO Recommendation whose **alphabetic part code begins with a Roman-numeral letter** — e.g. `ISO/R 194-CS:1964`. The part must stay the literal `"CS"`, not be folded into a Roman-numeral part.

Test-only — **no production code changes**. v2 already parses this correctly via the general part path; this just locks the behavior in.

## Why (issue #95 context)

Investigating #95 (transitioning v2 `rt-new-lutaml-model` to become `main`, and `main`→`v1`), I audited the 12 substantive fixes that landed on v1 *after* v2 forked, to make sure none are lost in the rename. **11 are already reimplemented in v2 with spec coverage.** The 12th — pubid 1.x's #56 `part_matcher` guard for Roman-letter-leading alphabetic ISO/R parts — was flagged by static analysis as possibly missing, but an empirical parse showed v2 handles it correctly:

```
ISO/R 194-CS:1964 → publisher ISO, number 194, part "CS", date 1964, round-trips
```

The only actual gap was **test coverage** (v1 held the only test for it, in a file layout that goes away when v1 is archived). This PR ports that safety net to v2.

## Test

- New group: 6 examples, 0 failures
- Full ISO suite: 3066 examples, 0 failures
- `bundle exec rake` (default): 7326 examples, 0 failures, 1 pending; integration 184, 0 failures
- Rubocop on the changed file: no new offenses

Refs #95, #56