### PR TITLE
fix(ieee): fix genuine round-trip mismatches, restore honest reporting (#32)

### DIFF
--- a/lib/pubid/ieee/aiee/builder.rb
+++ b/lib/pubid/ieee/aiee/builder.rb
@@ -23,7 +23,7 @@ module Pubid
                               end
 
           # Extract code
-          code_str = extract_value(parsed[:number])
+          code_str = extract_number(parsed[:number])
           if code_str
             attributes[:code] = Components::Code.parse(code_str)
           end
@@ -52,6 +52,18 @@ module Pubid
         end
 
         private
+
+        # Extract the number, flattening a "431 (105)" main-number/parenthetical
+        # subtree into a plain string. Without this, a Hash node leaks its raw
+        # Parslet inspect form (e.g. `{main_number: "431"@8, ...}`) into `to_s`.
+        def extract_number(value)
+          return extract_value(value) unless value.is_a?(Hash)
+
+          main = extract_value(value[:main_number])
+          paren = value[:parenthetical]
+          alt = paren.is_a?(Hash) ? extract_value(paren[:alt_number]) : nil
+          alt ? "#{main} (#{alt})" : main
+        end
 
         def extract_value(value)
           return nil if value.nil?

--- a/lib/pubid/ieee/identifiers/nesc/base.rb
+++ b/lib/pubid/ieee/identifiers/nesc/base.rb
@@ -28,6 +28,12 @@ module Pubid
           attribute :edition, :string              # Edition notation
           attribute :draft, :boolean               # Draft flag
           attribute :month, :string                # For draft identifiers
+          # Registered-trademark "(R)" after the full name or abbreviation
+          attribute :registered, :boolean
+          # Whether the "(NESC)"/"(NESC(R))" abbreviation suffix was present
+          attribute :abbr_suffix, :boolean
+          # Registered-trademark "(R)" inside the "(NESC(R))" suffix
+          attribute :abbr_suffix_registered, :boolean
 
           # Publisher portion for NESC identifiers
           #
@@ -36,18 +42,28 @@ module Pubid
             "NESC"
           end
 
-          # Base rendering - override in subclasses
+          # Rendering for year-first NESC identifiers (the C2-code standard form
+          # overrides this in Nesc::Standard). IEEE catalogues the year-first
+          # editions with the "IEEE Std" prefix, so it is prepended here.
           #
           # @return [String] String representation
           def to_s
-            parts = []
-            if code && year
-              parts << "#{code}-#{year.year}"
-            elsif year
-              parts << year.year.to_s
+            "IEEE Std #{year.year} #{name_portion}"
+          end
+
+          # The document-name portion, including the registered marks and the
+          # optional "(NESC(R))" abbreviation suffix.
+          #
+          # @return [String] e.g. "National Electrical Safety Code(R) (NESC(R))"
+          def name_portion
+            name = "National Electrical Safety Code"
+            name += "(R)" if registered
+            if abbr_suffix
+              suffix = "NESC"
+              suffix += "(R)" if abbr_suffix_registered
+              name += " (#{suffix})"
             end
-            parts << "National Electrical Safety Code"
-            parts.join(" ")
+            name
           end
         end
       end

--- a/lib/pubid/ieee/identifiers/nesc/handbook.rb
+++ b/lib/pubid/ieee/identifiers/nesc/handbook.rb
@@ -11,17 +11,19 @@ module Pubid
         #
         # @example Basic handbook
         #   nesc = Pubid::Ieee.parse("2012 NESC Handbook")
-        #   nesc.to_s  # => "2012 NESC Handbook"
+        #   nesc.to_s  # => "IEEE Std 2012 NESC Handbook"
         #
         # @example With edition
         #   nesc = Pubid::Ieee.parse("2017 NESC Handbook, Premier Edition")
-        #   nesc.to_s  # => "2017 NESC Handbook, Premier Edition"
+        #   nesc.to_s  # => "IEEE Std 2017 NESC Handbook, Premier Edition"
         class Handbook < Base
           # Render handbook identifier
           #
           # @return [String] YYYY NESC Handbook format with optional edition
           def to_s
-            parts = ["#{year.year} NESC Handbook"]
+            abbr = "NESC"
+            abbr += "(R)" if registered
+            parts = ["IEEE Std #{year.year} #{abbr} Handbook"]
             parts << ", #{edition}" if edition
             parts.join
           end

--- a/lib/pubid/ieee/nesc/builder.rb
+++ b/lib/pubid/ieee/nesc/builder.rb
@@ -66,6 +66,15 @@ module Pubid
             identifier.month = parsed_hash[:month].to_s
           end
 
+          # Registered-trademark "(R)" marks and the "(NESC(R))" abbreviation
+          # suffix (year-first forms) — see Identifiers::Nesc::Base#name_portion.
+          identifier.registered = true if parsed_hash[:name_registered] ||
+            parsed_hash[:abbr_registered]
+          if parsed_hash[:paren_abbr]
+            identifier.abbr_suffix = true
+            identifier.abbr_suffix_registered = true if parsed_hash[:paren_registered]
+          end
+
           identifier
         end
 

--- a/lib/pubid/ieee/nesc/parser.rb
+++ b/lib/pubid/ieee/nesc/parser.rb
@@ -34,15 +34,15 @@ module Pubid
           str("C2").as(:code)
         end
 
-        # NESC name variations
+        # NESC name variations (the "(R)" registered mark is captured
+        # separately by the `registered` rule so it can be round-tripped)
         rule(:nesc_full_name) do
-          str("National Electrical Safety Code(R)") |
-            str("National Electrical Safety Code") |
+          str("National Electrical Safety Code") |
             str("National Electric Safety Code") # Typo variation
         end
 
         rule(:nesc_abbr) do
-          str("NESC(R)") | str("NESC")
+          str("NESC")
         end
 
         rule(:nesc_name) do
@@ -51,7 +51,7 @@ module Pubid
 
         # Registered trademark notation
         rule(:registered) do
-          str("(R)").maybe
+          str("(R)")
         end
 
         # Edition notations
@@ -97,8 +97,8 @@ module Pubid
             dash >>
             year.as(:year) >>
             (comma.maybe >> space).maybe >>
-            nesc_full_name >>
-            (space >> str("(") >> nesc_abbr >> str(")")).maybe
+            nesc_full_name >> registered.maybe >>
+            (space >> str("(") >> nesc_abbr >> registered.maybe >> str(")")).maybe
         end
 
         # Pattern 2: YYYY NESC format (year-first)
@@ -109,11 +109,12 @@ module Pubid
           year.as(:year) >>
             space >>
             (
-              # Full name with optional (NESC) suffix
-              (nesc_full_name >> registered >>
-               (space >> str("(") >> nesc_abbr >> registered >> str(")")).maybe) |
-              # Just NESC abbreviation
-              (nesc_abbr >> registered)
+              # Full name with optional (NESC) abbreviation suffix
+              (nesc_full_name.as(:full_name) >> registered.as(:name_registered).maybe >>
+               (space >> str("(") >> nesc_abbr.as(:paren_abbr) >>
+                registered.as(:paren_registered).maybe >> str(")")).maybe) |
+              # Just the NESC abbreviation (e.g. "2017 NESC(R) Handbook")
+              (nesc_abbr.as(:abbr) >> registered.as(:abbr_registered).maybe)
             ) >>
             (space >> variant).maybe >>
             (comma >> space >> edition).maybe
@@ -123,7 +124,7 @@ module Pubid
         # Examples: "National Electrical Safety Code, C2-2012"
         #           "National Electrical Safety Code, C2-2012 - Redline"
         rule(:name_first) do
-          nesc_full_name >>
+          nesc_full_name >> registered.maybe >>
             comma >>
             space >>
             c2_code >>
@@ -138,7 +139,7 @@ module Pubid
         rule(:draft_nesc) do
           str("Draft").as(:draft) >>
             space >>
-            nesc_name >>
+            nesc_name >> registered.maybe >>
             comma >> space >>
             month >> space >> year.as(:year)
         end

--- a/spec/pubid/ieee/aiee_parenthetical_number_spec.rb
+++ b/spec/pubid/ieee/aiee_parenthetical_number_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Regression for issue #32: an AIEE number with a parenthetical alternate
+# number (e.g. "431 (105)") leaked its raw Parslet subtree into `to_s`
+# (`AIEE No {main_number: "431"@8, parenthetical: ...}-1958`).
+RSpec.describe "IEEE AIEE parenthetical number (issue #32)" do
+  let(:parsed) { Pubid::Ieee.parse("AIEE No 431 (105) -1958") }
+
+  it "does not leak the raw parse tree into to_s" do
+    expect(parsed.to_s).not_to include("main_number")
+    expect(parsed.to_s).not_to match(/@\d+/)
+  end
+
+  it "preserves the main and alternate numbers" do
+    expect(parsed.to_s).to include("431 (105)")
+  end
+end

--- a/spec/pubid/ieee/fixtures_spec.rb
+++ b/spec/pubid/ieee/fixtures_spec.rb
@@ -14,6 +14,26 @@ RSpec.describe "IEEE Fixture Round-trip Tests" do
     pubid_to_parse_fixtures + unapproved_fixtures + pubid_parsed_fixtures
   end
 
+  # Emit a concise, human-readable summary of the fixture mismatches so the
+  # real round-trip rate and the first failures are visible when running the
+  # suite (issue #32 — these blocks used to be empty, hiding the failures).
+  def report_mismatches(label, header, failures)
+    return if failures.empty?
+
+    lines = ["#{label}: #{header}, #{failures.size} mismatches (first 10):"]
+    failures.first(10).each { |f| lines << format_failure(f) }
+    RSpec.configuration.reporter.message(lines.join("\n"))
+  end
+
+  def format_failure(failure)
+    original = failure[:original].inspect
+    return "  #{original} -> ERROR #{failure[:error]}" if failure[:error]
+
+    detail = "  #{original}\n"
+    detail += "    expected: #{failure[:expected].inspect}\n" if failure.key?(:expected)
+    detail + "    got:      #{failure[:rendered].inspect} (#{failure[:class]})"
+  end
+
   describe "pubid-to-parse.txt fixtures" do
     it "round-trips pubid-to-parse identifiers" do
       failures = []
@@ -55,19 +75,26 @@ RSpec.describe "IEEE Fixture Round-trip Tests" do
         end
       end
 
-      if failures.any?
+      pct = (successes.to_f / total_tested * 100).round(2)
+      report_mismatches("pubid-to-parse",
+                        "#{successes}/#{total_tested} round-trip (#{pct}%)",
+                        failures)
 
-        failures.first(10).each do |failure|
-          if failure[:error]
-
-          end
-        end
-      end
-
-      # NOTE: These are V1 fixture files with legacy patterns
-      # V2 has different normalization (e.g., "IEEE No" → "IEEE Std")
-      # We expect lower pass rate due to architectural differences
-      expect(successes.to_f / total_tested).to be >= 0.01
+      # These are V1 fixture files whose "expected" column is internally
+      # inconsistent and, in many cases, encodes conventions V2 deliberately
+      # abandoned, so a large subset can never round-trip without regressing V2
+      # (see issue #32 for the analysis). Known non-round-trippable classes:
+      #   * V2 emits "IEEE Std 267A-1980" where the fixture expects bare
+      #     "IEEE 267A-1980" (V2's "IEEE Std" form is the correct one).
+      #   * The fixture drops "AIEE No" (→ "AIEE 14-1925"); V2 deliberately
+      #     retains it (asserted in identifiers/base_spec.rb).
+      #   * Month/year comma ("August 2016" vs "August, 2016") and trailing
+      #     ".pdf" differ between this file and pubid-parsed.txt.
+      # The threshold is therefore a floor over the genuinely round-trippable
+      # fixtures, raised from the historical 1% (which had been reached only by
+      # relaxing the denominator, not by fixing mismatches) to lock in the
+      # NESC-family fixes from issue #32.
+      expect(successes.to_f / total_tested).to be >= 0.05
     end
   end
 
@@ -110,14 +137,7 @@ RSpec.describe "IEEE Fixture Round-trip Tests" do
         end
       end
 
-      if failures.any?
-
-        failures.first(10).each do |failure|
-          if failure[:error]
-
-          end
-        end
-      end
+      report_mismatches("unapproved", "#{successes} round-trip", failures)
 
       # NOTE: These are V1 fixture files with legacy patterns
       # V2 has different normalization (e.g., "IEEE No" → "IEEE Std")
@@ -159,14 +179,8 @@ RSpec.describe "IEEE Fixture Round-trip Tests" do
         end
       end
 
-      if failures.any?
-
-        failures.first(10).each do |failure|
-          if failure[:error]
-
-          end
-        end
-      end
+      report_mismatches("pubid-parsed",
+                        "#{successes}/#{total_tested} round-trip", failures)
 
       # NOTE: These are V1 canonical forms - V2 normalization may differ
       # We expect lower pass rate due to architectural differences

--- a/spec/pubid/ieee/nesc_roundtrip_spec.rb
+++ b/spec/pubid/ieee/nesc_roundtrip_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Regression coverage for issue #32: year-first NESC identifiers dropped the
+# "IEEE Std" prefix, the registered-trademark "(R)" marks and the "(NESC(R))"
+# abbreviation suffix. See spec/pubid/ieee/fixtures_spec.rb for the aggregate
+# round-trip rate.
+RSpec.describe "IEEE NESC round-trip (issue #32)" do
+  # input => expected canonical string
+  {
+    "2012 NESC Handbook, Seventh Edition" =>
+      "IEEE Std 2012 NESC Handbook, Seventh Edition",
+    "2017 NESC(R) Handbook, Premier Edition" =>
+      "IEEE Std 2017 NESC(R) Handbook, Premier Edition",
+    "2017 National Electrical Safety Code(R) (NESC(R))" =>
+      "IEEE Std 2017 National Electrical Safety Code(R) (NESC(R))",
+  }.each do |input, expected|
+    it "round-trips #{input.inspect}" do
+      expect(Pubid::Ieee.parse(input).to_s).to eq(expected)
+    end
+  end
+
+  # Guard: C2-code NESC standards must NOT gain the "IEEE Std" prefix.
+  it "leaves C2-code standards unprefixed" do
+    expect(Pubid::Ieee.parse("C2-2012 National Electrical Safety Code").to_s)
+      .to eq("C2-2012 National Electrical Safety Code")
+  end
+
+  # Guard: splitting the "(R)" mark out of nesc_full_name/nesc_abbr must keep
+  # the name-first and draft NESC grammar rules (which also consume those
+  # names) able to match a trademark mark. Exercised at the NESC sub-parser
+  # level because that is the rule surface the refactor touched.
+  [
+    "National Electrical Safety Code(R), C2-2012",
+    "Draft National Electrical Safety Code(R), January 2016",
+    "Draft NESC(R), June 2011",
+  ].each do |input|
+    it "sub-parser still matches #{input.inspect}" do
+      expect { Pubid::Ieee::Nesc::Parser.new.parse(input) }.not_to raise_error
+    end
+  end
+
+  # And the draft "(R)" forms round-trip through the public API.
+  it "parses draft NESC with a trademark mark via the public API" do
+    expect { Pubid::Ieee.parse("Draft NESC(R), June 2011") }.not_to raise_error
+  end
+end


### PR DESCRIPTION
## Summary

Addresses #32. That issue reported the IEEE `pubid-to-parse.txt` round-trip rate below its threshold plus granular mismatches. Investigation found the threshold had been **silenced, not fixed** — commit `0bd9916d` swapped the assertion denominator (640 → 118 tested lines), moving the rate 0.78% → 4.24% with zero behavior change, and the spec's failure-reporting blocks were left empty, hiding all 113 failures.

This PR fixes the **genuinely-clean bugs** and restores honest measurement, raising the rate **5/118 (4.24%) → 8/118 (6.78%)** with no regressions.

## Changes

- **Honest reporting** — restored the dead `if failures.any?` blocks in `fixtures_spec.rb` (refactored into a shared `report_mismatches`/`format_failure` helper); the real rate and first mismatches now print. Threshold raised `0.01 → 0.05` — an honest floor over the genuine wins, no longer gameable by the denominator.
- **NESC year-first forms** now emit the `IEEE Std` prefix and round-trip the `(R)` registered marks + `(NESC(R))` abbreviation suffix that were previously dropped (parser now captures them; new rendering in `nesc/base.rb`/`handbook.rb`; builder maps them). **+3 fixtures.** C2-code standards deliberately stay unprefixed (guarded by spec).
- **AIEE `to_s`** no longer leaks a raw Parslet subtree (`{main_number: "431"@8, ...}`) for parenthetical numbers like `431 (105)`.

## Why not higher?

Implementation-phase analysis showed the remaining ~110 failures are dominated by **contradictions**, not clean bugs — the two V1 fixture files disagree with each other, or with V2's own tested conventions. Chasing them would regress V2. Documented inline; left out of scope:

| Cluster | Why out of scope |
|---|---|
| `AIEE No` removal | `identifiers/base_spec.rb` + `pre_parser_spec.rb` **assert V2 retains "AIEE No"** |
| Month/year comma (`August 2016` vs `August, 2016`) | 20 `pubid-parsed.txt` fixtures pass **with** the comma — the two fixture files disagree |
| `.pdf` suffix | one fixture drops it, ~15 keep it; also a filename artifact V2 strips |
| Redline | `RedlinedStandard` is a broken half-feature (base never populated) defeated by a global strip — disproportionate rewrite for ~2 fixtures |
| IRE-adopted `IEEE Std` placement | internally inconsistent across the 5 fixtures |

## Tests

- Full IEEE suite green (165 examples, 0 failures); new regression specs `nesc_roundtrip_spec.rb` and `aiee_parenthetical_number_spec.rb` pass.
- `rake test:all` green except `iso/performance_spec.rb:31` — a pre-existing timing-flaky benchmark unrelated to IEEE (passes in isolation; failed only under concurrent load here).
- A latent sub-parser regression (found in review) was fixed: `name_first`/`draft_nesc` needed `registered.maybe` after the `(R)` refactor.