### PR TITLE
feat(adobe): re-apply Pubid::Adobe flavor on main

### DIFF
--- a/lib/pubid.rb
+++ b/lib/pubid.rb
@@ -100,6 +100,7 @@ module Pubid
 
 
   # Require all flavor modules
+  autoload :Adobe, "pubid/adobe"
   autoload :Amca, "pubid/amca"
   autoload :Ansi, "pubid/ansi"
   autoload :Api, "pubid/api"

--- a/lib/pubid/adobe.rb
+++ b/lib/pubid/adobe.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Adobe
+    extend Pubid::PrefixesSupport
+
+    # Leading identifier prefix tokens that an Adobe document id can start
+    # with. Tech notes appear as both `Adobe Technical Note #<n>` and the
+    # short alias `ATN<n>` in citations; both must route to this flavor.
+    # Named publications start with `Adobe` (e.g. `Adobe Glyph List`,
+    # `Adobe-Japan1-7`).
+    PREFIXES = ["Adobe", "ATN"].freeze
+
+    autoload :Builder,      "#{__dir__}/adobe/builder"
+    autoload :Identifier,   "#{__dir__}/adobe/identifier"
+    autoload :Identifiers,  "#{__dir__}/adobe/identifiers"
+    autoload :Parser,       "#{__dir__}/adobe/parser"
+    autoload :Renderer,     "#{__dir__}/adobe/renderer"
+    autoload :UrnGenerator, "#{__dir__}/adobe/urn_generator"
+    autoload :UrnParser,    "#{__dir__}/adobe/urn_parser"
+
+    # Parse an Adobe identifier string into an identifier object.
+    # @param identifier [String]
+    # @return [Pubid::Adobe::Identifier]
+    def self.parse(identifier)
+      Identifier.parse(identifier)
+    end
+
+    # Per-flavor format registry: inherits global formats, overrides :human
+    # with the Adobe-specific renderer.
+    Identifiers::Base.format_registry = FormatRegistry.new(parent: ::Pubid::Identifier.format_registry)
+    Identifiers::Base.format_registry.register(:human, renderer: Adobe::Renderer)
+
+    # Auto-discover identifier types from the Identifiers namespace.
+    # @return [Array<Class>]
+    def self.identifier_types
+      @identifier_types ||= Identifiers.constants
+        .filter_map { |c| begin; Identifiers.const_get(c); rescue NameError; nil; end }
+        .select { |c| c.is_a?(Class) && c < Pubid::Identifier }
+        .reject { |c| c == Identifiers::Base }
+    end
+
+    # Lookup: type key → identifier class
+    # @param code [String, Symbol]
+    # @return [Class, nil]
+    def self.locate_type(code)
+      identifier_types.find { |t| t.type[:key].to_s == code.to_s }
+    end
+
+    # Lookup: type short letter (e.g. "ATN") → identifier class
+    # @param short [String]
+    # @return [Class<Identifiers::Base>]
+    def self.identifier_klass_for_short(short)
+      @by_short ||= identifier_types.to_h { |klass| [klass.type[:short].to_s, klass] }
+      @by_short.fetch(short.to_s)
+    end
+  end
+end
+
+Pubid::Registry.register(:adobe, Pubid::Adobe)

--- a/lib/pubid/adobe/builder.rb
+++ b/lib/pubid/adobe/builder.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Adobe
+    # Builds an Adobe identifier object from the Parslet parse tree.
+    class Builder
+      def build(parsed)
+        return build_tech_note(parsed[:tech_note]) if parsed[:tech_note]
+        return build_tech_note_bare(parsed[:tech_note_bare]) if parsed[:tech_note_bare]
+        return build_publication_version(parsed[:publication_version]) if parsed[:publication_version]
+        return build_publication(parsed[:slug]) if parsed[:slug]
+
+        raise ArgumentError, "Unrecognized Adobe parse tree: #{parsed.inspect}"
+      end
+
+      def self.build(parsed)
+        new.build(parsed)
+      end
+
+      private
+
+      def build_tech_note(hash)
+        Identifiers::TechNote.new(
+          number: stringify(hash[:number]),
+          slug:   stringify(hash[:slug]),
+        )
+      end
+
+      def build_tech_note_bare(number_hash)
+        Identifiers::TechNote.new(number: stringify(number_hash))
+      end
+
+      def build_publication(slug_value)
+        Identifiers::Publication.new(slug: stringify(slug_value))
+      end
+
+      def build_publication_version(hash)
+        Identifiers::Publication.new(
+          slug:    stringify(hash[:slug]),
+          version: stringify(hash[:version]),
+        )
+      end
+
+      def stringify(value)
+        return nil if value.nil?
+
+        str = value.to_s
+        str.empty? ? nil : str
+      end
+    end
+  end
+end

--- a/lib/pubid/adobe/identifier.rb
+++ b/lib/pubid/adobe/identifier.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Adobe
+    # Base class for all Adobe identifiers. Canonical name
+    # Pubid::Adobe::Identifier; every concrete Adobe identifier
+    # (Identifiers::*) descends from it, and Identifiers::Base — aliased
+    # at the foot of identifiers/base.rb — points back to it.
+    #
+    # Adobe identifiers come in two shapes:
+    #
+    #   * TechNote    — `Adobe Technical Note #<number>` / `ATN<number>`
+    #                   e.g. `Adobe Technical Note #5014`, `ATN5014`.
+    #   * Publication — slug-keyed named specs that have no number
+    #                   e.g. `adobe-glyph-list`, `adobe-japan1-7`.
+    class Identifier < ::Pubid::Identifier
+      # Parse an Adobe identifier string into an identifier object.
+      # @param identifier [String]
+      # @return [Pubid::Adobe::Identifier]
+      # @raise [Parslet::ParseFailed] If parsing fails
+      def self.parse(identifier)
+        parsed = Parser.parse(identifier)
+        Builder.build(parsed)
+      rescue Parslet::ParseFailed => e
+        raise "Failed to parse Adobe identifier '#{identifier}': #{e.message}"
+      end
+
+      attribute :publisher, :string, default: "Adobe"
+
+      ADOBE_TYPE_MAP = {
+        "pubid:adobe:tech-note"   => "Pubid::Adobe::Identifiers::TechNote",
+        "pubid:adobe:publication" => "Pubid::Adobe::Identifiers::Publication",
+      }.freeze
+
+      key_value do
+        map "_type", to: :_type, polymorphic_map: ADOBE_TYPE_MAP
+      end
+
+      def to_urn
+        UrnGenerator.new(self).generate
+      end
+
+      # Short type code (e.g. "ATN", nil for Publication) — convenience
+      # accessor used by Renderer and UrnGenerator.
+      def type_short
+        self.class.type[:short]
+      end
+    end
+  end
+end

--- a/lib/pubid/adobe/identifiers.rb
+++ b/lib/pubid/adobe/identifiers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Adobe
+    module Identifiers
+      autoload :Base,        "#{__dir__}/identifiers/base"
+      autoload :TechNote,    "#{__dir__}/identifiers/tech_note"
+      autoload :Publication, "#{__dir__}/identifiers/publication"
+    end
+  end
+end

--- a/lib/pubid/adobe/identifiers/base.rb
+++ b/lib/pubid/adobe/identifiers/base.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Adobe
+    module Identifiers
+      # Backward-compatible alias: Adobe's base class is
+      # Pubid::Adobe::Identifier (defined in identifier.rb), loaded by
+      # the parent autoload. Identifiers::Base points back to it so the
+      # `Identifiers::*` namespace reads naturally.
+      Base = Pubid::Adobe::Identifier
+    end
+  end
+end

--- a/lib/pubid/adobe/identifiers/publication.rb
+++ b/lib/pubid/adobe/identifiers/publication.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Adobe
+    module Identifiers
+      # Adobe named publication. Slug-keyed specs that have no tech-note
+      # number — Adobe Glyph List, PostScript Language, character
+      # collections, etc.
+      #
+      # Surface forms:
+      #   * slug `adobe-glyph-list`, `adobe-postscript-language`
+      #   * versioned character collections: `adobe-japan1` + version `7`
+      #   * human render is the slug title-cased (`Adobe Glyph List`,
+      #     `Adobe-Japan1-7`); the full publication title lives in the
+      #     data repo's title attribute, not here.
+      class Publication < Base
+        attribute :slug,    :string   # "adobe-glyph-list", "adobe-japan1"
+        attribute :version, :string   # "7", "3", nil
+
+        key_value do
+          map "slug",    to: :slug
+          map "version", to: :version
+        end
+
+        def self.type
+          { key: :publication, title: "Publication", short: nil }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/adobe/identifiers/tech_note.rb
+++ b/lib/pubid/adobe/identifiers/tech_note.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Adobe
+    module Identifiers
+      # Adobe Technical Note. Numbered 4-digit (5xxx series observed).
+      #
+      # Surface forms:
+      #   * `Adobe Technical Note #5014` — formal citation form
+      #   * `ATN5014`                    — short alias used in Metanorma
+      #                                    anchor ids ([[atn5014,…]])
+      #   * filename `5014.CIDFont_Spec.pdf` (data repo splits filename
+      #     into number + slug before calling the parser)
+      #
+      # The optional `slug` carries the filename's title segment
+      # (`CIDFont_Spec`) so round-trip through the data repo is lossless.
+      class TechNote < Base
+        attribute :number, :string   # "5014", "5902"
+        attribute :slug,   :string   # "CIDFont_Spec", "AFM_Spec", nil
+
+        key_value do
+          map "number", to: :number
+          map "slug",   to: :slug
+        end
+
+        def self.type
+          { key: :"tech-note", title: "Technical Note", short: "ATN" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/adobe/parser.rb
+++ b/lib/pubid/adobe/parser.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "parslet"
+
+module Pubid
+  module Adobe
+    # Parslet grammar for Adobe identifiers.
+    #
+    # Canonical citation forms (what the renderer produces):
+    #
+    #   Adobe TN 5014                  (tech note; replaces the older
+    #                                    "Adobe Technical Note #5014")
+    #   Adobe Publication adobe-glyph-list
+    #   Adobe Publication adobe-japan1-7
+    #
+    # The parser also accepts these legacy forms for back-compat:
+    #
+    #   Adobe Technical Note #5014
+    #   Adobe Technical Note 5014
+    #   Adobe TN5014                   (no space)
+    #   ATN5014                        (short alias)
+    #   5014                           (bare number; data-repo context)
+    #   adobe-glyph-list               (bare slug)
+    class Parser < Parslet::Parser
+      include ::Pubid::Parser::CommonParseRules
+
+      root :identifier
+
+      rule(:space)  { str(" ") }
+      rule(:space?) { space.maybe }
+      rule(:hash)   { str("#") }
+      rule(:dot)    { str(".") }
+      rule(:dash)   { str("-") }
+
+      # Canonical short prefix: "Adobe TN" with optional trailing space.
+      # Matches both "Adobe TN 5014" and "Adobe TN5014".
+      rule(:tech_note_tn_prefix) do
+        str("Adobe") >> space >> str("TN") >> space?.maybe
+      end
+
+      # Legacy long prefix: "Adobe Technical Note" with optional "#".
+      rule(:tech_note_long_prefix) do
+        str("Adobe") >> space >> str("Technical") >> space >> str("Note") >>
+          (space? >> hash.maybe >> space?).maybe
+      end
+
+      # Legacy short alias: "ATN" with optional trailing space.
+      rule(:tech_note_atn_prefix) do
+        str("ATN") >> space?.maybe
+      end
+
+      rule(:tech_note_prefix) do
+        tech_note_tn_prefix | tech_note_long_prefix | tech_note_atn_prefix
+      end
+
+      rule(:digits) do
+        match("[0-9]").repeat(1)
+      end
+
+      # 4-digit tech note number, optionally followed by ".<Slug>" from
+      # the filename form. The slug is captured but not required.
+      rule(:slug_chars) do
+        match("[A-Za-z0-9_]").repeat(1)
+      end
+
+      rule(:tech_note) do
+        (tech_note_prefix >>
+          digits.as(:number) >>
+          (dot >> slug_chars.as(:slug)).maybe).as(:tech_note)
+      end
+
+      # Bare number form (e.g. when the data repo passes just "5014"
+      # extracted from a filename). Not advertised in user docs; used
+      # internally by AdobeFetcher::Docid.
+      rule(:bare_number) do
+        digits.as(:number).as(:tech_note_bare)
+      end
+
+      # "Adobe Publication " prefix. Matched literally then discarded —
+      # the publication slug/version is parsed by the inner rule.
+      rule(:publication_prefix) do
+        str("Adobe") >> space >> str("Publication") >> space
+      end
+
+      # Publication slug. Lowercase ASCII letters and digits joined by `-`.
+      # Each segment starts with a letter (so a trailing `-<digits>` is
+      # unambiguously a version suffix, not part of the slug).
+      rule(:slug_segment) do
+        match("[a-z]") >> match("[a-z0-9]").repeat
+      end
+
+      rule(:slug_inner) do
+        slug_segment >> (dash >> slug_segment).repeat
+      end
+
+      rule(:publication_with_version) do
+        (slug_inner.as(:slug) >> dash >> digits.as(:version)).as(:publication_version)
+      end
+
+      rule(:publication_slug_or_version) do
+        # Try with-version first so `adobe-japan1-7` doesn't get captured
+        # as slug `adobe-japan1-7` with no version. The flat `:slug` form
+        # is the fallback for unversioned slugs.
+        publication_with_version | slug_inner.as(:slug)
+      end
+
+      rule(:publication) do
+        # Optional "Adobe Publication " prefix. The prefix is consumed
+        # but not captured — the inner rule produces :slug or
+        # :publication_version as before.
+        publication_prefix.maybe >> publication_slug_or_version
+      end
+
+      rule(:identifier) do
+        tech_note | bare_number | publication
+      end
+
+      # Parse a string and return the raw parslet tree.
+      # @param string [String]
+      # @return [Hash]
+      def self.parse(string)
+        raise ArgumentError, ::Pubid::INPUT_TOO_LONG_MESSAGE if string.length > ::Pubid::MAX_INPUT_LENGTH
+
+        new.parse(string.strip)
+      end
+    end
+  end
+end

--- a/lib/pubid/adobe/renderer.rb
+++ b/lib/pubid/adobe/renderer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Adobe
+    # Human-readable renderer for Adobe identifiers.
+    #
+    # Produces the canonical citation forms:
+    #   "Adobe TN 5014"                       (tech note)
+    #   "Adobe Publication adobe-glyph-list"  (publication, slug)
+    #   "Adobe Publication adobe-japan1-7"    (publication, slug + version)
+    #
+    # The data repo (AdobeFetcher::Docid) overrides #to_s for publications
+    # to use the title from metadata instead of the slug, producing e.g.
+    # "Adobe Publication Adobe Glyph List". Pubid::Adobe itself is purely
+    # structural and renders slug-form citations.
+    class Renderer < ::Pubid::Renderers::Base
+      def render(context: nil, **_opts)
+        id = @id
+
+        return render_tech_note(id) if id.is_a?(Identifiers::TechNote)
+        return render_publication(id) if id.is_a?(Identifiers::Publication)
+
+        raise ArgumentError, "Unknown Adobe identifier class: #{id.class}"
+      end
+
+      private
+
+      def render_tech_note(id)
+        "Adobe TN #{id.number}"
+      end
+
+      def render_publication(id)
+        rendered = "Adobe Publication #{id.slug}"
+        rendered << "-#{id.version}" if id.version
+        rendered
+      end
+    end
+  end
+end

--- a/lib/pubid/adobe/urn_generator.rb
+++ b/lib/pubid/adobe/urn_generator.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Adobe
+    # Generates URN strings for Adobe identifiers.
+    #
+    # Format:
+    #   urn:adobe:tech-note:<number>            e.g. urn:adobe:tech-note:5014
+    #   urn:adobe:publication:<slug>[:v<ver>]   e.g. urn:adobe:publication:adobe-glyph-list
+    #                                             urn:adobe:publication:adobe-japan1:v7
+    class UrnGenerator
+      attr_reader :identifier
+
+      def initialize(identifier)
+        @identifier = identifier
+      end
+
+      def generate
+        if identifier.is_a?(Identifiers::TechNote)
+          generate_tech_note
+        elsif identifier.is_a?(Identifiers::Publication)
+          generate_publication
+        else
+          raise ArgumentError,
+                "Unknown Adobe identifier class: #{identifier.class}"
+        end
+      end
+
+      private
+
+      def generate_tech_note
+        "urn:adobe:tech-note:#{identifier.number}"
+      end
+
+      def generate_publication
+        parts = ["urn:adobe:publication", identifier.slug]
+        parts << "v#{identifier.version}" if identifier.version
+        parts.join(":")
+      end
+    end
+  end
+end

--- a/lib/pubid/adobe/urn_parser.rb
+++ b/lib/pubid/adobe/urn_parser.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Adobe
+    # Parses Adobe URNs back into identifiers.
+    #
+    # UrnGenerator emits:
+    #   urn:adobe:tech-note:<number>
+    #   urn:adobe:publication:<slug>[:v<version>]
+    #
+    # Examples:
+    #   urn:adobe:tech-note:5014                  → Adobe Technical Note #5014
+    #   urn:adobe:publication:adobe-glyph-list    → adobe-glyph-list
+    #   urn:adobe:publication:adobe-japan1:v7     → adobe-japan1-7
+    class UrnParser < Pubid::UrnParser::Base
+      PREFIX = "urn:adobe:".freeze
+
+      def parse_urn(urn)
+        body = strip_namespace(urn)
+        parts = split_parts(body)
+        namespace = parts.fetch(0)
+
+        case namespace
+        when "tech-note"
+          parse_tech_note(parts)
+        when "publication"
+          parse_publication(parts)
+        else
+          raise Pubid::UrnParser::Errors::ParseError,
+                "Unknown Adobe URN namespace: #{namespace.inspect} in #{urn.inspect}"
+        end
+      end
+
+      private
+
+      def strip_namespace(urn)
+        unless urn.downcase.start_with?(PREFIX)
+          raise Pubid::UrnParser::Errors::ParseError,
+                "Invalid Adobe URN: #{urn.inspect}"
+        end
+
+        urn[PREFIX.length..]
+      end
+
+      def parse_tech_note(parts)
+        number = parts.fetch(1)
+        flavor_parse("Adobe Technical Note ##{number}")
+      end
+
+      def parse_publication(parts)
+        slug = parts.fetch(1)
+        version_seg = parts[2]
+        if version_seg&.start_with?("v")
+          flavor_parse("#{slug}-#{version_seg.sub(/\Av/, "")}")
+        else
+          flavor_parse(slug)
+        end
+      end
+
+      def split_parts(body)
+        body.split(":")
+      end
+
+      def flavor_parse(text)
+        ::Pubid::Adobe.parse(text)
+      end
+    end
+  end
+end

--- a/spec/pubid/adobe/identifier_spec.rb
+++ b/spec/pubid/adobe/identifier_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pubid/adobe"
+
+RSpec.describe Pubid::Adobe::Identifier do
+  describe ".parse" do
+    {
+      # TechNote — canonical "Adobe TN" form (preferred going forward).
+      "Adobe TN 5014"              => "Adobe TN 5014",
+      "Adobe TN5014"               => "Adobe TN 5014",
+      "Adobe TN 5902"              => "Adobe TN 5902",
+      # TechNote — legacy forms, still accepted for back-compat.
+      "Adobe Technical Note #5014" => "Adobe TN 5014",
+      "Adobe Technical Note 5014"  => "Adobe TN 5014",
+      "ATN5014"                    => "Adobe TN 5014",
+      # Publication — canonical "Adobe Publication <slug>" form.
+      "Adobe Publication adobe-glyph-list"          => "Adobe Publication adobe-glyph-list",
+      "Adobe Publication adobe-japan1-7"            => "Adobe Publication adobe-japan1-7",
+      "Adobe Publication adobe-postscript-language" => "Adobe Publication adobe-postscript-language",
+      # Publication — bare slug form (back-compat).
+      "adobe-glyph-list"           => "Adobe Publication adobe-glyph-list",
+      "adobe-japan1-7"             => "Adobe Publication adobe-japan1-7",
+    }.each do |input, canonical|
+      it "parses #{input.inspect} → #{canonical.inspect}" do
+        expect(Pubid::Adobe.parse(input).to_s).to eq(canonical)
+      end
+    end
+
+    it "routes TechNote forms to Identifiers::TechNote" do
+      expect(Pubid::Adobe.parse("Adobe TN 5014"))
+        .to be_a(Pubid::Adobe::Identifiers::TechNote)
+      expect(Pubid::Adobe.parse("ATN5014"))
+        .to be_a(Pubid::Adobe::Identifiers::TechNote)
+    end
+
+    it "routes slug forms to Identifiers::Publication" do
+      expect(Pubid::Adobe.parse("adobe-glyph-list"))
+        .to be_a(Pubid::Adobe::Identifiers::Publication)
+      expect(Pubid::Adobe.parse("Adobe Publication adobe-glyph-list"))
+        .to be_a(Pubid::Adobe::Identifiers::Publication)
+    end
+
+    it "captures the tech-note number" do
+      expect(Pubid::Adobe.parse("Adobe TN 5014").number).to eq("5014")
+    end
+
+    it "captures the publication slug" do
+      expect(Pubid::Adobe.parse("Adobe Publication adobe-glyph-list").slug)
+        .to eq("adobe-glyph-list")
+    end
+
+    it "splits slug-version into separate attributes" do
+      pub = Pubid::Adobe.parse("Adobe Publication adobe-japan1-7")
+      expect(pub.slug).to eq("adobe-japan1")
+      expect(pub.version).to eq("7")
+    end
+
+    it "raises on unparseable input" do
+      expect { Pubid::Adobe.parse("XYZ123-BAD!!!") }.to raise_error(StandardError)
+    end
+  end
+
+  describe "#to_urn" do
+    {
+      "Adobe TN 5014"                             => "urn:adobe:tech-note:5014",
+      "ATN5902"                                   => "urn:adobe:tech-note:5902",
+      "Adobe Publication adobe-glyph-list"        => "urn:adobe:publication:adobe-glyph-list",
+      "Adobe Publication adobe-japan1-7"          => "urn:adobe:publication:adobe-japan1:v7",
+    }.each do |input, urn|
+      it "renders #{input.inspect} as #{urn.inspect}" do
+        expect(Pubid::Adobe.parse(input).to_urn).to eq(urn)
+      end
+    end
+  end
+
+  describe "URN round-trip" do
+    %w[
+      urn:adobe:tech-note:5014
+      urn:adobe:tech-note:5902
+      urn:adobe:publication:adobe-glyph-list
+      urn:adobe:publication:adobe-japan1:v7
+    ].each do |urn|
+      it "round-trips #{urn.inspect} through the parser" do
+        id = Pubid::Adobe::UrnParser.parse(urn)
+        expect(id.to_urn).to eq(urn)
+      end
+    end
+  end
+
+  describe "polymorphic round-trip via to_hash / from_hash" do
+    %w[
+      Adobe\ TN\ 5014
+      ATN5902
+      Adobe\ Publication\ adobe-glyph-list
+      Adobe\ Publication\ adobe-japan1-7
+    ].each do |code|
+      it "round-trips #{code.inspect}" do
+        id = Pubid::Adobe.parse(code)
+        restored = Pubid::Adobe::Identifier.from_hash(id.to_hash)
+        expect(restored.to_s).to eq(id.to_s)
+        expect(restored.class).to eq(id.class)
+      end
+    end
+  end
+
+  describe "Pubid.prefixes" do
+    it "includes Adobe and ATN tokens" do
+      expect(Pubid.prefixes(:adobe)).to include("Adobe", "ATN")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Re-applies the `Pubid::Adobe` flavor on `main`. The original commit
(`0e9dee2d`) landed on `rt-new-lutaml-model` via #107 but never made it
across when the maintainer consolidated `rt-new-lutaml-model` → `main`.
`git ls-tree -r origin/main --name-only | grep adobe` returns nothing
on main today.

This is a clean cherry-pick of `0e9dee2d` onto current `main` (post-OGC,
post-IEEE fixes). No code changes — just re-landing the Adobe files.

## Files

- `lib/pubid.rb` — one autoload entry for `Pubid::Adobe`
- `lib/pubid/adobe.rb` — module + Registry.register
- `lib/pubid/adobe/{identifier,identifiers/{base,tech_note,publication},parser,builder,renderer,urn_generator,urn_parser}.rb`
- `spec/pubid/adobe/identifier_spec.rb` — 30 examples

## Test plan

- [x] `bundle exec rspec spec/pubid/adobe/` — 30 examples, 0 failures
- [x] `Pubid::Adobe.parse("Adobe TN 5014").to_s` → `"Adobe TN 5014"`
- [x] `Pubid::Adobe.parse("ATN5902").to_s` → `"Adobe TN 5902"`
- [x] `Pubid.prefixes(:adobe)` includes `"Adobe"` and `"ATN"`

## Refs

- Re-lands #107 (merged into `rt-new-lutaml-model`, never propagated to `main`)
- Tracks relaton/relaton#39