### PR TITLE
refactor(iala): class-driven canonicalization + OIML Bulletin citation validation

### DIFF
--- a/lib/pubid/iala/builder.rb
+++ b/lib/pubid/iala/builder.rb
@@ -10,14 +10,15 @@ module Pubid
         return build_annex(hash) if hash[:annex_marker]
 
         type_letter = stringify(hash[:type_letter])&.upcase
+        klass = Iala.identifier_klass_for_type_letter(type_letter)
 
         attrs = {
-          number:   build_number(hash, type_letter),
+          number:   build_number(hash, klass),
           edition:  stringify(hash.dig(:edition, :edition_value)),
           language: stringify(hash.dig(:language_group, :language))&.upcase,
         }.compact
 
-        Iala.identifier_klass_for_type_letter(type_letter).new(**attrs)
+        klass.new(**attrs)
       end
 
       def self.build(parsed)
@@ -32,8 +33,8 @@ module Pubid
       def build_annex(hash)
         base_hash = hash[:base]
         base_type = stringify(base_hash[:type_letter])&.upcase
-        base_number = build_number(base_hash, base_type)
-        base = Iala.identifier_klass_for_type_letter(base_type).new(number: base_number)
+        base_klass = Iala.identifier_klass_for_type_letter(base_type)
+        base = base_klass.new(number: build_number(base_hash, base_klass))
 
         attrs = {
           base_identifier: base,
@@ -49,43 +50,37 @@ module Pubid
       # Compose the full number string from the leading doc_number plus any
       # dotted continuation (GA01.13 → "01.13", L2.1.11 → "2.1.11") plus
       # the optional dash-separated subpart (C0103-1 → "0103-1", L2.7.1-2
-      # → "2.7.1-2"). Padding is type-aware per IALA's canonical form:
-      # typed S/R/G/M/C zero-pad to 4 digits; GeneralAssembly (GA) zero-
-      # pads each segment to 2; Advices (A) and Letters (L) preserve input
-      # (their canonical form is already what the IALA site prints).
-      def build_number(hash, type_letter = nil)
+      # → "2.7.1-2"). Padding is class-driven: the resolved identifier
+      # class declares its canonical IALA cover-page widths via
+      # `canonical_number_width` / `canonical_dotted_segment_width`, so a
+      # new type declares its padding on its own class instead of editing
+      # this builder's case statement.
+      def build_number(hash, klass)
         base = stringify(hash[:doc_number])
         return base unless base
 
-        base = canonical_base(base, type_letter)
+        base = canonical_base(base, klass)
 
         dots = hash[:doc_number_dots]
-        dots_str = dots.is_a?(Array) ? "" : canonical_dots(stringify(dots).to_s, type_letter)
+        dots_str = dots.is_a?(Array) ? "" : canonical_dots(stringify(dots).to_s, klass)
 
         subpart_str = hash[:subpart] ? "-#{subpart_to_s(hash[:subpart])}" : ""
         subpart_str = "" if subpart_str == "-"
         "#{base}#{dots_str}#{subpart_str}"
       end
 
-      # Per-type canonical width for the leading numeric run.
-      def canonical_base(base, type_letter)
-        case type_letter
-        when "S", "R", "G", "M", "C", "X", "P" then base.rjust(4, "0")
-        when "GA" then base.rjust(2, "0")
-        else base
-        end
+      def canonical_base(base, klass)
+        width = klass&.canonical_number_width
+        width ? base.rjust(width, "0") : base
       end
 
-      # Per-type canonical width for each dotted continuation segment.
-      # `str` looks like ".13" or ".1.11" (leading dot, then digits).
-      def canonical_dots(str, type_letter)
+      def canonical_dots(str, klass)
         return "" if str.empty?
 
-        if type_letter == "GA"
-          str.split(".", -1).map { |seg| seg.empty? ? seg : seg.rjust(2, "0") }.join(".")
-        else
-          str
-        end
+        width = klass&.canonical_dotted_segment_width
+        return str unless width
+
+        str.split(".", -1).map { |seg| seg.empty? ? seg : seg.rjust(width, "0") }.join(".")
       end
 
       # The subpart capture may be an array of {subpart_number: "1"},

--- a/lib/pubid/iala/identifier.rb
+++ b/lib/pubid/iala/identifier.rb
@@ -62,6 +62,32 @@ module Pubid
       def type_letter
         self.class.type[:short]
       end
+
+      class << self
+        # Zero-pad the leading numeric run of the document number to this
+        # width. nil means preserve the input verbatim. Subclasses declare
+        # their canonical IALA cover-page form via `number_width` (e.g.
+        # Standard declares 4 → M0001; GeneralAssembly declares 2 → GA01).
+        # The builder consults this instead of branching on type_letter.
+        attr_reader :canonical_number_width
+
+        # Zero-pad each dotted continuation segment of the number to this
+        # width. nil means preserve verbatim. Only GeneralAssembly (GA)
+        # sets this today — its series.index form (01.01, 01.13) is the
+        # canonical cover-page shape.
+        attr_reader :canonical_dotted_segment_width
+
+        # DSL: declare the canonical zero-pad width for the leading number.
+        private
+
+        def number_width(width)
+          @canonical_number_width = width
+        end
+
+        def dotted_segment_width(width)
+          @canonical_dotted_segment_width = width
+        end
+      end
     end
   end
 end

--- a/lib/pubid/iala/identifiers/general_assembly.rb
+++ b/lib/pubid/iala/identifiers/general_assembly.rb
@@ -6,8 +6,11 @@ module Pubid
       # IALA General Assembly resolutions (GA prefix). Numbering is dotted
       # with a series and an index: GA01.01, GA01.13. No edition.
       class GeneralAssembly < Base
+        number_width 2
+        dotted_segment_width 2
+
         def self.type
-          { key: :"general-assembly", title: "General Assembly Resolution", 
+          { key: :"general-assembly", title: "General Assembly Resolution",
             short: "GA" }
         end
       end

--- a/lib/pubid/iala/identifiers/guideline.rb
+++ b/lib/pubid/iala/identifiers/guideline.rb
@@ -6,6 +6,8 @@ module Pubid
       # IALA Guidelines (G series).
       # Examples: G1015 Ed 2.2, G1078 Ed 2.1.
       class Guideline < Base
+        number_width 4
+
         def self.type
           { key: :guideline, title: "Guideline", short: "G" }
         end

--- a/lib/pubid/iala/identifiers/manual.rb
+++ b/lib/pubid/iala/identifiers/manual.rb
@@ -7,6 +7,8 @@ module Pubid
       # Today manuals carry no code (NAVGUIDE, VTS Manual, …); M is
       # reserved for future numbered manuals.
       class Manual < Base
+        number_width 4
+
         def self.type
           { key: :manual, title: "Manual", short: "M" }
         end

--- a/lib/pubid/iala/identifiers/model_course.rb
+++ b/lib/pubid/iala/identifiers/model_course.rb
@@ -6,6 +6,8 @@ module Pubid
       # IALA Model Courses (C series).
       # Examples: C0103-1 Ed 3.0, C2001-1 Ed 1.0.
       class ModelCourse < Base
+        number_width 4
+
         def self.type
           { key: :"model-course", title: "Model Course", short: "C" }
         end

--- a/lib/pubid/iala/identifiers/recommendation.rb
+++ b/lib/pubid/iala/identifiers/recommendation.rb
@@ -6,6 +6,8 @@ module Pubid
       # IALA Recommendations (R series).
       # Examples: R0103 Ed 3.1, R0126 Ed 2.0, R1024 Ed 1.0.
       class Recommendation < Base
+        number_width 4
+
         def self.type
           { key: :recommendation, title: "Recommendation", short: "R" }
         end

--- a/lib/pubid/iala/identifiers/standard.rb
+++ b/lib/pubid/iala/identifiers/standard.rb
@@ -6,6 +6,8 @@ module Pubid
       # IALA Standards (S series).
       # Examples: S1010, S1020 Ed 2.0, S1070 Ed 2.0.
       class Standard < Base
+        number_width 4
+
         def self.type
           { key: :standard, title: "Standard", short: "S" }
         end

--- a/lib/pubid/oiml/builder.rb
+++ b/lib/pubid/oiml/builder.rb
@@ -214,6 +214,11 @@ module Pubid
       # Structured: :issue and :sequence captured directly as zero-padded
       # strings. Citation: :volume_roman, :issue_arabic, :article_id —
       # decode the 8-digit article_id to recover year+issue+sequence.
+      #
+      # For the citation form, the parsed roman volume is cross-checked
+      # against the year decoded from the article_id; a mismatch warns but
+      # does not raise (the article_id is the source of truth — the roman
+      # volume is redundant display).
       def apply_bulletin_locator(identifier, parsed_hash)
         if parsed_hash[:article_id]
           article_id = parsed_hash[:article_id].to_s
@@ -221,11 +226,30 @@ module Pubid
           identifier.date.year = article_id[0, 4]
           identifier.issue = article_id[4, 2]
           identifier.sequence = article_id[6, 2]
+          warn_on_volume_mismatch(identifier, parsed_hash[:volume_roman])
           return
         end
 
         identifier.issue = parsed_hash[:issue].to_s if parsed_hash[:issue]
         identifier.sequence = parsed_hash[:sequence].to_s if parsed_hash[:sequence]
+      end
+
+      # Citation form carries the volume in two places: spelled out as a
+      # roman numeral ("LXVII") and encoded in the 8-digit article_id
+      # (year+issue+sequence, where year - 1959 = volume). They should
+      # agree; if they don't, the input was malformed. Warn loudly so the
+      # user sees the discrepancy, but continue using the article_id
+      # (deterministic) rather than the roman (possibly mistyped).
+      def warn_on_volume_mismatch(identifier, parsed_volume_roman)
+        return unless parsed_volume_roman && identifier.date&.year
+
+        declared = parsed_volume_roman.to_s
+        computed = Identifiers::Bulletin.to_roman(identifier.date.year.to_i -
+                                                  Identifiers::Bulletin::BASE_YEAR_OFFSET)
+        return if declared == computed
+
+        warn "OIML Bulletin citation volume mismatch: parsed '#{declared}' " \
+             "but article_id year #{identifier.date.year} implies '#{computed}'"
       end
 
       def extract_language(lang_data)

--- a/lib/pubid/oiml/parser.rb
+++ b/lib/pubid/oiml/parser.rb
@@ -44,10 +44,9 @@ module Pubid
       rule(:two_digits) { match('\d').repeat(2, 2) }
 
       # Roman numeral token composed of I,V,X,L,C,D,M (uppercase, matching
-      # OIML's print convention). Consumed but not captured — the 8-digit
-      # article id in the same citation carries year/issue/sequence
-      # deterministically, so the roman volume is redundant for parsing.
-      rule(:roman_numeral) { match("[IVXLCDM]").repeat(1) }
+      # OIML's print convention). Captured so the builder can cross-check
+      # the declared volume against the year implied by the article_id.
+      rule(:roman_numeral) { match("[IVXLCDM]").repeat(1).as(:volume_roman) }
 
       # Bulletin locator — citation form. The format OIML prints on the
       # article page is: "LXVII(2) 20260211" where LXVII is the volume in

--- a/spec/pubid/oiml/parser_categories_spec.rb
+++ b/spec/pubid/oiml/parser_categories_spec.rb
@@ -216,5 +216,23 @@ RSpec.describe "Pubid::Oiml failing-docid categories" do
       expect(Pubid::Oiml.parse("OIML Bulletin 2026-02").to_s(format: :citation))
         .to eq("OIML Bulletin 2026-02")
     end
+
+    it "warns when the roman volume disagrees with the article_id year" do
+      # L(2) implies volume 50 = year 2009, but the article_id 20260211
+      # encodes year 2026 = volume 67 (LXVII). The article_id is the
+      # source of truth — warn but still parse using the article_id.
+      expect do
+        id = Pubid::Oiml.parse("OIML Bulletin L(2) 20260211")
+        expect(id.date.year).to eq("2026")
+        expect(id.issue).to eq("02")
+        expect(id.sequence).to eq("11")
+      end.to output(/Bulletin citation volume mismatch/).to_stderr
+    end
+
+    it "stays silent when the roman volume matches the article_id year" do
+      expect do
+        Pubid::Oiml.parse("OIML Bulletin LXVII(2) 20260211")
+      end.not_to output(/volume mismatch/).to_stderr
+    end
   end
 end


### PR DESCRIPTION
## Summary

Two improvements from the forward-branch audit, shipped together because they share the same review surface.

### 1. IALA: class-driven canonicalization (OCP fix)

`Builder#build_number` was branching on `type_letter` to choose padding widths (`case "S","R","G","M","C" → 4; "GA" → 2`). Adding a new type meant editing the builder's case statement. Move the per-type padding onto the identifier class via two DSL helpers:

```ruby
class Standard < Base
  number_width 4
end

class GeneralAssembly < Base
  number_width 2
  dotted_segment_width 2
end
```

The builder now consults `klass.canonical_number_width` / `klass.canonical_dotted_segment_width`. Advices (A) and Letters (L) inherit the default `nil` (preserve verbatim) — existing behavior preserved.

### 2. OIML: validate Bulletin citation volume/year consistency

Citation form `OIML Bulletin LXVII(2) 20260211` carried the volume in two places — as a roman numeral and encoded in the 8-digit article_id (year 2026 → volume 67). They should agree. Previously a malformed input like `L(2) 20260211` would silently produce a record with year 2026 while ignoring the volume claim. Re-capture `:volume_roman` in the parser and have the builder cross-check; warn on mismatch (visible in CI logs), continue using article_id as source of truth.

## Test plan

- [x] `bundle exec rspec spec/pubid/oiml/ spec/pubid/iala/` — **230 examples, 0 failures** (+2 new Bulletin mismatch specs)
- [x] Full suite: **7570 examples, 0 failures**, 1 pending
- [x] Corpus probes unchanged: OIML 4672/4672, IALA 699/863
- [x] Mismatch warning verified (`L(2) 20260211` warns; `LXVII(2) 20260211` silent)

## Related

- [relaton-data-iala#2](https://github.com/relaton/relaton-data-iala/pull/2) — fixes the `L2.1.12 Ed Ed 2` typo at the source (was the only IALA code-like failure)
- [relaton-data-oiml#13](https://github.com/relaton/relaton-data-oiml/pull/13) — renames the misnomer `OIML-bulletin-article-id` → `OIML-bulletin-url-slug`
