### PR TITLE
feat(gost): add Harmonized identifier and cross-flavor type resolution

### DIFF
--- a/lib/pubid.rb
+++ b/lib/pubid.rb
@@ -97,6 +97,7 @@ module Pubid
   autoload :Utils, "pubid/utils"
   autoload :Version, "pubid/version"
   autoload :Core, "pubid/core"
+  autoload :TypeResolver, "pubid/type_resolver"
 
 
   # Require all flavor modules

--- a/lib/pubid/gost/builder.rb
+++ b/lib/pubid/gost/builder.rb
@@ -23,24 +23,8 @@ module Pubid
       }.freeze
 
       def build(parsed)
-        russian = parsed[:scope_r] ? true : false
-        copublisher, subtype = split_prefix(stringify(parsed[:prefix_text]))
-        number, year = split_number_year(stringify(parsed[:raw]))
-
-        base_klass = russian ? Identifiers::NationalStandard : Identifiers::InterstateStandard
-        base = base_klass.new(**{
-          copublisher: copublisher,
-          subtype: subtype,
-          number: number,
-          year: year,
-          adopted_reference: stringify(parsed[:adopted_reference_raw]),
-        }.compact)
-
-        adopted_raw = stringify(parsed[:adopted_raw])
-        return base unless adopted_raw
-
-        adopted = parse_foreign(adopted_raw)
-        Identifiers::IdenticalAdoption.new(base: base, adopted: adopted)
+        base = build_base(parsed)
+        with_foreign_adoption(base, parsed)
       end
 
       def self.build(parsed)
@@ -49,6 +33,52 @@ module Pubid
 
       private
 
+      def build_base(parsed)
+        russian = parsed[:scope_r] ? true : false
+        copublisher, subtype = split_prefix(stringify(parsed[:prefix_text]))
+        number, year = split_number_year(stringify(parsed[:raw]))
+
+        klass = russian ? Identifiers::NationalStandard : Identifiers::InterstateStandard
+        klass.new(**{
+          copublisher: copublisher,
+          subtype: subtype,
+          number: number,
+          year: year,
+        }.compact)
+      end
+
+      # Apply the slash (IdenticalAdoption) and/or parens (Harmonized)
+      # wrappers around the base standard. Both can apply simultaneously.
+      def with_foreign_adoption(base, parsed)
+        wrapper = wrap_identical_adoption(base, parsed)
+        wrap_harmonized(wrapper, parsed)
+      end
+
+      def wrap_identical_adoption(base, parsed)
+        adopted_raw = stringify(parsed[:adopted_raw])
+        return base unless adopted_raw
+
+        adopted = parse_foreign(adopted_raw)
+        Identifiers::IdenticalAdoption.new(base: base, adopted: adopted)
+      end
+
+      def wrap_harmonized(base, parsed)
+        reference_raw = stringify(parsed[:adopted_reference_raw])
+        return base unless reference_raw
+
+        items = reference_raw.split(",").map(&:strip).map { |s| normalize_foreign(s) }
+        adopted = items.map { |item| adopt_identifier(item) }
+
+        Identifiers::Harmonized.new(base: base, adopted_identifiers: adopted)
+      end
+
+      # Parse a single foreign identifier, falling back to a
+      # ForeignReference that preserves the raw surface form when no
+      # registered flavor recognizes it (e.g. OECD, UNECE STANDARD).
+      def adopt_identifier(raw)
+        parse_foreign(raw) || Identifiers::ForeignReference.new(raw: raw)
+      end
+
       def split_prefix(text)
         return [nil, nil] unless text
 
@@ -56,9 +86,7 @@ module Pubid
         copublisher_raw = tokens.first
         subtype_raw = tokens.size > 1 ? tokens.drop(1).join(" ") : nil
 
-        copublisher = normalize_copublisher(copublisher_raw)
-        subtype = normalize_subtype(subtype_raw)
-        [copublisher, subtype]
+        [normalize_copublisher(copublisher_raw), normalize_subtype(subtype_raw)]
       end
 
       def normalize_copublisher(raw)
@@ -71,6 +99,18 @@ module Pubid
         SUBTYPE_MAP.fetch(raw) { raw }
       end
 
+      # Normalize a leading Cyrillic publisher token (e.g. "ИСО") to its
+      # Latin equivalent so a foreign parser can recognize it. Longest
+      # keys first so "ИСО/МЭК" wins over "ИСО".
+      def normalize_foreign(raw)
+        COPUBLISHER_MAP.keys.sort_by(&:length).reverse.each do |cyr|
+          next unless raw.start_with?(cyr + " ") || raw.start_with?(cyr + "/")
+
+          return COPUBLISHER_MAP[cyr] + raw[cyr.length..]
+        end
+        raw
+      end
+
       def split_number_year(raw)
         return [raw, nil] unless raw
 
@@ -80,17 +120,13 @@ module Pubid
         [m[1], m[2]]
       end
 
+      # Try every registered flavor (other than GOST itself) as a parser
+      # for a foreign adopted identifier. Returns the first successful
+      # parse, or nil if none recognize the string.
       def parse_foreign(raw)
-        # Pubid doesn't auto-detect flavor from a bare string, and
-        # autoloaded flavor modules may not be registered yet. Trigger
-        # the autoload by referencing the constant via const_get, which
-        # loads the module file (which in turn registers the flavor).
-        %w[Iso Iec Ieee Astm Bsi].each do |name|
-          mod = begin
-            ::Pubid.const_get(name)
-          rescue NameError
-            next
-          end
+        ::Pubid.eager_load_flavors!
+        ::Pubid::Registry.flavors.each_value do |mod|
+          next if mod == ::Pubid::Gost
 
           begin
             return mod.parse(raw)

--- a/lib/pubid/gost/identifier.rb
+++ b/lib/pubid/gost/identifier.rb
@@ -6,14 +6,11 @@ module Pubid
     #
     # GOST identifiers observed in the wild have the shape:
     #
-    #   GOST [R ][<copublisher> ][<subtype> ]<number>[-<year>][/<adopted>][(<ref>)]
+    #   GOST [R ][<copublisher> ][<subtype> ]<number>[-<year>][/<adopted>][(<refs>)]
     #
-    # Where /<adopted> is the IDT slash form (part of the identifier)
-    # and (<ref>) is a parenthesized adoption reference (MOD/NEQ or
-    # unknown degree — the foreign standard this GOST relates to).
-    #
-    # See identifiers/interstate_standard.rb, national_standard.rb, and
-    # identical_adoption.rb for the concrete classes.
+    # Where /<adopted> is the IDT slash form (modeled by IdenticalAdoption)
+    # and (<refs>) is the parenthesized harmonization list (modeled by
+    # Harmonized). A bare InterstateStandard/NationalStandard has neither.
     class Identifier < ::Pubid::Identifier
       def self.parse(identifier)
         parsed = Parser.parse(identifier)
@@ -22,26 +19,26 @@ module Pubid
         raise "Failed to parse GOST identifier '#{identifier}': #{e.message}"
       end
 
-      attribute :publisher,          :string, default: "GOST"
-      attribute :copublisher,        :string
-      attribute :subtype,            :string
-      attribute :number,             :string
-      attribute :year,               :string
-      attribute :adopted_reference,  :string   # parens content (raw)
+      attribute :publisher,   :string, default: "GOST"
+      attribute :copublisher, :string
+      attribute :subtype,     :string
+      attribute :number,      :string
+      attribute :year,        :string
 
       GOST_TYPE_MAP = {
         "pubid:gost:interstate-standard" => "Pubid::Gost::Identifiers::InterstateStandard",
         "pubid:gost:national-standard"   => "Pubid::Gost::Identifiers::NationalStandard",
         "pubid:gost:identical-adoption"  => "Pubid::Gost::Identifiers::IdenticalAdoption",
+        "pubid:gost:harmonized"          => "Pubid::Gost::Identifiers::Harmonized",
+        "pubid:gost:foreign-reference"   => "Pubid::Gost::Identifiers::ForeignReference",
       }.freeze
 
       key_value do
-        map "_type",              to: :_type, polymorphic_map: GOST_TYPE_MAP
-        map "copublisher",        to: :copublisher
-        map "subtype",            to: :subtype
-        map "number",             to: :number
-        map "year",               to: :year
-        map "adopted_reference",  to: :adopted_reference
+        map "_type",       to: :_type, polymorphic_map: GOST_TYPE_MAP
+        map "copublisher", to: :copublisher
+        map "subtype",     to: :subtype
+        map "number",      to: :number
+        map "year",        to: :year
       end
 
       def to_urn

--- a/lib/pubid/gost/identifiers.rb
+++ b/lib/pubid/gost/identifiers.rb
@@ -7,6 +7,8 @@ module Pubid
       autoload :InterstateStandard, "#{__dir__}/identifiers/interstate_standard"
       autoload :NationalStandard,   "#{__dir__}/identifiers/national_standard"
       autoload :IdenticalAdoption,  "#{__dir__}/identifiers/identical_adoption"
+      autoload :Harmonized,         "#{__dir__}/identifiers/harmonized"
+      autoload :ForeignReference,   "#{__dir__}/identifiers/foreign_reference"
     end
   end
 end

--- a/lib/pubid/gost/identifiers/foreign_reference.rb
+++ b/lib/pubid/gost/identifiers/foreign_reference.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Gost
+    module Identifiers
+      # Foreign reference captured verbatim when no registered flavor can
+      # parse the adopted identifier (e.g. "OECD 460:2017",
+      # "UNECE STANDARD FFV-18:2011"). It preserves the raw surface form
+      # for round-trip rendering without modelling the foreign standard's
+      # internal structure. Quacks like Pubid::Identifier for rendering
+      # and serialization.
+      class ForeignReference < Base
+        attribute :raw, :string
+
+        def self.type
+          { key: :"foreign-reference", title: "Foreign Reference", short: nil }
+        end
+
+        def to_s
+          raw.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/gost/identifiers/harmonized.rb
+++ b/lib/pubid/gost/identifiers/harmonized.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Gost
+    module Identifiers
+      # Harmonized standard. The GOST has been officially aligned with,
+      # modified from, or adopted directly from one or more foreign
+      # (typically ISO/IEC) standards. The parenthesized form is the
+      # Russian/CIS garmonizatsiya convention.
+      #
+      # Examples:
+      #   ГОСТ 25346-2013 (ISO 286-1:2010)
+      #   ГОСТ 6032-2017 (ISO 3651-1:1998, ISO 3651-2:1998)
+      #   ГОСТ 6996-66 (ИСО 4136-89, ИСО 5173-81, ИСО 5177-81)
+      #
+      # One GOST may harmonize with multiple foreign standards at once.
+      # The slash form (IdenticalAdoption) is reserved for the strict IDT case.
+      class Harmonized < Base
+        attribute :base, ::Pubid::Gost::Identifier, polymorphic: true
+        attribute :adopted_identifiers, ::Pubid::Identifier,
+                  collection: true, polymorphic: true
+
+        key_value do
+          map "base",                to: :base
+          map "adopted_identifiers", to: :adopted_identifiers
+        end
+
+        def self.type
+          { key: :harmonized, title: "Harmonized Standard", short: nil }
+        end
+
+        def number; base&.number; end
+        def year; base&.year; end
+        def copublisher; base&.copublisher; end
+        def subtype; base&.subtype; end
+      end
+    end
+  end
+end

--- a/lib/pubid/gost/identifiers/identical_adoption.rb
+++ b/lib/pubid/gost/identifiers/identical_adoption.rb
@@ -21,46 +21,18 @@ module Pubid
         attribute :adopted, ::Pubid::Identifier, polymorphic: true
 
         key_value do
-          map "base",    with: { to: :base_to_kv, from: :base_from_kv }
-          map "adopted", with: { to: :adopted_to_kv, from: :adopted_from_kv }
+          map "base",    to: :base
+          map "adopted", to: :adopted
         end
 
         def self.type
           { key: :"identical-adoption", title: "Identical Adoption", short: nil }
         end
 
-        # Delegate common accessors to the base for convenience.
         def number; base&.number; end
         def year; base&.year; end
         def copublisher; base&.copublisher; end
         def subtype; base&.subtype; end
-
-        # Public serialization helpers (lutaml invokes via public_send).
-        def base_to_kv(model, doc)
-          b = model.base
-          return unless b
-
-          doc.add_child(
-            ::Lutaml::KeyValue::DataModel::Element.new("base", b.to_hash),
-          )
-        end
-
-        def base_from_kv(model, value)
-          model.base = ::Pubid::Gost::Identifier.from_hash(value) if value
-        end
-
-        def adopted_to_kv(model, doc)
-          a = model.adopted
-          return unless a
-
-          doc.add_child(
-            ::Lutaml::KeyValue::DataModel::Element.new("adopted", a.to_hash),
-          )
-        end
-
-        def adopted_from_kv(model, value)
-          model.adopted = ::Pubid::Identifier.from_hash(value) if value
-        end
       end
     end
   end

--- a/lib/pubid/gost/renderer.rb
+++ b/lib/pubid/gost/renderer.rb
@@ -14,6 +14,7 @@ module Pubid
       def render(context: nil, **_opts)
         id = @id
 
+        return render_harmonized(id) if id.is_a?(Identifiers::Harmonized)
         return render_identical_adoption(id) if id.is_a?(Identifiers::IdenticalAdoption)
         return render_standard(id)
 
@@ -29,13 +30,17 @@ module Pubid
         rendered << " #{id.subtype}" if id.subtype
         rendered << " #{id.number}"
         rendered << "-#{id.year}" if id.year
-        rendered << " (#{id.adopted_reference})" if id.adopted_reference
         rendered
       end
 
       def render_identical_adoption(id)
-        rendered = +"#{id.base.to_s}/#{id.adopted.to_s}"
-        rendered << " (#{id.base.adopted_reference})" if id.base&.adopted_reference
+        +"#{id.base.to_s}/#{id.adopted.to_s}"
+      end
+
+      def render_harmonized(id)
+        rendered = +id.base.to_s
+        adopted = id.adopted_identifiers&.map(&:to_s)&.join(", ")
+        rendered << " (#{adopted})" unless adopted.nil? || adopted.empty?
         rendered
       end
     end

--- a/lib/pubid/gost/urn_generator.rb
+++ b/lib/pubid/gost/urn_generator.rb
@@ -16,8 +16,12 @@ module Pubid
       end
 
       def generate
-        return generate_for_base(identifier.base) if identifier.is_a?(Identifiers::IdenticalAdoption)
-        return generate_for_base(identifier) if standard?(identifier)
+        id = identifier
+        while id.is_a?(Identifiers::Harmonized) || id.is_a?(Identifiers::IdenticalAdoption)
+          id = id.base
+        end
+
+        return generate_for_standard(id) if standard?(id)
 
         raise ArgumentError,
               "Unknown GOST identifier class: #{identifier.class}"
@@ -25,7 +29,7 @@ module Pubid
 
       private
 
-      def generate_for_base(id)
+      def generate_for_standard(id)
         parts = ["urn:gost:std"]
         parts << "r" if id.is_a?(Identifiers::NationalStandard)
         parts << id.number.to_s

--- a/lib/pubid/identifier.rb
+++ b/lib/pubid/identifier.rb
@@ -19,13 +19,38 @@ module Pubid
       #
       # This generalizes the per-flavor `*_TYPE_MAP` dispatch that ISO, JIS,
       # IEC, CCSDS and IHO each hand-rolled — one implementation, inherited by
-      # every flavor base.
+      # every flavor base. Cross-flavor dispatch (a nested adopted identifier
+      # whose _type belongs to a different flavor) is delegated to
+      # {TypeResolver}, which knows about every registered flavor.
       def from_hash(data, options = {})
-        type = data && (data["_type"] || data[:_type])
-        klass = polymorphic_type_map[type]
+        klass = concrete_class_for(data)
         return klass.from_hash(data, options) if klass && klass != self
-
         super
+      end
+
+      # lutaml's nested polymorphic cast (Attribute#cast → apply_mappings)
+      # bypasses {from_hash}, so cross-flavor dispatch wouldn't fire for a
+      # nested attribute that carries another flavor's _type. Intercept
+      # apply_mappings and route to {from_hash} so the concrete class's own
+      # mappings (with their flavor-specific custom cast methods, e.g. ISO's
+      # number_from_kv) drive deserialization.
+      def apply_mappings(doc, format, options = {})
+        return super unless hash_with_type?(doc, format)
+
+        klass = concrete_class_for(doc)
+        return super unless klass && klass != self
+
+        klass.from_hash(doc, options)
+      end
+
+      # Resolve a polymorphic _type to the concrete class that owns it:
+      # this flavor's own map first, then any registered flavor's map via
+      # {TypeResolver}. Returns nil for blank or unknown types.
+      def concrete_class_for(data)
+        type = data && (data["_type"] || data[:_type])
+        return nil unless type
+
+        polymorphic_type_map[type] || ::Pubid::TypeResolver.resolve(type)
       end
 
       # Map of polymorphic_name ("pubid:iso:corrigendum") => concrete class for
@@ -33,13 +58,20 @@ module Pubid
       # `Identifiers` namespace for Pubid::Identifier descendants and unioning
       # the flavor's `identifier_types` registry (which may register classes
       # living outside that namespace, e.g. ISO's BundledIdentifier). Memoized
-      # per class.
+      # per class. Public so {TypeResolver} can read another flavor's map for
+      # cross-flavor polymorphic dispatch.
       def polymorphic_type_map
         @polymorphic_type_map ||=
           identifier_registry_classes.each_with_object({}) do |klass, map|
             poly = klass.polymorphic_name
             map[poly] ||= klass if poly
           end
+      end
+
+      private
+
+      def hash_with_type?(doc, format)
+        format == :hash && doc.is_a?(Hash) && (doc["_type"] || doc[:_type])
       end
 
       private

--- a/lib/pubid/type_resolver.rb
+++ b/lib/pubid/type_resolver.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Pubid
+  # Resolves a polymorphic `_type` string (e.g. "pubid:iso:technical-report")
+  # to the concrete Ruby class that owns it.
+  #
+  # Each flavor's Identifier base owns a `polymorphic_type_map` for the types
+  # defined in its own namespace. A nested polymorphic attribute (e.g. a GOST
+  # Harmonized identifier's adopted ISO identifier) carries a `_type` from a
+  # different flavor, so the owning flavor's map misses. This service routes
+  # the lookup to the registered flavor whose name appears in the type's
+  # second segment ("pubid:<flavor>:…"), giving every from_hash caller a
+  # single cross-flavor dispatch path.
+  class TypeResolver
+    TYPE_PREFIX = "pubid:"
+    SEGMENT_SEPARATOR = ":"
+
+    class << self
+      # @param type [String, nil] Polymorphic _type, e.g. "pubid:iso:technical-report".
+      # @return [Class<Pubid::Identifier>, nil] The concrete class, or nil if
+      #   the type is blank, malformed, or unknown to its flavor.
+      def resolve(type)
+        return nil unless type.is_a?(String)
+
+        flavor_name = flavor_segment(type)
+        return nil unless flavor_name
+
+        # Ensure the flavor module is loaded so its self-register call has
+        # run; without this, Registry may know of flavors that haven't yet
+        # populated their Identifier base's polymorphic_type_map.
+        ::Pubid.eager_load_flavors!
+
+        flavor = ::Pubid::Registry.get(flavor_name)
+        return nil unless flavor
+
+        identifier_base = flavor::Identifier
+        identifier_base.polymorphic_type_map[type]
+      rescue NameError
+        # Flavor module is registered but its Identifier base cannot be
+        # loaded (autoload failure). Treat as unresolvable.
+        nil
+      end
+
+      private
+
+      # The flavor name is the segment between the leading "pubid:" and the
+      # type-name, e.g. "iso" in "pubid:iso:technical-report".
+      def flavor_segment(type)
+        return nil unless type.start_with?(TYPE_PREFIX)
+
+        remainder = type[TYPE_PREFIX.length..]
+        flavor_end = remainder.index(SEGMENT_SEPARATOR)
+        return nil unless flavor_end
+
+        remainder[0, flavor_end]
+      end
+    end
+  end
+end

--- a/spec/pubid/gost/identifier_spec.rb
+++ b/spec/pubid/gost/identifier_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Pubid::Gost::Identifier do
     end
   end
 
-  describe ".parse — parens adoption reference (MOD/NEQ/unknown)" do
+  describe ".parse — harmonized (parens form)" do
     {
       "ГОСТ 35311.2-2025 (EN 1129-2:1995)"              => "GOST 35311.2-2025 (EN 1129-2:1995)",
       "ГОСТ 35298-2025 (ISO 23767:2021)"                => "GOST 35298-2025 (ISO 23767:2021)",
@@ -111,14 +111,46 @@ RSpec.describe Pubid::Gost::Identifier do
       end
     end
 
-    it "captures adopted_reference" do
+    it "routes single ISO parens to Harmonized" do
       id = Pubid::Gost.parse("ГОСТ 35298-2025 (ISO 23767:2021)")
-      expect(id.adopted_reference).to eq("ISO 23767:2021")
+      expect(id).to be_a(Pubid::Gost::Identifiers::Harmonized)
+      expect(id.base).to be_a(Pubid::Gost::Identifiers::InterstateStandard)
+      expect(id.adopted_identifiers.size).to eq(1)
+      expect(id.adopted_identifiers.first.to_s).to eq("ISO 23767:2021")
     end
 
-    it "stays as InterstateStandard (not a different class)" do
-      id = Pubid::Gost.parse("ГОСТ 35298-2025 (ISO 23767:2021)")
-      expect(id).to be_a(Pubid::Gost::Identifiers::InterstateStandard)
+    it "wraps unparseable foreign references as ForeignReference inside Harmonized" do
+      id = Pubid::Gost.parse("ГОСТ 34853-2022 (OECD 460:2017)")
+      expect(id).to be_a(Pubid::Gost::Identifiers::Harmonized)
+      expect(id.adopted_identifiers.size).to eq(1)
+      expect(id.adopted_identifiers.first).to be_a(Pubid::Gost::Identifiers::ForeignReference)
+      expect(id.adopted_identifiers.first.to_s).to eq("OECD 460:2017")
+    end
+  end
+
+  describe ".parse — multi-identifier harmonization" do
+    {
+      "ГОСТ 25346-2013 (ISO 286-1:2010)"                                  => "GOST 25346-2013 (ISO 286-1:2010)",
+      "ГОСТ 6032-2017 (ISO 3651-1:1998, ISO 3651-2:1998)"                 => "GOST 6032-2017 (ISO 3651-1:1998, ISO 3651-2:1998)",
+      "ГОСТ 6996-66 (ИСО 4136-89, ИСО 5173-81, ИСО 5177-81)"              => "GOST 6996-66 (ISO 4136-89, ISO 5173-81, ISO 5177-81)",
+    }.each do |input, canonical|
+      it "parses #{input.inspect} → #{canonical.inspect}" do
+        expect(Pubid::Gost.parse(input).to_s).to eq(canonical)
+      end
+    end
+
+    it "routes to Harmonized with multiple adopted identifiers" do
+      id = Pubid::Gost.parse("ГОСТ 6032-2017 (ISO 3651-1:1998, ISO 3651-2:1998)")
+      expect(id).to be_a(Pubid::Gost::Identifiers::Harmonized)
+      expect(id.adopted_identifiers.size).to eq(2)
+      expect(id.adopted_identifiers.map(&:to_s)).to eq(["ISO 3651-1:1998", "ISO 3651-2:1998"])
+    end
+
+    it "normalizes Cyrillic ИСО → ISO in each adopted identifier" do
+      id = Pubid::Gost.parse("ГОСТ 6996-66 (ИСО 4136-89, ИСО 5173-81, ИСО 5177-81)")
+      expect(id).to be_a(Pubid::Gost::Identifiers::Harmonized)
+      expect(id.adopted_identifiers.size).to eq(3)
+      expect(id.adopted_identifiers.map(&:to_s)).to eq(["ISO 4136-89", "ISO 5173-81", "ISO 5177-81"])
     end
   end
 
@@ -128,6 +160,7 @@ RSpec.describe Pubid::Gost::Identifier do
       "GOST R 34.12-2015"       => "urn:gost:std:r:34.12:2015",
       "GOST 2.312"              => "urn:gost:std:2.312",
       "ГОСТ 31610.18-2016/IEC 60079-18:2014" => "urn:gost:std:31610.18:2016",
+      "ГОСТ 6032-2017 (ISO 3651-1:1998, ISO 3651-2:1998)" => "urn:gost:std:6032:2017",
     }.each do |input, urn|
       it "renders #{input.inspect} as #{urn.inspect}" do
         expect(Pubid::Gost.parse(input).to_urn).to eq(urn)
@@ -153,6 +186,10 @@ RSpec.describe Pubid::Gost::Identifier do
       GOST\ 14946-82
       GOST\ R\ 34.12-2015
       GOST\ ISO\ 9692-1
+      ГОСТ\ 25346-2013\ (ISO\ 286-1:2010)
+      ГОСТ\ 6032-2017\ (ISO\ 3651-1:1998,\ ISO\ 3651-2:1998)
+      ГОСТ\ 6996-66\ (ИСО\ 4136-89,\ ИСО\ 5173-81,\ ИСО\ 5177-81)
+      ГОСТ\ Р\ 58904-2020/ISO/TR\ 25901-1:2016
     ].each do |code|
       it "round-trips #{code.inspect}" do
         id = Pubid::Gost.parse(code)

--- a/spec/pubid/gost/identifiers/foreign_reference_spec.rb
+++ b/spec/pubid/gost/identifiers/foreign_reference_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pubid/gost"
+
+RSpec.describe Pubid::Gost::Identifiers::ForeignReference do
+  describe ".type" do
+    it "registers under the foreign-reference key" do
+      expect(described_class.type[:key]).to eq(:"foreign-reference")
+    end
+  end
+
+  describe "#to_s" do
+    it "renders the raw surface form verbatim" do
+      ref = described_class.new(raw: "OECD 460:2017")
+      expect(ref.to_s).to eq("OECD 460:2017")
+    end
+
+    it "renders an empty string when raw is nil" do
+      expect(described_class.new.to_s).to eq("")
+    end
+  end
+
+  describe "polymorphic registration" do
+    it "appears in GOST_TYPE_MAP so it round-trips through to_hash/from_hash" do
+      expect(Pubid::Gost::Identifier::GOST_TYPE_MAP)
+        .to include("pubid:gost:foreign-reference" => "Pubid::Gost::Identifiers::ForeignReference")
+    end
+  end
+end

--- a/spec/pubid/gost/identifiers/harmonized_spec.rb
+++ b/spec/pubid/gost/identifiers/harmonized_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pubid/gost"
+
+RSpec.describe Pubid::Gost::Identifiers::Harmonized do
+  describe ".type" do
+    it "registers under the harmonized key" do
+      expect(described_class.type[:key]).to eq(:harmonized)
+    end
+  end
+
+  describe "polymorphic registration" do
+    it "appears in GOST_TYPE_MAP" do
+      expect(Pubid::Gost::Identifier::GOST_TYPE_MAP)
+        .to include("pubid:gost:harmonized" => "Pubid::Gost::Identifiers::Harmonized")
+    end
+  end
+
+  describe "delegation to base" do
+    let(:base) do
+      Pubid::Gost::Identifiers::InterstateStandard.new(number: "25346", year: "2013")
+    end
+
+    it "delegates number/year/copublisher/subtype to the base" do
+      harmonized = described_class.new(
+        base: base,
+        adopted_identifiers: [Pubid::Iso.parse("ISO 286-1:2010")],
+      )
+
+      expect(harmonized.number).to eq("25346")
+      expect(harmonized.year).to eq("2013")
+      expect(harmonized.copublisher).to be_nil
+      expect(harmonized.subtype).to be_nil
+    end
+  end
+end

--- a/spec/pubid/identifier_polymorphism_spec.rb
+++ b/spec/pubid/identifier_polymorphism_spec.rb
@@ -95,4 +95,31 @@ RSpec.describe "Identifier class polymorphism contract" do
       expect(base).to be_a(Pubid::Nist::Identifier)
     end
   end
+
+  describe "cross-flavor polymorphic dispatch" do
+    it "root Pubid::Identifier.from_hash dispatches by _type to a flavor class" do
+      require "pubid/iso"
+      hash = { "_type" => "pubid:iso:technical-report",
+               "number" => "25901", "part" => "1", "year" => "2016" }
+      resolved = Pubid::Identifier.from_hash(hash)
+      expect(resolved).to be_a(Pubid::Iso::Identifiers::TechnicalReport)
+      expect(resolved.to_s).to eq("ISO/TR 25901-1:2016")
+    end
+
+    it "from_hash on a flavor base dispatches a nested adopted identifier" do
+      require "pubid/gost"
+      outer = { "_type" => "pubid:gost:identical-adoption",
+                "number" => "58904",
+                "year" => "2020",
+                "base" => { "_type" => "pubid:gost:national-standard",
+                            "number" => "58904", "year" => "2020" },
+                "adopted" => { "_type" => "pubid:iso:technical-report",
+                               "number" => "25901", "part" => "1",
+                               "year" => "2016" } }
+      restored = Pubid::Gost::Identifier.from_hash(outer)
+      expect(restored).to be_a(Pubid::Gost::Identifiers::IdenticalAdoption)
+      expect(restored.adopted).to be_a(Pubid::Iso::Identifiers::TechnicalReport)
+      expect(restored.to_s).to eq("GOST R 58904-2020/ISO/TR 25901-1:2016")
+    end
+  end
 end

--- a/spec/pubid/type_resolver_spec.rb
+++ b/spec/pubid/type_resolver_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pubid"
+require "pubid/gost"
+
+RSpec.describe Pubid::TypeResolver do
+  describe ".resolve" do
+    it "returns nil for nil" do
+      expect(described_class.resolve(nil)).to be_nil
+    end
+
+    it "returns nil for a non-string" do
+      expect(described_class.resolve(Object.new)).to be_nil
+    end
+
+    it "returns nil when the type has no pubid: prefix" do
+      expect(described_class.resolve("iso:technical-report")).to be_nil
+    end
+
+    it "returns nil when the type has no flavor segment" do
+      expect(described_class.resolve("pubid:")).to be_nil
+    end
+
+    it "returns nil when the flavor is not registered" do
+      expect(described_class.resolve("pubid:unknown-flavor:thing")).to be_nil
+    end
+
+    it "returns nil when the type is unknown to its own flavor" do
+      expect(described_class.resolve("pubid:iso:not-a-real-type")).to be_nil
+    end
+
+    it "resolves an ISO _type to the concrete class" do
+      resolved = described_class.resolve("pubid:iso:technical-report")
+      expect(resolved).to eq(Pubid::Iso::Identifiers::TechnicalReport)
+    end
+
+    it "resolves a GOST _type to the concrete class" do
+      resolved = described_class.resolve("pubid:gost:harmonized")
+      expect(resolved).to eq(Pubid::Gost::Identifiers::Harmonized)
+    end
+
+    it "eager-loads flavors before lookup so Registry is populated" do
+      # In a fresh process, only loaded flavors appear in Registry. The
+      # resolver must trigger autoload so any registered flavor can serve
+      # its map — without this, a nested adopted ISO identifier inside a
+      # GOST Harmonized would never resolve.
+      expect(Pubid::Registry).to receive(:get).with("iso").and_call_original
+      described_class.resolve("pubid:iso:technical-report")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Parens-form GOST identifiers are now modelled as `Harmonized` (base GOST standard + one or more adopted foreign identifiers), replacing the previous raw-string `adopted_reference` attribute on the base standard. Slash form stays as `IdenticalAdoption`.

### Examples

- `ГОСТ 25346-2013 (ISO 286-1:2010)` → `Harmonized(base=GOST 25346-2013, adopted=[ISO 286-1:2010])`
- `ГОСТ 6032-2017 (ISO 3651-1:1998, ISO 3651-2:1998)` → multi-adopted
- `ГОСТ 6996-66 (ИСО 4136-89, ИСО 5173-81, ИСО 5177-81)` → Cyrillic ИСО normalized to ISO
- `ГОСТ Р 58904-2020/ISO/TR 25901-1:2016` → IdenticalAdoption (already existed)

### Architecture changes

- **`Pubid::TypeResolver`** (new): single source of truth for cross-flavor `_type` → concrete class lookup. Reads the flavor segment of the type (`pubid:<flavor>:<type>`), then asks that flavor's `Identifier.polymorphic_type_map`.
- **`Pubid::Identifier.from_hash` and `.apply_mappings`**: share `concrete_class_for(data)` so cross-flavor dispatch goes through one path. lutaml's nested cast no longer bypasses our override.
- **`polymorphic_type_map` is now public** — TypeResolver needs it for cross-flavor reads.
- **`ForeignReference`** (new GOST identifier): wraps the raw string when no registered flavor recognizes an adopted identifier (OECD, UNECE STANDARD, …). Preserves round-trip without sacrificing the model-driven Harmonized shape for the common ISO/IEC case.
- **`Harmonized` and `IdenticalAdoption` are now declarative** — hand-rolled `*_to_kv`/`*_from_kv` methods removed; `attribute … polymorphic: true` + plain `key_value` mapping cover both.
- **Builder no longer hardcodes `FOREIGN_FLAVORS`** — iterates `Pubid::Registry` (after `eager_load_flavors!`) so new flavors participate in foreign adoption automatically.

## Test plan

- [x] `bundle exec rspec spec/pubid/gost/` — 465 examples, 0 failures
- [x] `bundle exec rspec spec/pubid/type_resolver_spec.rb` — new
- [x] `bundle exec rspec spec/pubid/identifier_polymorphism_spec.rb` — 44 examples (added cross-flavor dispatch tests)
- [x] `bundle exec rake test:all` — 8929 examples, 0 failures, 1 pre-existing CSA pending
- [ ] GHA on all Rubies + downstream relaton