### PR TITLE
feat(jcgm): add committee/meeting identifier type

### DIFF
--- a/lib/pubid/jcgm/identifiers.rb
+++ b/lib/pubid/jcgm/identifiers.rb
@@ -6,6 +6,7 @@ module Pubid
       autoload :Amendment, "#{__dir__}/identifiers/amendment"
       autoload :Guide, "#{__dir__}/identifiers/guide"
       autoload :GumGuide, "#{__dir__}/identifiers/gum_guide"
+      autoload :Meeting, "#{__dir__}/identifiers/meeting"
     end
   end
 end

--- a/lib/pubid/jcgm/identifiers/meeting.rb
+++ b/lib/pubid/jcgm/identifiers/meeting.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Jcgm
+    module Identifiers
+      # A JCGM committee/meeting record, e.g. "JCGM 17th Meeting (2012)".
+      #
+      # `number` (Components::Code) holds the meeting ordinal as a clean integer
+      # value ("17"); `date` (Components::Date, year-only) holds the year.
+      class Meeting < SingleIdentifier
+        attribute :type, Pubid::Components::Type, default: -> { self.class.type[:key] }
+
+        TYPED_STAGES = [
+          Pubid::Components::TypedStage.new(
+            code: :pubmeeting,
+            stage_code: :published,
+            type_code: :jcgm_meeting,
+            abbr: ["Meeting"],
+            name: "Meeting",
+            harmonized_stages: %w[60.00 60.60],
+          ),
+        ].freeze
+
+        def self.type
+          { key: :jcgm_meeting, title: "Meeting" }
+        end
+
+        # Ordinal suffix as printed by the JCGM/BIPM data generator: a naive
+        # last-digit rule (1->st, 2->nd, 3->rd, else th) with NO 11/12/13 teens
+        # exception. The real records print "11st", "12nd", "13rd", so applying
+        # the standard-English teens exception would break round-trip.
+        def self.ordinal(number)
+          n = number.to_i
+          suffix = case n % 10
+                   when 1 then "st"
+                   when 2 then "nd"
+                   when 3 then "rd"
+                   else "th"
+                   end
+          "#{n}#{suffix}"
+        end
+
+        def ordinal
+          self.class.ordinal(number&.value)
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/jcgm/parser.rb
+++ b/lib/pubid/jcgm/parser.rb
@@ -11,7 +11,22 @@ module Pubid
       root :identifier
 
       rule(:identifier) do
-        amendment_identifier | base_identifier
+        meeting_identifier | amendment_identifier | base_identifier
+      end
+
+      # Committee/meeting record, e.g. "JCGM 17th Meeting (2012)". Diverges
+      # from base_identifier right after the digits (base wants ":", meeting
+      # wants the ordinal suffix), so ordered choice is unambiguous. Emits the
+      # same tokens as a guide plus type_with_stage "Meeting", so the generic
+      # builder path resolves it to Identifiers::Meeting (like "Amd").
+      rule(:meeting_identifier) do
+        publisher >> space >> digits.as(:number) >> ordinal_suffix >>
+          space >> str("Meeting").as(:type_with_stage) >> space >>
+          str("(") >> year_digits.as(:date) >> str(")")
+      end
+
+      rule(:ordinal_suffix) do
+        str("st") | str("nd") | str("rd") | str("th")
       end
 
       rule(:base_identifier) do

--- a/lib/pubid/jcgm/renderer.rb
+++ b/lib/pubid/jcgm/renderer.rb
@@ -13,19 +13,19 @@ module Pubid
     # registry and invoked via `render(format: :human)`.
     class Renderer < ::Pubid::Renderers::Base
       def render(context: nil, **opts)
-        id = @id
-
-        case id
-        when Identifiers::Amendment
-          render_amendment(id, context)
-        when Identifiers::GumGuide
-          render_gum_guide(id, context)
-        else
-          render_single(id)
+        case @id
+        when Identifiers::Amendment then render_amendment(@id, context)
+        when Identifiers::GumGuide then render_gum_guide(@id, context)
+        when Identifiers::Meeting then render_meeting(@id)
+        else render_single(@id)
         end
       end
 
       private
+
+      def render_meeting(id)
+        "JCGM #{id.ordinal} Meeting (#{id.date.year})"
+      end
 
       def render_single(id)
         parts = [id.publisher_portion]

--- a/lib/pubid/jcgm/urn_generator.rb
+++ b/lib/pubid/jcgm/urn_generator.rb
@@ -4,7 +4,9 @@ module Pubid
   module Jcgm
     class UrnGenerator < Pubid::UrnGenerator::Base
       def generate
-        if identifier.is_a?(SupplementIdentifier)
+        if identifier.is_a?(Identifiers::Meeting)
+          generate_meeting_urn
+        elsif identifier.is_a?(SupplementIdentifier)
           generate_supplement_urn
         else
           generate_base_urn
@@ -12,6 +14,14 @@ module Pubid
       end
 
       protected
+
+      # urn:jcgm:meeting:<number>:<year>, e.g. urn:jcgm:meeting:17:2012
+      def generate_meeting_urn
+        parts = ["urn", "jcgm", "meeting"]
+        parts << identifier.number.value if identifier.number
+        parts << identifier.date.year if identifier.date
+        parts.join(":")
+      end
 
       def generate_base_urn
         parts = ["urn", "jcgm"]

--- a/lib/pubid/jcgm/urn_parser.rb
+++ b/lib/pubid/jcgm/urn_parser.rb
@@ -4,19 +4,31 @@ module Pubid
   module Jcgm
     # Parses JCGM URNs back into identifiers.
     #
-    # UrnGenerator emits: `urn:jcgm:{number}:{year}`.
+    # UrnGenerator emits `urn:jcgm:{number}:{year}` for guides and
+    # `urn:jcgm:meeting:{number}:{year}` for committee/meeting records.
     #
     # Examples:
     # - urn:jcgm:200:2012 → JCGM 200:2012
     # - urn:jcgm:100:2008 → JCGM 100:2008
+    # - urn:jcgm:meeting:17:2012 → JCGM 17th Meeting (2012)
     class UrnParser < Pubid::UrnParser::Base
       def parse_urn(urn)
-        body = strip_namespace(urn)
-        parts = split_parts(body)
+        parts = split_parts(strip_namespace(urn))
+        return parse_meeting_urn(parts) if parts.first == "meeting"
+
         number, year = parts
         text = "JCGM #{number}"
         text += ":#{year}" if year
         flavor_parse(text)
+      end
+
+      private
+
+      # urn:jcgm:meeting:<number>:<year> -> "JCGM <ordinal> Meeting (<year>)"
+      def parse_meeting_urn(parts)
+        _, number, year = parts
+        ordinal = Identifiers::Meeting.ordinal(number)
+        flavor_parse("JCGM #{ordinal} Meeting (#{year})")
       end
     end
   end

--- a/spec/fixtures/jcgm/identifiers/full/meeting.txt
+++ b/spec/fixtures/jcgm/identifiers/full/meeting.txt
@@ -1,0 +1,20 @@
+# JCGM Meeting - Full
+# Source of truth for all JCGM committee/meeting identifiers
+# (relaton-data-bipm/data/jcgm/meeting/*.yaml). Naive last-digit ordinal.
+
+JCGM 11st Meeting (2006)
+JCGM 12nd Meeting (2007)
+JCGM 13rd Meeting (2008)
+JCGM 15th Meeting (2009)
+JCGM 16th Meeting (2011)
+JCGM 17th Meeting (2012)
+JCGM 18th Meeting (2013)
+JCGM 19th Meeting (2014)
+JCGM 20th Meeting (2015)
+JCGM 21st Meeting (2017)
+JCGM 22nd Meeting (2018)
+JCGM 23rd Meeting (2020)
+JCGM 24th Meeting (2021)
+JCGM 25th Meeting (2022)
+JCGM 26th Meeting (2024)
+JCGM 27th Meeting (2025)

--- a/spec/fixtures/jcgm/identifiers/pass/meeting.txt
+++ b/spec/fixtures/jcgm/identifiers/pass/meeting.txt
@@ -1,0 +1,20 @@
+# JCGM Meeting - Pass
+# JCGM committee/meeting records, sampled from relaton-data-bipm/data/jcgm/meeting/*.yaml
+# Note the naive last-digit ordinal used by the source data: 11st, 12nd, 13rd (no teens exception).
+
+JCGM 11st Meeting (2006)
+JCGM 12nd Meeting (2007)
+JCGM 13rd Meeting (2008)
+JCGM 15th Meeting (2009)
+JCGM 16th Meeting (2011)
+JCGM 17th Meeting (2012)
+JCGM 18th Meeting (2013)
+JCGM 19th Meeting (2014)
+JCGM 20th Meeting (2015)
+JCGM 21st Meeting (2017)
+JCGM 22nd Meeting (2018)
+JCGM 23rd Meeting (2020)
+JCGM 24th Meeting (2021)
+JCGM 25th Meeting (2022)
+JCGM 26th Meeting (2024)
+JCGM 27th Meeting (2025)

--- a/spec/pubid/jcgm/fixtures_spec.rb
+++ b/spec/pubid/jcgm/fixtures_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module JcgmFixturesSpec
   FIXTURE_FILES = Dir.glob(File.join(__dir__,
-                                     "../../../fixtures/JCGM/identifiers/pass", "*.txt")).freeze
+                                     "../../../fixtures/jcgm/identifiers/pass", "*.txt")).freeze
 end
 
 RSpec.describe "JCGM Fixture Round-trip Tests" do

--- a/spec/pubid/jcgm/identifier_spec.rb
+++ b/spec/pubid/jcgm/identifier_spec.rb
@@ -165,6 +165,62 @@ RSpec.describe Pubid::Jcgm do
       end
     end
 
+    context "committee meetings" do
+      describe "JCGM 17th Meeting (2012)" do
+        subject { "JCGM 17th Meeting (2012)" }
+
+        let(:parsed) { described_class.parse(subject) }
+
+        it "parses as Meeting" do
+          expect(parsed).to be_a(Pubid::Jcgm::Identifiers::Meeting)
+        end
+
+        it "parses publisher" do
+          expect(parsed.publisher.to_s).to eq("JCGM")
+        end
+
+        it "parses the meeting number as a clean integer value" do
+          expect(parsed.number.value).to eq("17")
+        end
+
+        it "parses the year" do
+          expect(parsed.date.year).to eq("2012")
+        end
+
+        it "round-trips" do
+          expect(parsed.to_s).to eq(subject)
+        end
+      end
+
+      # Exercise the naive last-digit ordinal rule (1->st, 2->nd, 3->rd,
+      # else th; NO 11/12/13 teens exception) — matches the real records.
+      {
+        "JCGM 11st Meeting (2006)" => %w[11 2006],
+        "JCGM 12nd Meeting (2007)" => %w[12 2007],
+        "JCGM 13rd Meeting (2008)" => %w[13 2008],
+        "JCGM 15th Meeting (2009)" => %w[15 2009],
+        "JCGM 21st Meeting (2017)" => %w[21 2017],
+        "JCGM 22nd Meeting (2018)" => %w[22 2018],
+        "JCGM 23rd Meeting (2020)" => %w[23 2020],
+      }.each do |id_str, (number, year)|
+        describe id_str do
+          subject { id_str }
+
+          let(:parsed) { described_class.parse(subject) }
+
+          it "parses as Meeting with number #{number} and year #{year}" do
+            expect(parsed).to be_a(Pubid::Jcgm::Identifiers::Meeting)
+            expect(parsed.number.value).to eq(number)
+            expect(parsed.date.year).to eq(year)
+          end
+
+          it "round-trips" do
+            expect(parsed.to_s).to eq(subject)
+          end
+        end
+      end
+    end
+
     context "amendments" do
       describe "JCGM 100:2008/Amd 1" do
         subject { "JCGM 100:2008/Amd 1" }

--- a/spec/pubid/jcgm/serialization_spec.rb
+++ b/spec/pubid/jcgm/serialization_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pubid/jcgm"
+
+RSpec.describe "JCGM serialization" do
+  describe "#to_hash / .from_hash round-trip" do
+    {
+      "JCGM 17th Meeting (2012)" => "pubid:jcgm:meeting",
+      "JCGM 11st Meeting (2006)" => "pubid:jcgm:meeting",
+      "JCGM 23rd Meeting (2020)" => "pubid:jcgm:meeting",
+      # a guide, to show the mechanism is general (not meeting-specific)
+      "JCGM 100:2008" => "pubid:jcgm:guide",
+    }.each do |id_str, expected_type|
+      describe id_str do
+        let(:identifier) { Pubid::Jcgm.parse(id_str) }
+        let(:hash) { identifier.to_hash }
+
+        it "produces a non-empty hash" do
+          expect(hash).to be_a(Hash)
+          expect(hash).not_to be_empty
+        end
+
+        it "carries the polymorphic _type #{expected_type.inspect}" do
+          expect(hash["_type"]).to eq(expected_type)
+        end
+
+        it "rebuilds via from_hash and round-trips to_s" do
+          rebuilt = Pubid::Jcgm::Identifier.from_hash(hash)
+          expect(rebuilt.to_s).to eq(id_str)
+        end
+
+        it "is idempotent under from_hash(to_hash)" do
+          rebuilt = Pubid::Jcgm::Identifier.from_hash(hash)
+          expect(rebuilt.to_hash).to eq(hash)
+        end
+      end
+    end
+  end
+end

--- a/spec/pubid/jcgm/urn_parser_spec.rb
+++ b/spec/pubid/jcgm/urn_parser_spec.rb
@@ -8,5 +8,7 @@ RSpec.describe Pubid::Jcgm::UrnParser do
   it_behaves_like "flavor URN round-trip", Pubid::Jcgm, [
     "JCGM 200:2012",
     "JCGM 100:2008",
+    "JCGM 17th Meeting (2012)",
+    "JCGM 11st Meeting (2006)",
   ]
 end

--- a/spec/pubid/jcgm/urn_spec.rb
+++ b/spec/pubid/jcgm/urn_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe "JCGM URN Generation" do
       urn = id.to_urn
       expect(urn).to start_with("urn:jcgm:")
     end
+
+    it "generates a meeting URN" do
+      id = Pubid::Jcgm.parse("JCGM 17th Meeting (2012)")
+      expect(id.to_urn).to eq("urn:jcgm:meeting:17:2012")
+    end
   end
 
   describe "URN format compliance" do


### PR DESCRIPTION
## Summary

Teaches `Pubid::Jcgm` to parse/render/serialize JCGM **committee-meeting** records such as `JCGM 17th Meeting (2012)` → `_type: pubid:jcgm:meeting`. This closes the one gap in JCGM coverage so the ~16 meeting rows currently mis-filed as bespoke hashes inside `relaton-data-bipm` can migrate to the structured index form.

Purely **additive** — existing guide / GUM-guide / amendment behaviour is unchanged.

| Form | Example | `_type` |
|---|---|---|
| Meeting (new) | `JCGM 17th Meeting (2012)` | `pubid:jcgm:meeting` |

## Design notes

- **New `Identifiers::Meeting`** (`< SingleIdentifier`) reuses the inherited `number` (Code) and `date` (year-only) attributes. The parser emits `type_with_stage: "Meeting"`, so the record flows through the **existing** generic builder path exactly like the `Amd` amendment token — **no builder change** was required. `_type` is derived automatically from the class name (no type-map edit).
- **Naive last-digit ordinal.** The real BIPM records print `11st`, `12nd`, `13rd` (not standard-English `11th/12th/13th`), so `Meeting.ordinal` uses `1→st, 2→nd, 3→rd, else th` with **no** teens exception. All 16 source records round-trip; standard English would have broken `JCGM 11st Meeting (2006)`.
- **URN:** `urn:jcgm:meeting:<number>:<year>`, round-tripped by `UrnParser`.
- **Latent CI fix:** `fixtures_spec.rb` globbed uppercase `fixtures/JCGM/`, which silently matches zero files on case-sensitive CI (only worked locally on a case-insensitive FS). Corrected to lowercase `jcgm` so the JCGM fixtures actually run.

## Tests

- New/updated `identifier_spec`, `serialization_spec`, `urn_spec`, `urn_parser_spec`, and `pass`+`full` meeting fixtures (16 real records).
- `bundle exec rspec spec/pubid/jcgm/ spec/pubid/prefixes_spec.rb` → green.
- Full `bundle exec rake` green except a pre-existing, unrelated ISO **performance** timing flake (`spec/pubid/iso/performance_spec.rb:53`), which passes in isolation. This change touches only `lib/pubid/jcgm/`.
- Rubocop: no new offenses.

## Follow-up (out of scope)

- Downstream migration is captured in a hand-off (`HANDOFFS/relaton__relaton-data-jcgm.md`, not committed): create a new `relaton-data-jcgm` repo and move the JCGM subtree out of `relaton-data-bipm`.
- `Pubid::Jcgm.parse` still lacks the `MAX_INPUT_LENGTH` ReDoS guard (pre-existing flavor-wide gap).