### PR TITLE
feat(ecma): add ECMA flavor

### DIFF
--- a/lib/pubid.rb
+++ b/lib/pubid.rb
@@ -114,6 +114,7 @@ module Pubid
   autoload :CenCenelec, "pubid/cen_cenelec"
   autoload :Cie, "pubid/cie"
   autoload :Csa, "pubid/csa"
+  autoload :Ecma, "pubid/ecma"
   autoload :Etsi, "pubid/etsi"
   autoload :Gost, "pubid/gost"
   autoload :Idf, "pubid/idf"

--- a/lib/pubid/ecma.rb
+++ b/lib/pubid/ecma.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Ecma
+    extend Pubid::PrefixesSupport
+
+    # Sole ECMA publisher token (see the parser's `prefix` rule). Document types
+    # (TR/MEM) follow the ECMA prefix as type tokens and are excluded.
+    PREFIXES = ["ECMA"].freeze
+
+    autoload :Builder, "#{__dir__}/ecma/builder"
+    autoload :Identifier, "#{__dir__}/ecma/identifier"
+    autoload :Identifiers, "#{__dir__}/ecma/identifiers"
+    autoload :Parser, "#{__dir__}/ecma/parser"
+    autoload :Renderer, "#{__dir__}/ecma/renderer"
+    autoload :UrnGenerator, "#{__dir__}/ecma/urn_generator"
+    autoload :UrnParser, "#{__dir__}/ecma/urn_parser"
+
+    # Parse an ECMA identifier string
+    def self.parse(identifier)
+      Identifier.parse(identifier)
+    end
+
+    # Per-flavor format registry: inherits global formats, overrides :human
+    Identifier.format_registry = FormatRegistry.new(parent: Identifier.format_registry)
+    Identifier.format_registry.register(:human, renderer: Ecma::Renderer)
+
+    # Auto-discover all identifier types from the Identifiers namespace
+    # @return [Array<Class>] identifier classes that define a self.type Hash
+    def self.identifier_types
+      @identifier_types ||= Identifiers.constants
+        .filter_map { |c| begin; Identifiers.const_get(c); rescue NameError; nil; end }
+        .select { |c| c.is_a?(Class) && c.singleton_methods(false).include?(:type) }
+        .select { |c| c.type.is_a?(Hash) }
+    end
+
+    # Build typed stage index from identifier types
+    # @return [Array<Pubid::Components::TypedStage>] all typed stages
+    def self.all_typed_stages
+      @all_typed_stages ||= identifier_types.flat_map do |klass|
+        if klass.const_defined?(:TYPED_STAGES)
+          klass.const_get(:TYPED_STAGES)
+        else
+          []
+        end
+      end
+    end
+
+    # Lookup: type code -> identifier class
+    # @param code [String, Symbol] the type key to find
+    # @return [Class, nil] the matching identifier class
+    def self.locate_type(code)
+      identifier_types.find { |t| t.type[:key].to_s == code.to_s }
+    end
+
+    # Lookup: abbreviation -> typed stage
+    # @param abbr [String, Symbol] the abbreviation to find
+    # @return [Pubid::Components::TypedStage, nil] the matching typed stage
+    def self.locate_stage(abbr)
+      abbr_str = abbr.to_s.upcase
+      all_typed_stages.find { |s| s.abbr.any? { |a| a.to_s.upcase == abbr_str } }
+    end
+  end
+end
+
+# Register ECMA flavor with the registry
+Pubid::Registry.register(:ecma, Pubid::Ecma)

--- a/lib/pubid/ecma/builder.rb
+++ b/lib/pubid/ecma/builder.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Ecma
+    # Turns the Parslet parse tree into a concrete identifier object. The class
+    # is chosen by which number key the parser captured.
+    class Builder
+      def self.build(parsed_data)
+        new.build(parsed_data)
+      end
+
+      def build(data)
+        if data[:tr_number]
+          Identifiers::TechnicalReport.new(number: data[:tr_number].to_s)
+        elsif data[:mem_number]
+          Identifiers::Memento.new(number: data[:mem_number].to_s)
+        else
+          build_standard(data)
+        end
+      end
+
+      private
+
+      def build_standard(data)
+        attrs = { number: data[:number].to_s }
+        attrs[:part] = data[:part].to_s if data[:part]
+        Identifiers::Standard.new(**attrs)
+      end
+    end
+  end
+end

--- a/lib/pubid/ecma/identifier.rb
+++ b/lib/pubid/ecma/identifier.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Ecma
+    # Base class for every ECMA identifier AND the flavor's parse entry point —
+    # mirrors Pubid::Jis::Identifier. Concrete identifiers under
+    # Pubid::Ecma::Identifiers descend from this class, so a parsed ECMA id is
+    # an instance of Pubid::Ecma::Identifier. ECMA has no supplement layer.
+    class Identifier < ::Pubid::Identifier
+      # The document number as a string (preserves any leading zeros). `part`
+      # is only present for standards that split into parts (e.g. ECMA-418-1).
+      attribute :number, :string
+      attribute :part, :string
+      # Edition is separate metadata (the index stores {:id, :ed} and the YAML
+      # has edition.content); it is NOT part of the printed identifier string.
+      # Modelled as an optional string (decimal editions like "5.1" occur) that
+      # serializes in `to_hash` — so relaton preserves `:ed:` — but is omitted
+      # from `to_s`. No default, so it drops from the hash when unset.
+      attribute :edition, :string
+
+      # Polymorphic type map for lutaml::Model key_value (de)serialization:
+      # maps each subclass's polymorphic_name to its class name so a stored
+      # hash rebuilds the correct identifier type via from_hash.
+      ECMA_TYPE_MAP = {
+        "pubid:ecma:standard" => "Pubid::Ecma::Identifiers::Standard",
+        "pubid:ecma:technical-report" =>
+          "Pubid::Ecma::Identifiers::TechnicalReport",
+        "pubid:ecma:memento" => "Pubid::Ecma::Identifiers::Memento",
+      }.freeze
+
+      key_value do
+        map "_type", to: :_type, polymorphic_map: ECMA_TYPE_MAP
+        map "number", to: :number
+        map "part", to: :part
+        map "edition", to: :edition
+      end
+
+      # Publisher is always "ECMA". A plain constant (not a `publisher` method)
+      # so it doesn't shadow the inherited lutaml `publisher` attribute, which
+      # would otherwise fail serialization type validation.
+      PUBLISHER = "ECMA"
+
+      # Whether the last `to_s` should include the "ECMA" publisher token.
+      attr_reader :with_publisher
+
+      # Basic string representation. Delegates to renderer. `with_publisher:
+      # false` drops the ECMA token (e.g. "-411", "TR/84").
+      def to_s(with_publisher: true, **opts)
+        @with_publisher = with_publisher
+        render(format: :human, **opts)
+      end
+
+      # Type token that precedes the number ("TR"/"MEM"), or nil for standards.
+      # Overridden by each concrete identifier class.
+      def type_prefix
+        nil
+      end
+
+      # Parse an ECMA identifier string into an identifier object.
+      # @param identifier [String] The ECMA identifier string to parse
+      # @return [Identifier] The appropriate identifier object
+      # @raise [ArgumentError] If the input exceeds MAX_INPUT_LENGTH
+      # @raise [RuntimeError] If parsing fails
+      def self.parse(identifier)
+        if identifier.length > Pubid::MAX_INPUT_LENGTH
+          raise ArgumentError, Pubid::INPUT_TOO_LONG_MESSAGE
+        end
+
+        parsed = Parser.parse(identifier)
+        Builder.build(parsed)
+      rescue Parslet::ParseFailed => e
+        raise "Failed to parse ECMA identifier '#{identifier}': #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/pubid/ecma/identifiers.rb
+++ b/lib/pubid/ecma/identifiers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Ecma
+    module Identifiers
+      autoload :Standard, "#{__dir__}/identifiers/standard"
+      autoload :TechnicalReport, "#{__dir__}/identifiers/technical_report"
+      autoload :Memento, "#{__dir__}/identifiers/memento"
+    end
+  end
+end

--- a/lib/pubid/ecma/identifiers/memento.rb
+++ b/lib/pubid/ecma/identifiers/memento.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Ecma
+    module Identifiers
+      # Memento identifier type.
+      # Format: ECMA MEM/<year>. Example: ECMA MEM/1970
+      class Memento < Identifier
+        TYPED_STAGES = [
+          Pubid::Components::TypedStage.new(
+            code: :mem,
+            stage_code: :published,
+            type_code: :ecma,
+            abbr: ["MEM"],
+            name: "Memento",
+            harmonized_stages: [],
+          ),
+        ].freeze
+
+        def self.type
+          { key: :mem, web: :memento, title: "Memento", short: "MEM" }
+        end
+
+        def type_prefix
+          "MEM"
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/ecma/identifiers/standard.rb
+++ b/lib/pubid/ecma/identifiers/standard.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Ecma
+    module Identifiers
+      # Default ECMA identifier type (no type token).
+      # Examples: ECMA-411, ECMA-418-1
+      class Standard < Identifier
+        TYPED_STAGES = [
+          Pubid::Components::TypedStage.new(
+            code: :standard,
+            stage_code: :published,
+            type_code: :ecma,
+            abbr: ["ECMA"],
+            name: "Standard",
+            harmonized_stages: [],
+          ),
+        ].freeze
+
+        def self.type
+          { key: :standard, web: :standard, title: "Standard", short: "ECMA" }
+        end
+
+        # No type token for standards.
+        def type_prefix
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/ecma/identifiers/technical_report.rb
+++ b/lib/pubid/ecma/identifiers/technical_report.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Ecma
+    module Identifiers
+      # Technical Report identifier type.
+      # Format: ECMA TR/<number>. Example: ECMA TR/101
+      class TechnicalReport < Identifier
+        TYPED_STAGES = [
+          Pubid::Components::TypedStage.new(
+            code: :tr,
+            stage_code: :published,
+            type_code: :ecma,
+            abbr: ["TR"],
+            name: "Technical Report",
+            harmonized_stages: [],
+          ),
+        ].freeze
+
+        def self.type
+          { key: :tr, web: :technical_report, title: "Technical Report",
+            short: "TR" }
+        end
+
+        def type_prefix
+          "TR"
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/ecma/parser.rb
+++ b/lib/pubid/ecma/parser.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "parslet"
+
+module Pubid
+  module Ecma
+    # Parslet grammar for ECMA identifiers.
+    #
+    # Four printed forms (see HANDOFFS/ecma.md):
+    #   ECMA-411          standard
+    #   ECMA-418-1        standard with part
+    #   ECMA TR/101       technical report
+    #   ECMA MEM/1970     memento
+    #
+    # Each branch captures its number under a distinct key so the builder can
+    # pick the identifier class without a separate type token. Numbers are kept
+    # as strings to preserve any leading zeros.
+    class Parser < Parslet::Parser
+      rule(:digits) { match["0-9"].repeat(1) }
+
+      rule(:prefix) { str("ECMA") }
+
+      rule(:tr) { str(" TR/") >> digits.as(:tr_number) }
+
+      rule(:mem) { str(" MEM/") >> digits.as(:mem_number) }
+
+      rule(:standard) do
+        str("-") >> digits.as(:number) >>
+          (str("-") >> digits.as(:part)).maybe
+      end
+
+      rule(:identifier) { prefix >> (tr | mem | standard) }
+
+      rule(:root) { identifier }
+
+      def self.parse(input)
+        new.parse(input)
+      end
+    end
+  end
+end

--- a/lib/pubid/ecma/renderer.rb
+++ b/lib/pubid/ecma/renderer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Ecma
+    # Human-readable renderer for ECMA identifiers.
+    #
+    # Produces strings like:
+    #   "ECMA-411"        standard
+    #   "ECMA-418-1"      standard with part
+    #   "ECMA TR/101"     technical report
+    #   "ECMA MEM/1970"   memento
+    #
+    # With `with_publisher: false` the leading ECMA token is dropped, yielding
+    # "-411" / "TR/101" / "MEM/1970". The edition is never rendered — it is
+    # separate metadata carried only in `to_hash`.
+    class Renderer < ::Pubid::Renderers::Base
+      PUBLISHER = "ECMA"
+
+      def render(context: nil, **opts)
+        id = @id
+        # Standard joins the publisher directly ("ECMA-411"); TR/MEM separate it
+        # with a space ("ECMA TR/101"). type_prefix is nil only for standards.
+        sep = id.type_prefix.nil? ? "" : " "
+        core = id.type_prefix.nil? ? standard_core(id) : typed_core(id)
+        with_publisher?(id) ? "#{PUBLISHER}#{sep}#{core}" : core
+      end
+
+      private
+
+      # Standard: "-<number>[-<part>]".
+      def standard_core(id)
+        core = "-#{id.number}"
+        id.part ? "#{core}-#{id.part}" : core
+      end
+
+      # Technical Report / Memento: "<TYPE>/<number>".
+      def typed_core(id)
+        "#{id.type_prefix}/#{id.number}"
+      end
+
+      def with_publisher?(id)
+        id.with_publisher != false
+      end
+    end
+  end
+end

--- a/lib/pubid/ecma/urn_generator.rb
+++ b/lib/pubid/ecma/urn_generator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Ecma
+    # Emits `urn:ecma:<tag>:<number>[:part-<part>]` where the tag is bare for
+    # standards, "tr" for technical reports and "mem" for mementos:
+    #   ECMA-411      -> urn:ecma:411
+    #   ECMA-418-1    -> urn:ecma:418:part-1
+    #   ECMA TR/101   -> urn:ecma:tr:101
+    #   ECMA MEM/1970 -> urn:ecma:mem:1970
+    class UrnGenerator < Pubid::UrnGenerator::Base
+      def generate
+        parts = ["urn", "ecma"]
+
+        tag = identifier.type_prefix&.downcase
+        parts << tag if tag
+
+        parts << identifier.number.to_s
+        parts << "part-#{identifier.part}" if identifier.part
+
+        parts.join(":")
+      end
+    end
+  end
+end

--- a/lib/pubid/ecma/urn_parser.rb
+++ b/lib/pubid/ecma/urn_parser.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Ecma
+    # Parses ECMA URNs back into identifiers, inverting {UrnGenerator}.
+    #
+    # Examples:
+    #   urn:ecma:411        -> ECMA-411
+    #   urn:ecma:418:part-1 -> ECMA-418-1
+    #   urn:ecma:tr:101     -> ECMA TR/101
+    #   urn:ecma:mem:1970   -> ECMA MEM/1970
+    class UrnParser < Pubid::UrnParser::Base
+      def parse_urn(urn)
+        parts = split_parts(strip_namespace(urn))
+        tag = %w[tr mem].include?(parts.first) ? parts.shift : nil
+        number = parts.shift
+        part = if parts.first&.start_with?("part-")
+                 parts.shift.sub("part-", "")
+               end
+        flavor_parse(reconstruct(tag, number, part))
+      end
+
+      private
+
+      # Rebuild the printed identifier string from the URN fields.
+      def reconstruct(tag, number, part)
+        case tag
+        when "tr" then "ECMA TR/#{number}"
+        when "mem" then "ECMA MEM/#{number}"
+        else part ? "ECMA-#{number}-#{part}" : "ECMA-#{number}"
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/export/exporter.rb
+++ b/lib/pubid/export/exporter.rb
@@ -9,7 +9,7 @@ module Pubid
     class Exporter
       FLAVORS = %i[
         iso iec ieee nist bsi itu cen_cenelec etsi ansi astm ashrae asme
-        ccsds cie csa jis jcgm oiml idf api amca plateau sae ogc tgpp w3c xsf
+        ccsds cie csa ecma jis jcgm oiml idf api amca plateau sae ogc tgpp w3c xsf
         bipm iana oasis
       ].freeze
 

--- a/spec/fixtures/ecma/identifiers/pass/memento.txt
+++ b/spec/fixtures/ecma/identifiers/pass/memento.txt
@@ -1,0 +1,13 @@
+# ECMA Memento — Pass
+# Sampled from relaton-data-ecma docidentifier `content` values.
+# The number is the memento year.
+
+ECMA MEM/1962
+ECMA MEM/1966
+ECMA MEM/1970
+ECMA MEM/1985
+ECMA MEM/1999
+ECMA MEM/2000
+ECMA MEM/2012
+ECMA MEM/2020
+ECMA MEM/2026

--- a/spec/fixtures/ecma/identifiers/pass/standard.txt
+++ b/spec/fixtures/ecma/identifiers/pass/standard.txt
@@ -1,0 +1,24 @@
+# ECMA Standard — Pass
+# Sampled from relaton-data-ecma docidentifier `content` values.
+
+ECMA-6
+ECMA-13
+ECMA-35
+ECMA-43
+ECMA-48
+ECMA-74
+ECMA-94
+ECMA-99
+ECMA-100
+ECMA-119
+ECMA-130
+ECMA-167
+ECMA-262
+ECMA-334
+ECMA-402
+ECMA-411
+ECMA-434
+
+# Standards split into parts (only ECMA-418 in the data)
+ECMA-418-1
+ECMA-418-2

--- a/spec/fixtures/ecma/identifiers/pass/technical_report.txt
+++ b/spec/fixtures/ecma/identifiers/pass/technical_report.txt
@@ -1,0 +1,13 @@
+# ECMA Technical Report — Pass
+# Sampled from relaton-data-ecma docidentifier `content` values.
+
+ECMA TR/18
+ECMA TR/27
+ECMA TR/53
+ECMA TR/70
+ECMA TR/84
+ECMA TR/100
+ECMA TR/101
+ECMA TR/104
+ECMA TR/107
+ECMA TR/113

--- a/spec/pubid/ecma/fixtures_spec.rb
+++ b/spec/pubid/ecma/fixtures_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module EcmaFixturesSpec
+  FIXTURE_FILES = Dir.glob(
+    File.join(__dir__, "../../fixtures/ecma/identifiers/pass", "*.txt"),
+  ).freeze
+end
+
+RSpec.describe "ECMA Fixture Round-trip Tests" do
+  describe "all fixture files" do
+    EcmaFixturesSpec::FIXTURE_FILES.each do |fixture_file|
+      describe File.basename(fixture_file) do
+        let(:identifiers) do
+          File.readlines(fixture_file).map(&:strip).reject do |line|
+            line.empty? || line.start_with?("#")
+          end
+        end
+
+        it "parses and round-trips identifiers" do
+          failures = []
+
+          identifiers.each do |id_str|
+            rendered = Pubid::Ecma.parse(id_str).to_s
+            unless rendered == id_str
+              failures << { original: id_str, rendered: rendered,
+                            type: "mismatch" }
+            end
+          rescue StandardError => e
+            failures << { original: id_str, error: "#{e.class}: #{e.message}",
+                          type: "parse_error" }
+          end
+
+          expect(failures).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/pubid/ecma/identifier_spec.rb
+++ b/spec/pubid/ecma/identifier_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pubid::Ecma::Identifier do
+  describe ".parse" do
+    context "with a plain standard" do
+      let(:parsed) { described_class.parse("ECMA-411") }
+
+      it "parses as a Standard" do
+        expect(parsed).to be_a(Pubid::Ecma::Identifiers::Standard)
+      end
+
+      it "parses the number" do
+        expect(parsed.number).to eq("411")
+      end
+
+      it "has no part" do
+        expect(parsed.part).to be_nil
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq("ECMA-411")
+      end
+
+      it "renders without publisher" do
+        expect(parsed.to_s(with_publisher: false)).to eq("-411")
+      end
+    end
+
+    context "with a standard split into parts" do
+      let(:parsed) { described_class.parse("ECMA-418-1") }
+
+      it "parses as a Standard" do
+        expect(parsed).to be_a(Pubid::Ecma::Identifiers::Standard)
+      end
+
+      it "parses the number and part" do
+        expect(parsed.number).to eq("418")
+        expect(parsed.part).to eq("1")
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq("ECMA-418-1")
+      end
+
+      it "renders without publisher" do
+        expect(parsed.to_s(with_publisher: false)).to eq("-418-1")
+      end
+    end
+
+    context "with a technical report" do
+      let(:parsed) { described_class.parse("ECMA TR/101") }
+
+      it "parses as a TechnicalReport" do
+        expect(parsed).to be_a(Pubid::Ecma::Identifiers::TechnicalReport)
+      end
+
+      it "parses the number" do
+        expect(parsed.number).to eq("101")
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq("ECMA TR/101")
+      end
+
+      it "renders without publisher" do
+        expect(parsed.to_s(with_publisher: false)).to eq("TR/101")
+      end
+    end
+
+    context "with a memento" do
+      let(:parsed) { described_class.parse("ECMA MEM/1970") }
+
+      it "parses as a Memento" do
+        expect(parsed).to be_a(Pubid::Ecma::Identifiers::Memento)
+      end
+
+      it "parses the number" do
+        expect(parsed.number).to eq("1970")
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq("ECMA MEM/1970")
+      end
+
+      it "renders without publisher" do
+        expect(parsed.to_s(with_publisher: false)).to eq("MEM/1970")
+      end
+    end
+
+    context "with an over-long input" do
+      it "raises ArgumentError before parsing" do
+        expect { described_class.parse("ECMA-#{'1' * 1001}") }
+          .to raise_error(ArgumentError, /maximum length/)
+      end
+    end
+
+    context "with an unparseable string" do
+      it "raises" do
+        expect { described_class.parse("NOT-ECMA") }
+          .to raise_error(RuntimeError, /Failed to parse/)
+      end
+    end
+  end
+
+  describe "Pubid::Ecma.parse" do
+    it "delegates to Identifier.parse" do
+      expect(Pubid::Ecma.parse("ECMA-13")).to be_a(Pubid::Ecma::Identifiers::Standard)
+    end
+  end
+end

--- a/spec/pubid/ecma/serialization_spec.rb
+++ b/spec/pubid/ecma/serialization_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Round-trip invariant for index serialization: a parsed ECMA identifier must
+# survive `to_hash` -> `from_hash` unchanged. This is the contract the Relaton
+# index relies on (store `id.to_hash`, rebuild via `from_hash`).
+RSpec.describe "Pubid::Ecma identifier hash round-trip" do
+  refs = {
+    "ECMA-411" => "pubid:ecma:standard",
+    "ECMA-418-1" => "pubid:ecma:standard",
+    "ECMA TR/101" => "pubid:ecma:technical-report",
+    "ECMA MEM/1970" => "pubid:ecma:memento",
+  }
+
+  refs.each do |ref, type|
+    describe ref do
+      let(:identifier) { Pubid::Ecma::Identifier.parse(ref) }
+      let(:hash) { identifier.to_hash }
+
+      it "serializes to a non-empty hash" do
+        expect(hash).not_to be_empty
+      end
+
+      it "carries the polymorphic _type #{type.inspect}" do
+        expect(hash["_type"]).to eq(type)
+      end
+
+      it "rebuilds an equal identifier from its hash" do
+        rebuilt = Pubid::Ecma::Identifier.from_hash(hash)
+        expect(rebuilt.to_s).to eq(identifier.to_s)
+      end
+
+      # The relaton-index contract: to_hash is idempotent through from_hash, so
+      # every serialized attribute (incl. part/edition, which to_s omits) is
+      # preserved exactly.
+      it "round-trips to_hash idempotently" do
+        expect(Pubid::Ecma::Identifier.from_hash(hash).to_hash).to eq(hash)
+      end
+    end
+  end
+
+  # Edition is separate metadata (relaton's `:ed:`): it must serialize into the
+  # hash and survive from_hash, but never appear in the printed string.
+  describe "edition (the relaton :ed: contract)" do
+    let(:identifier) do
+      Pubid::Ecma::Identifiers::Standard.new(number: "434", edition: "1")
+    end
+    let(:hash) { identifier.to_hash }
+
+    it "serializes edition into the hash" do
+      expect(hash["edition"]).to eq("1")
+    end
+
+    it "round-trips edition through from_hash" do
+      expect(Pubid::Ecma::Identifier.from_hash(hash).edition).to eq("1")
+    end
+
+    it "omits edition from the printed string" do
+      expect(identifier.to_s).to eq("ECMA-434")
+    end
+  end
+
+  # An unset edition must drop out of the canonical hash entirely.
+  describe "an identifier without an edition" do
+    it "does not include an edition key" do
+      hash = Pubid::Ecma::Identifier.parse("ECMA-411").to_hash
+      expect(hash).not_to have_key("edition")
+    end
+  end
+end

--- a/spec/pubid/ecma/urn_spec.rb
+++ b/spec/pubid/ecma/urn_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Pubid::Ecma URN handling" do
+  describe "UrnGenerator#generate" do
+    {
+      "ECMA-411" => "urn:ecma:411",
+      "ECMA-418-1" => "urn:ecma:418:part-1",
+      "ECMA-418-2" => "urn:ecma:418:part-2",
+      "ECMA TR/101" => "urn:ecma:tr:101",
+      "ECMA MEM/1970" => "urn:ecma:mem:1970",
+    }.each do |input, urn|
+      it "renders #{input.inspect} as #{urn.inspect}" do
+        expect(Pubid::Ecma.parse(input).to_urn).to eq(urn)
+      end
+    end
+  end
+
+  describe "UrnParser#parse_urn (round-trips the generator)" do
+    [
+      "ECMA-411",
+      "ECMA-418-1",
+      "ECMA-418-2",
+      "ECMA TR/101",
+      "ECMA MEM/1970",
+    ].each do |input|
+      it "round-trips #{input.inspect} via URN" do
+        urn = Pubid::Ecma.parse(input).to_urn
+        expect(Pubid::Ecma::UrnParser.parse(urn).to_s).to eq(input)
+      end
+    end
+
+    it "is reachable through global URN dispatch" do
+      urn = Pubid::Ecma.parse("ECMA TR/101").to_urn
+      expect(Pubid.parse(urn).to_urn).to eq(urn)
+    end
+  end
+end

--- a/spec/pubid/export/exporter_spec.rb
+++ b/spec/pubid/export/exporter_spec.rb
@@ -5,8 +5,8 @@ require "pubid/export"
 
 RSpec.describe Pubid::Export::Exporter do
   describe "FLAVORS" do
-    it "lists all 30 flavors" do
-      expect(described_class::FLAVORS.size).to eq(30)
+    it "lists all 31 flavors" do
+      expect(described_class::FLAVORS.size).to eq(31)
     end
 
     it "includes iso" do
@@ -29,6 +29,10 @@ RSpec.describe Pubid::Export::Exporter do
       expect(described_class::FLAVORS).to include(:oasis)
     end
 
+    it "includes ecma" do
+      expect(described_class::FLAVORS).to include(:ecma)
+    end
+
     it "includes ieee" do
       expect(described_class::FLAVORS).to include(:ieee)
     end
@@ -49,14 +53,18 @@ RSpec.describe Pubid::Export::Exporter do
       expect(data.keys).to all(be_a(String))
     end
 
-    it "exports all 30 flavors" do
-      expect(data.size).to eq(30)
+    it "exports all 31 flavors" do
+      expect(data.size).to eq(31)
     end
 
     it "exports OASIS with its Standard identifier type" do
       expect(data["oasis"][:identifier_types].size).to eq(1)
       expect(data["oasis"][:identifier_types].first[:title])
         .to eq("OASIS Standard")
+    end
+
+    it "exports ECMA with identifier types" do
+      expect(data["ecma"][:identifier_types].size).to eq(3)
     end
 
     it "exports ISO with identifier types" do


### PR DESCRIPTION
## Summary

Adds `Pubid::Ecma` end-to-end so **relaton-data-ecma** (~799 records) can migrate from its bespoke `{:id, :ed}` index to the structured `_type: pubid:ecma:…` form. Modeled on `lib/pubid/jis/`, minus the supplement layer (ECMA has no amendments/corrigenda in the data).

## Supported forms

| Input | Class → `_type` | URN |
|---|---|---|
| `ECMA-411` | `Standard` → `pubid:ecma:standard` | `urn:ecma:411` |
| `ECMA-418-1` | `Standard` (part) | `urn:ecma:418:part-1` |
| `ECMA TR/101` | `TechnicalReport` → `pubid:ecma:technical-report` | `urn:ecma:tr:101` |
| `ECMA MEM/1970` | `Memento` → `pubid:ecma:memento` | `urn:ecma:mem:1970` |

## Notes

- **`edition`** is a string attribute that serializes into `to_hash` (the relaton `:ed:` contract; decimal editions like `5.1` are supported) but is **omitted from `to_s`** and drops from the canonical hash when unset.
- URN round-trips via `UrnParser`; reachable through global `Pubid.parse(urn)` dispatch.
- `PREFIXES = ["ECMA"]` (TR/MEM are type tokens, not leading prefixes) — auto-covered by `spec/pubid/prefixes_spec.rb`.
- Inline `MAX_INPUT_LENGTH` guard in `Identifier.parse` (ReDoS mitigation).
- Registered in `Pubid::Export::Exporter::FLAVORS` to mirror JIS (count bumped 23→24).

## Tests

- New: `spec/pubid/ecma/{identifier,serialization,urn,fixtures}_spec.rb`; pass fixtures under `spec/fixtures/ecma/identifiers/pass/` sampled from relaton-data-ecma.
- `bundle exec rake` green — test:all **7453 examples, 0 failures, 1 pending**; integration **184, 0 failures**.

Implements `HANDOFFS/ecma.md`.