### PR TITLE
feat(nist): add RB, CHIPS, and NWIRP series

### DIFF
--- a/lib/pubid/nist.rb
+++ b/lib/pubid/nist.rb
@@ -13,6 +13,7 @@ module Pubid
       NIST NBS
       AMS VTS BSS BMS BH FIPS GCR HB MONO MP NCSTAR NSRDS IR SP TN CSWP
       AI CIRC CS CSM CRPL LCIRC OWMWP PC RPT SIBS TIBM TTB EAB JPCRD JRES
+      CHIPS NWIRP RB
     ].freeze
 
     autoload :Builder, "#{__dir__}/nist/builder"

--- a/lib/pubid/nist/parser.rb
+++ b/lib/pubid/nist/parser.rb
@@ -116,7 +116,9 @@ module Pubid
           str("AI") | str("CIRC") | str("CS") | str("CSM") |
           str("CRPL") | str("LCIRC") | str("OWMWP") | str("PC") | str("RPT") |
           str("SIBS") | str("TIBM") | str("TTB") | str("EAB") |
-          str("JPCRD") | str("JRES")
+          str("JPCRD") | str("JRES") |
+          # NEW - CHIPS Act, NWIRP, and Research Brief series
+          str("CHIPS") | str("NWIRP") | str("RB")
         ).as(:series)
       end
 

--- a/lib/pubid/nist/router.rb
+++ b/lib/pubid/nist/router.rb
@@ -18,6 +18,7 @@ module Pubid
         "GCR", "AMS", "BSS", "BMS", "BH", "MONO", "MP",
         "NCSTAR", "NSRDS", "CSWP", "VTS", "AI", "OWMWP",
         "PC", "RPT", "SIBS", "TIBM", "TTB", "EAB",
+        "CHIPS", "NWIRP", "RB",
         "JPCRD", "JRES", "CIS", "HR", "IRPL", "IP",
         "LC", "PS", "LCIRC",
         # Compound series

--- a/spec/fixtures/nist/identifiers/pass/chips.txt
+++ b/spec/fixtures/nist/identifiers/pass/chips.txt
@@ -1,0 +1,9 @@
+# NIST CHIPS (CHIPS Act R&D program) - Pass
+# Observed set from the NIST-Tech-Pubs MODS dump (dotted DOI forms
+# NIST.CHIPS.<n>-<m> arrive here spaced as the human form).
+
+NIST CHIPS 1100-1
+NIST CHIPS 1400-1
+NIST CHIPS 1400-2
+NIST CHIPS 1400-3
+NIST CHIPS 1400-4

--- a/spec/fixtures/nist/identifiers/pass/nwirp.txt
+++ b/spec/fixtures/nist/identifiers/pass/nwirp.txt
@@ -1,0 +1,5 @@
+# NIST NWIRP - Pass
+# Low-volume series present in the NIST-Tech-Pubs MODS dump (1 doc). The dump
+# gave no concrete identifier, so a generic number pins parse + round-trip.
+
+NIST NWIRP 1

--- a/spec/fixtures/nist/identifiers/pass/rb.txt
+++ b/spec/fixtures/nist/identifiers/pass/rb.txt
@@ -1,0 +1,15 @@
+# NIST RB (Research Brief) - Pass
+# Observed set from the NIST-Tech-Pubs MODS dump (dotted DOI forms
+# NIST.RB.<n>[r<rev>] arrive here spaced as the human form).
+
+NIST RB 1
+NIST RB 2
+NIST RB 3
+NIST RB 4
+NIST RB 4r1
+NIST RB 5
+NIST RB 6
+NIST RB 7
+NIST RB 8
+NIST RB 10
+NIST RB 11

--- a/spec/pubid/nist/identifiers/chips_spec.rb
+++ b/spec/pubid/nist/identifiers/chips_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+# CHIPS is a simple NIST series (CHIPS Act R&D program) with no dedicated
+# identifier class; it routes to the Identifiers::Base fallback. Its number
+# carries a hyphenated compound form (e.g. "1400-3"), like SP "800-53".
+RSpec.describe "NIST CHIPS series" do
+  describe ".parse" do
+    describe "NIST CHIPS 1400-3" do
+      subject { "NIST CHIPS 1400-3" }
+
+      let(:parsed) { Pubid::Nist.parse(subject) }
+
+      it "parses as a NIST identifier" do
+        expect(parsed).to be_a(Pubid::Nist::Identifier)
+      end
+
+      it "parses publisher" do
+        expect(parsed.publisher.to_s).to eq("NIST")
+      end
+
+      it "parses series" do
+        expect(parsed.series.to_s).to eq("CHIPS")
+      end
+
+      it "keeps the hyphen in the compound number" do
+        expect(parsed.number.value).to eq("1400-3")
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq(subject)
+      end
+
+      it "renders the mr form" do
+        expect(parsed.to_s(:mr)).to eq("NIST.CHIPS.1400-3")
+      end
+    end
+
+    describe "NIST CHIPS 1100-1" do
+      subject { "NIST CHIPS 1100-1" }
+
+      let(:parsed) { Pubid::Nist.parse(subject) }
+
+      it "parses series" do
+        expect(parsed.series.to_s).to eq("CHIPS")
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq(subject)
+      end
+    end
+  end
+end

--- a/spec/pubid/nist/identifiers/nwirp_spec.rb
+++ b/spec/pubid/nist/identifiers/nwirp_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+# NWIRP is a low-volume simple NIST series routed to the Identifiers::Base
+# fallback. The hand-off gave no concrete identifier, so a generic number is
+# used to pin down parse + round-trip.
+RSpec.describe "NIST NWIRP series" do
+  describe ".parse" do
+    describe "NIST NWIRP 1" do
+      subject { "NIST NWIRP 1" }
+
+      let(:parsed) { Pubid::Nist.parse(subject) }
+
+      it "parses as a NIST identifier" do
+        expect(parsed).to be_a(Pubid::Nist::Identifier)
+      end
+
+      it "parses series" do
+        expect(parsed.series.to_s).to eq("NWIRP")
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq(subject)
+      end
+    end
+  end
+end

--- a/spec/pubid/nist/identifiers/rb_spec.rb
+++ b/spec/pubid/nist/identifiers/rb_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+
+# RB (Research Brief) is a simple NIST series with no dedicated identifier
+# class; it routes to the Identifiers::Base fallback (like AMS/VTS/TTB/EAB).
+RSpec.describe "NIST RB series" do
+  describe ".parse" do
+    context "basic RB identifier" do
+      describe "NIST RB 6" do
+        subject { "NIST RB 6" }
+
+        let(:parsed) { Pubid::Nist.parse(subject) }
+
+        it "parses as a NIST identifier" do
+          expect(parsed).to be_a(Pubid::Nist::Identifier)
+        end
+
+        it "parses publisher" do
+          expect(parsed.publisher.to_s).to eq("NIST")
+        end
+
+        it "parses series" do
+          expect(parsed.series.to_s).to eq("RB")
+        end
+
+        it "parses number" do
+          expect(parsed.number.value).to eq("6")
+        end
+
+        it "round-trips" do
+          expect(parsed.to_s).to eq(subject)
+        end
+      end
+    end
+
+    context "RB with revision" do
+      describe "NIST RB 4r1" do
+        subject { "NIST RB 4r1" }
+
+        let(:parsed) { Pubid::Nist.parse(subject) }
+
+        it "parses series" do
+          expect(parsed.series.to_s).to eq("RB")
+        end
+
+        it "parses number" do
+          expect(parsed.number.value).to eq("4")
+        end
+
+        it "parses revision as edition" do
+          expect(parsed.edition).to be_a(Pubid::Nist::Components::Edition)
+          expect(parsed.edition.type).to eq("r")
+          expect(parsed.edition.id).to eq("1")
+        end
+
+        it "round-trips" do
+          expect(parsed.to_s).to eq(subject)
+        end
+      end
+    end
+
+    context "dotted (DOI / machine-readable) form" do
+      describe "NIST.RB.4r1" do
+        subject { "NIST.RB.4r1" }
+
+        let(:parsed) { Pubid::Nist.parse(subject) }
+
+        it "parses series" do
+          expect(parsed.series.to_s).to eq("RB")
+        end
+
+        it "renders the mr form" do
+          expect(parsed.to_s(:mr)).to eq("NIST.RB.4r1")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Teach `Pubid::Nist` three new NIST-Tech-Pubs series so the `relaton-data-nist` crawler can index them instead of skipping them as `Unparseable id ... was not indexed`:

- **RB** (Research Brief) — e.g. `NIST RB 6`, `NIST RB 4r1` (11 docs in the latest MODS dump)
- **CHIPS** (CHIPS Act R&D) — e.g. `NIST CHIPS 1400-3` (5 docs)
- **NWIRP** — low-volume series present in the dump (1 doc)

All three are plain simple-series with no publisher-embedding, deliberately routed to the `Identifiers::Base` fallback like the existing `AMS`/`VTS`/`TTB`/`EAB` — **no dedicated identifier class or series policy**. Default behavior handles both shapes:
- `RB 4r1` → `number=4` + `edition {type: "r", id: "1"}` (same path as `SP 1026r1`)
- `CHIPS 1400-3` → compound `number.value == "1400-3"` (same path as `SP 800-53`)

## Changes

Three leading-token edits plus specs/fixtures:

- `lib/pubid/nist/parser.rb` — add `str("CHIPS") | str("NWIRP") | str("RB")` to the `simple_series` rule
- `lib/pubid/nist/router.rb` — add `"CHIPS"`, `"NWIRP"`, `"RB"` to `VALID_SERIES`
- `lib/pubid/nist.rb` — add `CHIPS NWIRP RB` to the `PREFIXES` routing constant
- New unit specs (`rb_spec.rb`, `chips_spec.rb`, `nwirp_spec.rb`) and round-trip fixtures (`pass/rb.txt`, `pass/chips.txt`, `pass/nwirp.txt`)

## Acceptance (from the relaton hand-off)

| Input | `to_s` | `#number` |
|---|---|---|
| `NIST RB 6` | `NIST RB 6` | `6` |
| `NIST RB 4r1` | `NIST RB 4r1` | `4` (edition `r1`) |
| `NIST CHIPS 1400-3` | `NIST CHIPS 1400-3` | `1400-3` |

Dotted DOI forms round-trip too (`NIST.RB.4r1`, `NIST.CHIPS.1400-3`). The other "also worth verifying" series from the hand-off all parse: `EAB`/`VTS`/`TTB` (simple), `DCI` (compound `NIST DCI`), and now `NWIRP`.

## Testing

- Full suite: **7385 examples, 0 failures, 1 pending** (pre-existing, unrelated)
- New specs: 22 examples, 0 failures; fixtures: all round-trip
- Adversarial review confirmed the new tokens are purely additive in the ordered-choice grammar (appended last, no prefix collisions, no regression on C-/R-/N-leading ids); all three prefixes resolve solely to `:nist`.

## Follow-up

Once merged and released, bump the `pubid` pin in `relaton.gemspec` and the RB/CHIPS/NWIRP documents index with no further relaton crawler change.

> Note: based on `rt-new-lutaml-model` (the v2 line), since `main` is still the old v1 layout.