### PR TITLE
feat(oasis): add Pubid::Oasis flavor for OASIS identifiers

### DIFF
--- a/lib/pubid.rb
+++ b/lib/pubid.rb
@@ -127,6 +127,7 @@ module Pubid
   autoload :Jcgm, "pubid/jcgm"
   autoload :Jis, "pubid/jis"
   autoload :Nist, "pubid/nist"
+  autoload :Oasis, "pubid/oasis"
   autoload :Ogc, "pubid/ogc"
   autoload :Oiml, "pubid/oiml"
   autoload :Plateau, "pubid/plateau"

--- a/lib/pubid/export/exporter.rb
+++ b/lib/pubid/export/exporter.rb
@@ -10,7 +10,7 @@ module Pubid
       FLAVORS = %i[
         iso iec ieee nist bsi itu cen_cenelec etsi ansi astm ashrae asme
         ccsds cie csa jis jcgm oiml idf api amca plateau sae ogc tgpp w3c xsf
-        bipm iana
+        bipm iana oasis
       ].freeze
 
       # Export all flavors to a hash suitable for JSON serialization.

--- a/lib/pubid/oasis.rb
+++ b/lib/pubid/oasis.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Oasis
+    extend Pubid::PrefixesSupport
+
+    # Sole OASIS publisher token (see the parser's `prefix` rule). Everything
+    # after "OASIS " is a free-form slug, so there are no leading type tokens to
+    # exclude.
+    PREFIXES = ["OASIS"].freeze
+
+    autoload :Builder, "#{__dir__}/oasis/builder"
+    autoload :Identifier, "#{__dir__}/oasis/identifier"
+    autoload :Identifiers, "#{__dir__}/oasis/identifiers"
+    autoload :Parser, "#{__dir__}/oasis/parser"
+    autoload :Renderer, "#{__dir__}/oasis/renderer"
+    autoload :UrnGenerator, "#{__dir__}/oasis/urn_generator"
+    autoload :UrnParser, "#{__dir__}/oasis/urn_parser"
+
+    # Parse an OASIS identifier string
+    def self.parse(identifier)
+      # Reject pathological inputs before they reach the parser
+      # (CodeQL rb/polynomial-redos barrier — inline .length by design).
+      if identifier.length > Pubid::MAX_INPUT_LENGTH
+        raise ArgumentError, Pubid::INPUT_TOO_LONG_MESSAGE
+      end
+
+      Identifier.parse(identifier)
+    end
+
+    # Per-flavor format registry: inherits global formats, overrides :human
+    Identifier.format_registry = FormatRegistry.new(parent: Identifier.format_registry)
+    Identifier.format_registry.register(:human, renderer: Oasis::Renderer)
+
+    # Auto-discover all identifier types from the Identifiers namespace
+    # @return [Array<Class>] identifier classes that define a self.type Hash
+    def self.identifier_types
+      @identifier_types ||= Identifiers.constants
+        .filter_map { |c| begin; Identifiers.const_get(c); rescue NameError; nil; end }
+        .select { |c| c.is_a?(Class) && c.singleton_methods(false).include?(:type) }
+        .select { |c| c.type.is_a?(Hash) }
+    end
+
+    # Build typed stage index from identifier types
+    # @return [Array<Pubid::Components::TypedStage>] all typed stages
+    def self.all_typed_stages
+      @all_typed_stages ||= identifier_types.flat_map do |klass|
+        if klass.const_defined?(:TYPED_STAGES)
+          klass.const_get(:TYPED_STAGES)
+        else
+          []
+        end
+      end
+    end
+
+    # Lookup: type code -> identifier class
+    # @param code [String, Symbol] the type key to find
+    # @return [Class, nil] the matching identifier class
+    def self.locate_type(code)
+      identifier_types.find { |t| t.type[:key].to_s == code.to_s }
+    end
+
+    # Lookup: abbreviation -> typed stage
+    # @param abbr [String, Symbol] the abbreviation to find
+    # @return [Pubid::Components::TypedStage, nil] the matching typed stage
+    def self.locate_stage(abbr)
+      abbr_str = abbr.to_s.upcase
+      all_typed_stages.find { |s| s.abbr.any? { |a| a.to_s.upcase == abbr_str } }
+    end
+  end
+end
+
+# Register OASIS flavor with the registry
+Pubid::Registry.register(:oasis, Pubid::Oasis)

--- a/lib/pubid/oasis/builder.rb
+++ b/lib/pubid/oasis/builder.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Oasis
+    # Turns the parse tree into an `Identifiers::Standard`: stores the slug
+    # verbatim in `original`, then performs a best-effort, ORDER-INDEPENDENT
+    # decomposition into spec / version / stage / part / label.
+    #
+    # Decomposition splits `original` on "-" and classifies each *whole*
+    # fragment (so a stage-like substring inside a spec name — e.g. "CSDL" — is
+    # never mistaken for a stage). `spec` is the run of leading name fragments
+    # before the first recognized fragment; `version`/`stage`/`part` are the
+    # first fragment of each recognized kind; `label` is any name fragment
+    # appearing after the first recognized one. Anything the classifier cannot
+    # place stays only in `original`, so the printed form always round-trips.
+    class Builder
+      # A fragment is a version when it is `v?N(.N)+` (e.g. "3.0", "v1.2.1",
+      # "V1.0"). Bare integers are deliberately NOT versions (too ambiguous
+      # with spec-name tokens).
+      VERSION_RE = /\Av?\d+(?:\.\d+)+\z/i
+      # OASIS approval-stage tokens (+ optional revision digits). Longest-first
+      # so shared prefixes classify correctly (CSPRD/CSD before CS, COS before
+      # CS/OS).
+      STAGE_RE = /\A(?:CSPRD|CSD|COS|CS|WD|OS|PS|PRD|CD|Errata)\d*\z/
+      # Part tokens across the three observed spellings, plus bare "Pt"/"P".
+      PART_RE = /\A(?:Part|Pt|part|P)\d*\z/
+
+      def self.build(parsed_data)
+        new.build(parsed_data)
+      end
+
+      def build(data)
+        original = data[:original].to_s
+        Identifiers::Standard.new(original: original, **decompose(original))
+      end
+
+      private
+
+      # @return [Hash] best-effort { spec:, version:, stage:, part:, label: }.
+      # Each fragment is classified once into a [fragment, kind] pair. `spec` is
+      # the leading run of name fragments; `label` is any name fragment after
+      # the first recognized one; version/stage/part are the first of each kind.
+      def decompose(original)
+        pairs = original.split("-").map { |f| [f, classify(f)] }
+        lead = pairs.take_while { |_, kind| kind.nil? }
+        rest = pairs.drop(lead.length)
+        {
+          spec: names(lead),
+          version: first_of(rest, :version),
+          stage: first_of(rest, :stage),
+          part: first_of(rest, :part),
+          label: names(rest),
+        }
+      end
+
+      # @return [Symbol, nil] :version / :stage / :part, or nil for a name token
+      def classify(fragment)
+        return :version if fragment.match?(VERSION_RE)
+        return :stage if fragment.match?(STAGE_RE)
+        return :part if fragment.match?(PART_RE)
+
+        nil
+      end
+
+      # First fragment of the given kind among [fragment, kind] pairs, or nil.
+      def first_of(pairs, kind)
+        pairs.find { |_, k| k == kind }&.first
+      end
+
+      # Name (unclassified) fragments among the pairs, re-joined, or nil.
+      def names(pairs)
+        fragments = pairs.select { |_, kind| kind.nil? }.map(&:first)
+        fragments.empty? ? nil : fragments.join("-")
+      end
+    end
+  end
+end

--- a/lib/pubid/oasis/identifier.rb
+++ b/lib/pubid/oasis/identifier.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Oasis
+    # Base class for every OASIS identifier AND the flavor's parse/create entry
+    # point. The single concrete type `Identifiers::Standard` descends from this
+    # class, so a parsed OASIS id is an instance of `Pubid::Oasis::Identifier`.
+    #
+    # OASIS identifiers are free-form slugs with an inconsistent internal
+    # structure (spec name + version + approval stage + part + label, in
+    # varying order). To guarantee a lossless round-trip we always keep the
+    # exact printed slug verbatim in `original` (which alone drives `to_s`); the
+    # remaining component fields are a best-effort decomposition for relaton
+    # querying and can be nil without ever affecting the rendered string.
+    class Identifier < ::Pubid::Identifier
+      # The exact slug printed after "OASIS " — always set. Drives `to_s`, so
+      # the printed form round-trips verbatim regardless of decomposition.
+      attribute :original, :string
+      # Best-effort decomposition (any may be nil). `spec`/`label` are plain
+      # slug fragments; `version`/`stage`/`part` carry the recognized fragment
+      # verbatim (e.g. "3.0", "v1.2.1", "PS01", "Errata01", "Pt8", "Part1").
+      attribute :spec, :string
+      attribute :version, :string
+      # `stage`/`part` intentionally override the inherited Components::Stage /
+      # Components::Code attributes with plain strings (same mechanism JIS uses
+      # for `number`, W3C for `date`): OASIS stages/parts are opaque tokens that
+      # must round-trip exactly and are never re-parsed as structured parts.
+      attribute :stage, :string
+      attribute :part, :string
+      attribute :label, :string
+
+      # Polymorphic type map for lutaml::Model key_value (de)serialization: maps
+      # the subclass's polymorphic_name to its class name so a stored hash
+      # rebuilds the correct identifier type via from_hash.
+      OASIS_TYPE_MAP = {
+        "pubid:oasis:standard" => "Pubid::Oasis::Identifiers::Standard",
+      }.freeze
+
+      key_value do
+        map "_type", to: :_type, polymorphic_map: OASIS_TYPE_MAP
+        map "original", to: :original
+        map "spec", to: :spec
+        map "version", to: :version
+        map "stage", to: :stage
+        map "part", to: :part
+        map "label", to: :label
+      end
+
+      # Publisher is always "OASIS". A plain constant (not a `publisher` method)
+      # so it doesn't shadow the inherited lutaml `publisher` attribute, which
+      # would otherwise fail serialization type validation.
+      PUBLISHER = "OASIS"
+
+      attr_reader :with_publisher
+
+      def to_s(with_publisher: true, **opts)
+        @with_publisher = with_publisher
+        render(format: :human, **opts)
+      end
+
+      # from_hash is the shared polymorphic dispatch on Pubid::Identifier;
+      # OASIS_TYPE_MAP remains as the key_value polymorphic_map.
+
+      # Parse an OASIS identifier string into an identifier object
+      # @param identifier [String] The OASIS identifier string to parse
+      # @return [Identifier] The Standard identifier object
+      # @raise [RuntimeError] If parsing fails
+      def self.parse(identifier)
+        # Reject pathological inputs before they reach the parser
+        # (CodeQL rb/polynomial-redos barrier — inline .length by design).
+        if identifier.length > Pubid::MAX_INPUT_LENGTH
+          raise ArgumentError, Pubid::INPUT_TOO_LONG_MESSAGE
+        end
+
+        parsed = Parser.parse(identifier)
+        Builder.build(parsed)
+      rescue Parslet::ParseFailed => e
+        raise "Failed to parse OASIS identifier '#{identifier}': #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/pubid/oasis/identifiers.rb
+++ b/lib/pubid/oasis/identifiers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Oasis
+    module Identifiers
+      autoload :Standard, "#{__dir__}/identifiers/standard"
+    end
+  end
+end

--- a/lib/pubid/oasis/identifiers/standard.rb
+++ b/lib/pubid/oasis/identifiers/standard.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Oasis
+    module Identifiers
+      # The sole OASIS identifier type. OASIS records carry no document-type
+      # distinction in the printed id (every record is `type: OASIS`); the
+      # approval stage lives in the `stage` component field, not in the class.
+      # Example: "OASIS OSLC-CoreShapes-3.0-PS01-Pt8".
+      class Standard < Identifier
+        TYPED_STAGES = [
+          Pubid::Components::TypedStage.new(
+            code: :oasis,
+            stage_code: :published,
+            type_code: :oasis,
+            abbr: ["OASIS"],
+            name: "OASIS Standard",
+            harmonized_stages: [],
+          ),
+        ].freeze
+
+        def self.type
+          { key: :oasis, web: :standard, title: "OASIS Standard",
+            short: "OASIS" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/oasis/parser.rb
+++ b/lib/pubid/oasis/parser.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "parslet"
+
+module Pubid
+  module Oasis
+    # Parslet grammar for printed OASIS identifiers, e.g.
+    #   "OASIS OSLC-CoreShapes-3.0-PS01-Pt8"
+    #   "OASIS amqp-core"
+    #
+    # OASIS slugs are free-form with a highly inconsistent internal structure
+    # (varying fragment order, three part spellings, mixed case, a few
+    # malformed records with spaces or stray characters). The grammar therefore
+    # only strips the "OASIS " publisher prefix and captures the remainder
+    # verbatim; the spec/version/stage/part/label decomposition is done in the
+    # Builder with order-independent fragment classification. Keeping
+    # decomposition out of the PEG avoids brittle backtracking and guarantees a
+    # lossless round-trip.
+    class Parser < Parslet::Parser
+      rule(:prefix) { str("OASIS") >> str(" ") }
+
+      # The whole slug, captured verbatim (any character, incl. spaces / "]").
+      rule(:slug) { any.repeat(1).as(:original) }
+
+      rule(:identifier) { prefix >> slug }
+
+      rule(:root) { identifier }
+
+      def self.parse(input)
+        new.parse(input)
+      end
+    end
+  end
+end

--- a/lib/pubid/oasis/renderer.rb
+++ b/lib/pubid/oasis/renderer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Oasis
+    # Human-readable renderer for OASIS identifiers.
+    #
+    # Renders the verbatim slug (`original`), prefixed with the "OASIS "
+    # publisher token unless `id.with_publisher == false`. Because rendering is
+    # a pure echo of `original`, the printed form always round-trips exactly.
+    #
+    #   "OASIS OSLC-CoreShapes-3.0-PS01-Pt8"  (with publisher)
+    #   "OSLC-CoreShapes-3.0-PS01-Pt8"        (without)
+    class Renderer < ::Pubid::Renderers::Base
+      PUBLISHER = "OASIS"
+
+      def render(context: nil, **opts)
+        id = @id
+        body = id.original.to_s
+        with_publisher?(id) ? "#{PUBLISHER} #{body}" : body
+      end
+
+      private
+
+      def with_publisher?(id)
+        id.with_publisher != false
+      end
+    end
+  end
+end

--- a/lib/pubid/oasis/urn_generator.rb
+++ b/lib/pubid/oasis/urn_generator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Oasis
+    # Emits `urn:oasis:<slug>`, echoing the verbatim `original` as a single URN
+    # segment (OASIS slugs never contain ":"). The only characters that occur in
+    # real records outside the URN-safe set are the space and a stray "]" (both
+    # only in a handful of malformed records); these are percent-encoded so the
+    # URN stays well-formed, and UrnParser reverses them exactly.
+    #
+    #   "OASIS amqp-core"          -> "urn:oasis:amqp-core"
+    #   "OASIS OSLC-CM-v1.0-CS01"  -> "urn:oasis:OSLC-CM-v1.0-CS01"
+    class UrnGenerator < Pubid::UrnGenerator::Base
+      # Character -> percent-encoding for the non-URN-safe characters that
+      # actually appear in OASIS slugs. Kept explicit (not a blanket URI escape)
+      # so clean slugs — dots, hyphens, mixed case — pass through unchanged.
+      ENCODE = { " " => "%20", "]" => "%5D" }.freeze
+
+      def generate
+        slug = identifier.original.to_s.gsub(/[ \]]/) { |c| ENCODE[c] }
+        "urn:oasis:#{slug}"
+      end
+    end
+  end
+end

--- a/lib/pubid/oasis/urn_parser.rb
+++ b/lib/pubid/oasis/urn_parser.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Oasis
+    # Parses OASIS URNs back into identifiers by reconstructing the printed form
+    # and delegating to the flavor's text parser.
+    #
+    # UrnGenerator emits `urn:oasis:<slug>` (single segment) with the space and
+    # "]" characters percent-encoded; reverse exactly those two here.
+    #
+    #   urn:oasis:OSLC-CM-v1.0-CS01 -> OASIS OSLC-CM-v1.0-CS01
+    #   urn:oasis:amqp-core         -> OASIS amqp-core
+    class UrnParser < Pubid::UrnParser::Base
+      DECODE = { "%20" => " ", "%5D" => "]" }.freeze
+
+      def parse_urn(urn)
+        slug = strip_namespace(urn).gsub(/%20|%5D/, DECODE)
+        flavor_parse("OASIS #{slug}")
+      end
+    end
+  end
+end

--- a/spec/fixtures/oasis/identifiers/pass/oasis.txt
+++ b/spec/fixtures/oasis/identifiers/pass/oasis.txt
@@ -1,0 +1,77 @@
+# Curated sample of real OASIS identifiers from relaton-data-oasis (~605 records).
+# Every line must satisfy parse(x).to_s == x (100%) — the verbatim `original`
+# contract guarantees this regardless of how much decomposition succeeds.
+# Covers: bare spec, version forms (v/bare/3-part/glued), the three part
+# spellings, all stage tokens, labels, both fragment orders, and the handful of
+# malformed records (embedded space / stray `]`).
+
+# --- bare spec name only ---
+OASIS EDXL
+OASIS OSLC
+OASIS SAML
+OASIS WSS
+OASIS OData
+OASIS BIASPROFILE
+OASIS SAML-QR
+OASIS amqp-core
+OASIS cals-table-model
+
+# --- spec + version ---
+OASIS WSDM-v1.1
+OASIS OpenDocument-v1.1
+OASIS DITA-v1.2
+OASIS SAML-v1.1
+OASIS UBL-v2.4
+OASIS OData-JSON-Format-v4.0
+OASIS xacml-rest-v1.1
+
+# --- bare (no v) version ---
+OASIS OSLC-CM-v1.0
+OASIS OSLC-RM-2.1-Part2-PS01
+OASIS UBL-2.3
+
+# --- three-component version ---
+OASIS STIX-v1.2.1-Report-CS01-Pt11
+OASIS SARIF-v2.1.0
+OASIS PKCS11-Profiles-v2.40
+
+# --- spec + version + part (Pt spelling) ---
+OASIS amqp-core-overview-v1.0-Pt0
+OASIS OSLC-Discovery-3.0-PS01-Pt2
+
+# --- spec + version + stage + part ---
+OASIS OSLC-CoreShapes-3.0-PS01-Pt8
+OASIS OSLC-AM-2.1-CS01-Pt1
+
+# --- part-before-stage order variant ---
+OASIS OSLC-AM-3.0-Part1-PS01
+OASIS OSLC-CM-3.0-Part1-CS02
+OASIS OpenDocument-v1.3-part1
+
+# --- label between fragments ---
+OASIS STIX-v1.2.1-Common-CS01-Pt2
+OASIS STIX-v2.0-Pt1-Core-CS01
+OASIS OSLC-PROMCODE-v1.0-Shapes-CS02-Pt3
+
+# --- trailing free-text label ---
+OASIS AkomaNtosoCore-v1.0-Pt2-Specifications
+
+# --- stage tokens: CS0x / PS0x ---
+OASIS BasicSecurityProfile-v1.1-CS01
+OASIS ECF-v5.0-CS01
+OASIS OSLC-TRS-v3.0-PS02
+
+# --- errata ---
+OASIS CMIS-v1.1-Errata01
+OASIS DITA-v1.3-Errata02
+OASIS CMIS-v1.1-Plus-Errata01
+
+# --- mixed-case spec names ---
+OASIS xacml-3.0-nested-ent-v1.0-CS01
+OASIS OSLC-am-2.1-Part2-CS01
+
+# --- malformed records (must still round-trip via verbatim original) ---
+OASIS ECF v4.01
+OASIS PLCS v1.0-CS01
+OASIS CTAS-v3.0]-PS01
+OASIS OpenC2-MQTT-v1.0] -CS01

--- a/spec/pubid/export/exporter_spec.rb
+++ b/spec/pubid/export/exporter_spec.rb
@@ -5,8 +5,8 @@ require "pubid/export"
 
 RSpec.describe Pubid::Export::Exporter do
   describe "FLAVORS" do
-    it "lists all 29 flavors" do
-      expect(described_class::FLAVORS.size).to eq(29)
+    it "lists all 30 flavors" do
+      expect(described_class::FLAVORS.size).to eq(30)
     end
 
     it "includes iso" do
@@ -23,6 +23,10 @@ RSpec.describe Pubid::Export::Exporter do
 
     it "includes bipm" do
       expect(described_class::FLAVORS).to include(:bipm)
+    end
+
+    it "includes oasis" do
+      expect(described_class::FLAVORS).to include(:oasis)
     end
 
     it "includes ieee" do
@@ -45,8 +49,14 @@ RSpec.describe Pubid::Export::Exporter do
       expect(data.keys).to all(be_a(String))
     end
 
-    it "exports all 29 flavors" do
-      expect(data.size).to eq(29)
+    it "exports all 30 flavors" do
+      expect(data.size).to eq(30)
+    end
+
+    it "exports OASIS with its Standard identifier type" do
+      expect(data["oasis"][:identifier_types].size).to eq(1)
+      expect(data["oasis"][:identifier_types].first[:title])
+        .to eq("OASIS Standard")
     end
 
     it "exports ISO with identifier types" do

--- a/spec/pubid/oasis/fixtures_spec.rb
+++ b/spec/pubid/oasis/fixtures_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Bulk round-trip over hand-picked real identifiers from relaton-data-oasis.
+# Every line must satisfy parse(x).to_s == x (100% — no pass-rate slack, since
+# the verbatim `original` field guarantees the printed string is preserved even
+# for the malformed records that decomposition cannot classify).
+RSpec.describe "Pubid::Oasis fixtures round-trip" do
+  fixture_glob = File.join(__dir__,
+                           "../../fixtures/oasis/identifiers/pass/*.txt")
+
+  Dir.glob(fixture_glob).each do |file|
+    describe File.basename(file) do
+      lines = File.readlines(file).map(&:strip)
+        .reject { |l| l.empty? || l.start_with?("#") }
+
+      lines.each do |pubid|
+        it "round-trips #{pubid.inspect}" do
+          expect(Pubid::Oasis.parse(pubid).to_s).to eq(pubid)
+        end
+      end
+    end
+  end
+end

--- a/spec/pubid/oasis/identifier_spec.rb
+++ b/spec/pubid/oasis/identifier_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pubid::Oasis::Identifier do
+  describe ".parse" do
+    context "with a fully-decomposable slug (spec + version + stage + part)" do
+      subject { "OASIS OSLC-CoreShapes-3.0-PS01-Pt8" }
+
+      let(:parsed) { described_class.parse(subject) }
+
+      it "builds the Standard type" do
+        expect(parsed).to be_a(Pubid::Oasis::Identifiers::Standard)
+      end
+
+      it "preserves the verbatim slug in original" do
+        expect(parsed.original).to eq("OSLC-CoreShapes-3.0-PS01-Pt8")
+      end
+
+      it "decomposes the component fields" do
+        expect(parsed.spec).to eq("OSLC-CoreShapes")
+        expect(parsed.version).to eq("3.0")
+        expect(parsed.stage).to eq("PS01")
+        expect(parsed.part).to eq("Pt8")
+      end
+
+      it "round-trips through to_s" do
+        expect(parsed.to_s).to eq(subject)
+      end
+
+      it "drops the publisher token when asked" do
+        expect(parsed.to_s(with_publisher: false))
+          .to eq("OSLC-CoreShapes-3.0-PS01-Pt8")
+      end
+    end
+
+    context "with a bare spec name (no version/stage/part)" do
+      subject { "OASIS amqp-core" }
+
+      let(:parsed) { described_class.parse(subject) }
+
+      it "keeps everything in spec/original and leaves the rest nil" do
+        expect(parsed.original).to eq("amqp-core")
+        expect(parsed.spec).to eq("amqp-core")
+        expect(parsed.version).to be_nil
+        expect(parsed.stage).to be_nil
+        expect(parsed.part).to be_nil
+        expect(parsed.to_s).to eq(subject)
+      end
+    end
+
+    context "with a part-before-stage order variant" do
+      subject { "OASIS OSLC-AM-3.0-Part1-PS01" }
+
+      let(:parsed) { described_class.parse(subject) }
+
+      it "decomposes order-independently" do
+        expect(parsed.spec).to eq("OSLC-AM")
+        expect(parsed.version).to eq("3.0")
+        expect(parsed.part).to eq("Part1")
+        expect(parsed.stage).to eq("PS01")
+        expect(parsed.to_s).to eq(subject)
+      end
+    end
+
+    context "with a trailing free-text label" do
+      subject { "OASIS AkomaNtosoCore-v1.0-Pt2-Specifications" }
+
+      let(:parsed) { described_class.parse(subject) }
+
+      it "captures the label after the classified fragments" do
+        expect(parsed.spec).to eq("AkomaNtosoCore")
+        expect(parsed.version).to eq("v1.0")
+        expect(parsed.part).to eq("Pt2")
+        expect(parsed.label).to eq("Specifications")
+        expect(parsed.to_s).to eq(subject)
+      end
+    end
+
+    context "with a malformed slug (stray ] and embedded space)" do
+      it "still round-trips verbatim via original" do
+        [
+          "OASIS CTAS-v3.0]-PS01",
+          "OASIS ECF v4.01",
+          "OASIS OpenC2-MQTT-v1.0] -CS01",
+        ].each do |ref|
+          parsed = described_class.parse(ref)
+          expect(parsed).to be_a(Pubid::Oasis::Identifiers::Standard)
+          expect(parsed.to_s).to eq(ref)
+        end
+      end
+    end
+
+    it "rejects overly long input (ReDoS guard)" do
+      expect { described_class.parse("OASIS #{'a' * Pubid::MAX_INPUT_LENGTH}") }
+        .to raise_error(ArgumentError, Pubid::INPUT_TOO_LONG_MESSAGE)
+    end
+  end
+end

--- a/spec/pubid/oasis/serialization_spec.rb
+++ b/spec/pubid/oasis/serialization_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Round-trip invariant for index serialization: a parsed OASIS identifier must
+# survive `to_hash` -> `from_hash` unchanged. This is the contract the Relaton
+# index relies on (store `id.to_hash`, rebuild via `from_hash`).
+RSpec.describe "Pubid::Oasis identifier hash round-trip" do
+  refs = [
+    "OASIS amqp-core",                            # bare spec
+    "OASIS WSDM-v1.1",                            # spec + version
+    "OASIS amqp-core-overview-v1.0-Pt0",          # spec + version + part
+    "OASIS OSLC-CoreShapes-3.0-PS01-Pt8",         # spec+version+stage+part
+    "OASIS AkomaNtosoCore-v1.0-Pt2-Specifications", # + trailing label
+    "OASIS OSLC-AM-3.0-Part1-PS01",               # part-before-stage order
+    "OASIS CMIS-v1.1-Errata01",                   # errata stage
+    "OASIS CTAS-v3.0]-PS01",                      # malformed, verbatim original
+  ]
+
+  refs.each do |ref|
+    describe ref do
+      let(:identifier) { Pubid::Oasis::Identifier.parse(ref) }
+      let(:hash) { identifier.to_hash }
+
+      it "serializes to a non-empty hash" do
+        expect(hash).not_to be_empty
+      end
+
+      it "carries the polymorphic _type" do
+        expect(hash["_type"]).to eq("pubid:oasis:standard")
+      end
+
+      it "rebuilds an equal identifier from its hash" do
+        rebuilt = Pubid::Oasis::Identifier.from_hash(hash)
+        expect(rebuilt.to_s).to eq(identifier.to_s)
+      end
+
+      it "round-trips the hash idempotently" do
+        rebuilt = Pubid::Oasis::Identifier.from_hash(hash)
+        expect(rebuilt.to_hash).to eq(hash)
+      end
+    end
+  end
+end

--- a/spec/pubid/oasis/urn_parser_spec.rb
+++ b/spec/pubid/oasis/urn_parser_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rspec"
+require_relative "../../../lib/pubid/oasis"
+require_relative "../../support/urn_round_trip"
+
+RSpec.describe Pubid::Oasis::UrnParser do
+  it_behaves_like "flavor URN round-trip", Pubid::Oasis, [
+    "OASIS amqp-core",                     # bare spec
+    "OASIS WSDM-v1.1",                     # spec + version
+    "OASIS OSLC-CoreShapes-3.0-PS01-Pt8",  # fully decomposed
+    "OASIS CMIS-v1.1-Errata01",            # errata
+    "OASIS OSLC-AM-3.0-Part1-PS01",        # order variant
+  ]
+end

--- a/spec/pubid/oasis/urn_spec.rb
+++ b/spec/pubid/oasis/urn_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rspec"
+require_relative "../../../lib/pubid/oasis"
+
+RSpec.describe "OASIS URN Generation" do
+  describe "#to_urn" do
+    it "generates a urn:oasis: URN carrying the slug" do
+      id = Pubid::Oasis.parse("OASIS OSLC-CoreShapes-3.0-PS01-Pt8")
+      urn = id.to_urn
+      expect(urn).to eq("urn:oasis:OSLC-CoreShapes-3.0-PS01-Pt8")
+    end
+
+    it "follows the urn: format for a bare spec" do
+      id = Pubid::Oasis.parse("OASIS amqp-core")
+      expect(id.to_urn).to eq("urn:oasis:amqp-core")
+    end
+
+    it "percent-encodes space and ] so a malformed slug stays well-formed" do
+      ["OASIS CTAS-v3.0]-PS01", "OASIS ECF v4.01"].each do |ref|
+        urn = Pubid::Oasis.parse(ref).to_urn
+        expect(urn).not_to match(/[ \]]/)
+        expect(Pubid::Oasis::UrnParser.parse(urn).to_s).to eq(ref)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a new `Pubid::Oasis` flavor so `relaton-data-oasis` (~605 records) can migrate from its plain-string index to the structured `_type: pubid:oasis:standard` form.

OASIS identifiers are free-form slugs (`OASIS <slug>`) with a highly inconsistent internal structure — **varying fragment order** (`…-PS01-Pt8` vs `…-Part1-PS01` vs `…-Pt1-Core-CS01`), **three part spellings** (`Pt`/`Part`/`part`), mixed case, glued versions (`SDDS1.0`), and a handful of **malformed records** (embedded space or stray `]`, e.g. `OASIS CTAS-v3.0]-PS01`).

## Design (scope: lossless split + verbatim `original`)

- **`original` holds the verbatim slug and alone drives `to_s`**, so `parse(x).to_s == x` is 100% by construction — even for malformed records.
- The builder additionally performs a **best-effort, order-independent** decomposition into `spec`/`version`/`stage`/`part`/`label` (for relaton querying) by classifying whole `-`-delimited fragments — never substrings (so `CSDL` inside a spec name is never read as a stage). A wrong or nil field can never change the rendered string.
- Single `Identifiers::Standard` type (every record is `type: OASIS`; the approval stage is a data field, not a document type). `stage`/`part` override the base `Components` with plain strings — the same mechanism W3C uses for `date` and JIS for `number`.
- Grammar only strips the `OASIS ` prefix and captures the slug verbatim; decomposition lives in the builder, keeping the PEG free of brittle backtracking.
- URN: `urn:oasis:<slug>`, with space→`%20` and `]`→`%5D` percent-encoded (the only non-URN-safe chars that occur) and reversed on parse.
- Inline ReDoS length guard on both parse entries; frozen non-empty `PREFIXES = ["OASIS"]`.
- Registered in the export layer (`Export::Exporter::FLAVORS`).

## Tests

- `spec/pubid/oasis/{identifier,serialization,urn,urn_parser,fixtures}_spec.rb` and a curated fixture (`spec/fixtures/oasis/identifiers/pass/oasis.txt`) sampling every real form incl. the malformed records — all round-trip `parse(x).to_s == x`.
- Serialization round-trip (`from_hash(id.to_hash).to_s == id.to_s`, `_type: pubid:oasis:standard`), URN round-trip, and export-layer assertions.
- OASIS suite, cross-flavor `prefixes_spec`, and export specs are green. Full `rake test:all` is green except a pre-existing ISO perf-timing flake unrelated to this change.

Unblocks the matching `relaton-data-oasis` structured-index migration (out of scope here).
