### PR TITLE
fix(oiml,iala): close URN round-trip gaps for Bulletin and Annex

### DIFF
--- a/lib/pubid/iala/urn_parser.rb
+++ b/lib/pubid/iala/urn_parser.rb
@@ -6,11 +6,15 @@ module Pubid
     #
     # UrnGenerator emits:
     #   urn:mrn:iala:pub:<type-lower><number>[:ed<edition>][:<lang-lower>]
+    # and for Annex identifiers:
+    #   urn:mrn:iala:pub:<base-code>:annex[-<letter>][:ed<edition>][:<lang>]
     #
     # Examples:
     #   urn:mrn:iala:pub:s1070:ed2.0          → IALA S1070 Ed 2.0
     #   urn:mrn:iala:pub:r1016:ed2.0:f        → IALA R1016 Ed 2.0 (F)
     #   urn:mrn:iala:pub:c0103-1              → IALA C0103-1
+    #   urn:mrn:iala:pub:g1045:annex:ed1      → IALA G1045 Annex Ed 1
+    #   urn:mrn:iala:pub:g1128:annex-a:ed1.6  → IALA G1128 ANNEX A Ed 1.6
     class UrnParser < Pubid::UrnParser::Base
       PREFIX = "urn:mrn:iala:pub:".freeze
 
@@ -21,15 +25,28 @@ module Pubid
 
         edition = nil
         language = nil
+        annex_form = nil
+        annex_letter = nil
+
         parts.drop(1).each do |seg|
-          if seg.start_with?("ed")
+          case seg
+          when /\Aannex(-([a-z]))?\z/i
+            # UrnGenerator emits "annex" (bare) for the Annex-without-letter
+            # form and "annex-X" (lettered) for the uppercase ANNEX form.
+            # The human parser accepts both "Annex" and "ANNEX"; mirror the
+            # generator's casing so URN round-trip is exact.
+            annex_letter = Regexp.last_match(2)&.upcase
+            annex_form = annex_letter ? "ANNEX" : "Annex"
+          when /\Aed/
             edition = seg.sub(/\Aed/, "")
-          elsif seg.length == 1 && seg.match?(/\A[a-z]\z/i)
+          when /\A[a-z]\z/i
             language = seg.upcase
           end
         end
 
         text = "IALA #{code.upcase}"
+        text += " #{annex_form}" if annex_form
+        text += " #{annex_letter}" if annex_letter
         text += " Ed #{edition}" if edition
         text += " (#{language})" if language
         flavor_parse(text)

--- a/lib/pubid/oiml/urn_parser.rb
+++ b/lib/pubid/oiml/urn_parser.rb
@@ -4,18 +4,35 @@ module Pubid
   module Oiml
     # Parses OIML URNs back into identifiers.
     #
-    # UrnGenerator emits: `urn:oiml:{type}:{number}[-{part}]` where type
-    # is the lowercase document class (r for Recommendation, d for Document).
+    # UrnGenerator emits: `urn:oiml:{type}:{locator}` where type is the
+    # lowercase document class — single letter for typed documents
+    # (r, d, b, g, …) or the word "bulletin" for Bulletin issues. The
+    # locator is the number-part-subpart for typed documents and the
+    # YYYY-II-SS tuple for Bulletins.
     #
     # Examples:
-    # - urn:oiml:r:111-1 → OIML R 111-1
-    # - urn:oiml:d:1     → OIML D 1
+    # - urn:oiml:r:111-1           → OIML R 111-1
+    # - urn:oiml:d:1               → OIML D 1
+    # - urn:oiml:bulletin:2026-02-11 → OIML Bulletin 2026-02-11
     class UrnParser < Pubid::UrnParser::Base
       def parse_urn(urn)
         body = strip_namespace(urn)
         parts = split_parts(body)
-        type_token, number = parts
-        flavor_parse("OIML #{type_token.upcase} #{number}")
+        type_token = parts.fetch(0)
+        number = parts[1]
+
+        text = "OIML #{display_type(type_token)}"
+        text += " #{number}" if number
+        flavor_parse(text)
+      end
+
+      private
+
+      # URN type tokens are lowercase. Typed documents use a single letter
+      # that maps cleanly via upcase; Bulletin is the multi-letter word
+      # that the human parser expects capitalized.
+      def display_type(token)
+        token.downcase == "bulletin" ? "Bulletin" : token.upcase
       end
     end
   end

--- a/spec/pubid/iala/identifier_spec.rb
+++ b/spec/pubid/iala/identifier_spec.rb
@@ -149,6 +149,13 @@ RSpec.describe Pubid::Iala::Identifier do
       urn:mrn:iala:pub:r1016:ed2.0:f
       urn:mrn:iala:pub:c0103-1:ed3.0
       urn:mrn:iala:pub:g1015
+      urn:mrn:iala:pub:m0001:ed9.0
+      urn:mrn:iala:pub:a12-01
+      urn:mrn:iala:pub:ga01.01
+      urn:mrn:iala:pub:l2.1.11:ed2
+      urn:mrn:iala:pub:g1045:annex:ed1
+      urn:mrn:iala:pub:g1128:annex-a:ed1.6
+      urn:mrn:iala:pub:g1128:annex-d:ed1.6:e
     ].each do |urn|
       it "round-trips #{urn.inspect} through the parser" do
         id = Pubid::Iala::UrnParser.parse(urn)

--- a/spec/pubid/oiml/urn_parser_spec.rb
+++ b/spec/pubid/oiml/urn_parser_spec.rb
@@ -8,5 +8,14 @@ RSpec.describe Pubid::Oiml::UrnParser do
   it_behaves_like "flavor URN round-trip", Pubid::Oiml, [
     "OIML R 111-1",
     "OIML D 1",
+    # Bulletin — every tier of the periodical hierarchy round-trips through
+    # the URN, including the bare periodical (no locator).
+    "OIML Bulletin",
+    "OIML Bulletin 1960",
+    "OIML Bulletin 1960-03",
+    "OIML Bulletin 1960-03-01",
+    # Citation form URN-canonicalizes to structured on the way out, so the
+    # round-trip lands on the structured form.
+    "OIML Bulletin 2026-02-11",
   ]
 end


### PR DESCRIPTION
## Summary

Two real URN round-trip bugs caught while auditing the forward branch for improvements:

- **OIML UrnParser didn't recognize the Bulletin type token** — `urn:oiml:bulletin:2026-02-11` raised `ParseFailed` because the parser did `type_token.upcase` → `"OIML BULLETIN ..."`, but the human parser expects `"Bulletin"`. Special-cased the multi-letter token; also handle the bare-periodicals case where the URN has no locator.
- **IALA UrnParser silently dropped the Annex segment** — `urn:mrn:iala:pub:g1045:annex:ed1` round-tripped as `urn:mrn:iala:pub:g1045:ed1`, a different identifier. The parser now detects `annex` / `annex-<letter>` segments and rebuilds the human string with the marker (preserving the casing the generator emits: bare "Annex" vs lettered "ANNEX").

Spec coverage expands to every type that has a URN:
- OIML: 2 → 7 cases (added all 4 Bulletin tiers + bare)
- IALA: 4 → 11 cases (added Manual, Advice, GeneralAssembly, Letter, three Annex variants)

## Test plan

- [x] `bundle exec rspec` — **7580 examples, 0 failures**
- [x] Corpus probes still clean: OIML 4672/4672, IALA 699/863
- [x] URN round-trip probe — every shape (including the new `urn:oiml:bulletin` and `urn:mrn:iala:pub:g1128:annex-d:ed1.6:e`) round-trips exactly
