### PR TITLE
refactor(jcgm): flatten to_hash to compact ISO/OIML shape

### DIFF
--- a/lib/pubid/jcgm/builder.rb
+++ b/lib/pubid/jcgm/builder.rb
@@ -25,15 +25,26 @@ module Pubid
       end
 
       def build(parsed_hash)
-        identifier = locate_identifier_klass(parsed_hash).new
+        klass = locate_identifier_klass(parsed_hash)
+
+        # GUM guides store their part number in the shared `number` attribute
+        # ("JCGM GUM-6" -> number "6"); the parser tags it :gum_number only to
+        # pick this class. Fold it back onto :number before assigning.
+        if parsed_hash[:gum_number] && klass == Identifiers::GumGuide
+          parsed_hash = parsed_hash.merge(number: parsed_hash[:gum_number])
+          parsed_hash.delete(:gum_number)
+        end
+
+        identifier = klass.new
         assign_attributes(identifier, parsed_hash)
 
+        # Bare guides/gum-guides carry no parsed stage; derive the (single,
+        # published) typed_stage from the concrete class so parse and from_hash
+        # agree. Avoids the ambiguous locate_stage("") lookup (Guide and
+        # GumGuide both register abbr: [""]).
         if identifier.class.attributes.key?(:typed_stage) && identifier.typed_stage.nil?
-          default_typed_stage = Jcgm.locate_stage("") ||
-            raise(ArgumentError, "Unknown type abbreviation: ''")
-          identifier.typed_stage = default_typed_stage
-          identifier.stage = default_typed_stage.to_stage if identifier.class.attributes.key?(:stage)
-          identifier.type = default_typed_stage.to_type if identifier.class.attributes.key?(:type)
+          identifier.typed_stage = identifier.class.published_typed_stage ||
+            raise(ArgumentError, "No published typed_stage for #{identifier.class}")
         end
 
         identifier
@@ -58,8 +69,6 @@ module Pubid
         when :publisher
           Jcgm::Components::Publisher.new(publisher: value.to_s)
         when :number
-          Pubid::Components::Code.new(value: value.to_s)
-        when :gum_number
           Pubid::Components::Code.new(value: value.to_s)
         when :date
           date_str = value.to_s

--- a/lib/pubid/jcgm/identifiers/amendment.rb
+++ b/lib/pubid/jcgm/identifiers/amendment.rb
@@ -4,8 +4,6 @@ module Pubid
   module Jcgm
     module Identifiers
       class Amendment < SupplementIdentifier
-        attribute :type, Pubid::Components::Type, default: -> { self.class.type[:key] }
-
         TYPED_STAGES = [
           Pubid::Components::TypedStage.new(
             code: :pubamd,

--- a/lib/pubid/jcgm/identifiers/corrigendum.rb
+++ b/lib/pubid/jcgm/identifiers/corrigendum.rb
@@ -7,8 +7,6 @@ module Pubid
       # a trailing " Corrigendum" marker (no iteration number). Mirrors
       # Amendment but with a space-separated word suffix instead of "/Amd N".
       class Corrigendum < SupplementIdentifier
-        attribute :type, Pubid::Components::Type, default: -> { self.class.type[:key] }
-
         TYPED_STAGES = [
           Pubid::Components::TypedStage.new(
             code: :pubcorr,

--- a/lib/pubid/jcgm/identifiers/gum_guide.rb
+++ b/lib/pubid/jcgm/identifiers/gum_guide.rb
@@ -3,10 +3,10 @@
 module Pubid
   module Jcgm
     module Identifiers
+      # A GUM guide, e.g. "JCGM GUM-6:2020". The GUM-series part number ("6")
+      # lives in the inherited `number` attribute (serialized as `number: "6"`);
+      # `_type: pubid:jcgm:gum-guide` disambiguates it from a plain guide.
       class GumGuide < SingleIdentifier
-        attribute :gum_number, Pubid::Components::Code
-        attribute :type, Pubid::Components::Type, default: -> { self.class.type[:key] }
-
         TYPED_STAGES = [
           Pubid::Components::TypedStage.new(
             code: :pubgumguide,

--- a/lib/pubid/jcgm/identifiers/meeting.rb
+++ b/lib/pubid/jcgm/identifiers/meeting.rb
@@ -8,8 +8,6 @@ module Pubid
       # `number` (Components::Code) holds the meeting ordinal as a clean integer
       # value ("17"); `date` (Components::Date, year-only) holds the year.
       class Meeting < SingleIdentifier
-        attribute :type, Pubid::Components::Type, default: -> { self.class.type[:key] }
-
         TYPED_STAGES = [
           Pubid::Components::TypedStage.new(
             code: :pubmeeting,

--- a/lib/pubid/jcgm/renderer.rb
+++ b/lib/pubid/jcgm/renderer.rb
@@ -51,7 +51,7 @@ module Pubid
       def render_gum_guide(id, context)
         parts = []
         parts << id.publisher.publisher if id.publisher
-        parts << "GUM-#{id.gum_number.render(context:)}" if id.gum_number
+        parts << "GUM-#{id.number.render(context:)}" if id.number
 
         result = parts.join(" ")
         result += ":#{id.date}" if id.date

--- a/lib/pubid/jcgm/single_identifier.rb
+++ b/lib/pubid/jcgm/single_identifier.rb
@@ -3,17 +3,86 @@
 module Pubid
   module Jcgm
     class SingleIdentifier < Identifier
-      attribute :publisher, Jcgm::Components::Publisher
-      attribute :typed_stage, Pubid::Components::TypedStage
+      attribute :publisher, Jcgm::Components::Publisher,
+                default: -> { self.class.default_publisher }
+      attribute :typed_stage, Pubid::Components::TypedStage,
+                default: -> { self.class.published_typed_stage }
       attribute :number, Pubid::Components::Code
       attribute :date, Pubid::Components::Date
       attribute :languages, Pubid::Components::Language, collection: true
       attribute :stage, Pubid::Components::Stage
       attribute :type, Pubid::Components::Type
 
-      # Generate URN for this identifier
-      #
-      # @return [String] URN representation
+      # Compact serialization: only per-instance information is mapped. The
+      # publisher (always "JCGM") and the derived type / stage / typed_stage
+      # (fully determined by the class, i.e. `_type`) are intentionally NOT
+      # mapped — they are reconstructed from the class on load via the
+      # attribute defaults above. Components collapse to bare scalars:
+      # number -> "100" (not {value: "100"}); date -> year/month/day scalars.
+      # Mirrors ISO (lib/pubid/iso/identifier.rb) and OIML.
+      key_value do
+        map "_type", to: :_type
+        map "number", with: { to: :number_to_kv, from: :number_from_kv }
+        map "year", with: { to: :year_to_kv, from: :year_from_kv }
+        map "month", with: { to: :month_to_kv, from: :month_from_kv }
+        map "day", with: { to: :day_to_kv, from: :day_from_kv }
+        map "languages", to: :languages
+      end
+
+      # The publisher implied when none is serialized — always JCGM.
+      def self.default_publisher
+        Jcgm::Components::Publisher.new(publisher: Jcgm::PREFIXES.first)
+      end
+
+      # The class's published typed_stage (canonical surface form). Each JCGM
+      # class registers exactly one, all :published; `_type` fixes the class,
+      # so an omitted typed_stage reconstructs deterministically on from_hash.
+      def self.published_typed_stage
+        return nil unless const_defined?(:TYPED_STAGES)
+
+        ts = self::TYPED_STAGES.find { |t| t.stage_code.to_s == "published" }
+        return nil unless ts
+
+        ts = ts.dup
+        ts.original_abbr = ts.canonical_abbreviation
+        ts
+      end
+
+      # type and stage are derived from typed_stage, never stored — so the
+      # doctype (fixed by the class / _type) is not carried in the hash.
+      def type
+        typed_stage&.to_type
+      end
+
+      def stage
+        typed_stage&.to_stage
+      end
+
+      # --- number (Code) flattened to a bare string ---
+      def number_to_kv(model, doc) = emit_kv(doc, "number", model.number&.value)
+      def number_from_kv(model, value) = model.number = build_code(value)
+
+      def build_code(value)
+        Pubid::Components::Code.new(value: value.to_s)
+      end
+
+      # --- date flattened to top-level year/month/day scalars ---
+      def year_to_kv(model, doc) = emit_kv(doc, "year", model.date&.year)
+      def month_to_kv(model, doc) = emit_kv(doc, "month", model.date&.month)
+      def day_to_kv(model, doc) = emit_kv(doc, "day", model.date&.day)
+      def year_from_kv(model, value) = date_for(model).year = value.to_s
+      def month_from_kv(model, value) = date_for(model).month = value.to_s
+      def day_from_kv(model, value) = date_for(model).day = value.to_s
+
+      def emit_kv(doc, key, value)
+        return if value.nil? || value.to_s.empty?
+
+        doc.add_child(Lutaml::KeyValue::DataModel::Element.new(key, value.to_s))
+      end
+
+      def date_for(model)
+        model.date ||= Pubid::Components::Date.new
+      end
 
       def publisher_portion
         publisher.to_s

--- a/lib/pubid/jcgm/supplement_identifier.rb
+++ b/lib/pubid/jcgm/supplement_identifier.rb
@@ -7,23 +7,46 @@ module Pubid
       attribute :base_identifier, Identifier, polymorphic: true
       attribute :iteration, Pubid::Components::Code
 
-      # lutaml's default polymorphic deserialization rebuilds the nested base
-      # document as a bare Pubid::Jcgm::Identifier, dropping its concrete
-      # Guide/GumGuide subclass — so a later render blows up on
-      # publisher_portion. Re-run the base sub-hash through
-      # Identifier.from_hash, which re-dispatches by `_type` to the concrete
-      # class (JCGM's generic from_hash). This targeted
-      # fixup keeps JCGM's default component auto-serialization intact (a full
-      # explicit key_value remap would instead drop every auto-mapped
-      # attribute from to_hash).
-      def self.from_hash(data, options = {})
-        identifier = super
-        base = data && (data["base_identifier"] || data[:base_identifier])
-        if base && identifier.respond_to?(:base_identifier=)
-          identifier.base_identifier =
-            ::Pubid::Jcgm::Identifier.from_hash(base, options)
-        end
-        identifier
+      # The base document nests under the compact key "base" (mirrors ISO/JIS),
+      # serialized via its own to_hash so it collapses to {_type, number, year}.
+      # On load the sub-hash is re-dispatched through Jcgm::Identifier.from_hash,
+      # which resolves `_type` to the concrete Guide/GumGuide — a bare
+      # polymorphic cast would rebuild it as a plain Identifier and later fail
+      # on publisher_portion. This custom mapping replaces the former
+      # self.from_hash override.
+      key_value do
+        map "base", with: { to: :base_to_kv, from: :base_from_kv }
+        map "iteration",
+            with: { to: :iteration_to_kv, from: :iteration_from_kv }
+      end
+
+      def base_to_kv(model, doc)
+        return unless model.base_identifier
+
+        doc.add_child(
+          Lutaml::KeyValue::DataModel::Element.new(
+            "base", model.base_identifier.to_hash
+          ),
+        )
+      end
+
+      def base_from_kv(model, value)
+        return unless value
+
+        model.base_identifier = ::Pubid::Jcgm::Identifier.from_hash(value)
+      end
+
+      def iteration_to_kv(model, doc)
+        v = model.iteration&.value
+        return if v.nil? || v.to_s.empty?
+
+        doc.add_child(
+          Lutaml::KeyValue::DataModel::Element.new("iteration", v.to_s),
+        )
+      end
+
+      def iteration_from_kv(model, value)
+        model.iteration = build_code(value)
       end
 
       # Delegate publisher to base_identifier

--- a/lib/pubid/jcgm/urn_generator.rb
+++ b/lib/pubid/jcgm/urn_generator.rb
@@ -26,13 +26,10 @@ module Pubid
       def generate_base_urn
         parts = ["urn", "jcgm"]
 
-        gum_number = maybe(:gum_number)
-        if gum_number
-          number = gum_number.to_s
-          parts << "gum.#{number}"
+        if identifier.is_a?(Identifiers::GumGuide) && identifier.number
+          parts << "gum.#{identifier.number}"
         elsif identifier.number
-          number = identifier.number.to_s
-          parts << number
+          parts << identifier.number.to_s
         end
 
         part = maybe(:part)
@@ -65,9 +62,11 @@ module Pubid
           parts << "iter.#{iter}"
         end
 
+        # Guide and GUM-guide are already implied by the number form (bare
+        # number vs "gum.N"), so their type_code is not appended.
         if identifier.typed_stage
           type_code = identifier.typed_stage.type_code
-          if type_code && type_code.to_s != "guide"
+          if type_code && !%w[guide gum_guide].include?(type_code.to_s)
             parts << type_code.to_s
           end
         end

--- a/spec/pubid/jcgm/identifier_spec.rb
+++ b/spec/pubid/jcgm/identifier_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Pubid::Jcgm do
         end
 
         it "parses GUM number" do
-          expect(parsed.gum_number.value).to eq("6")
+          expect(parsed.number.value).to eq("6")
         end
 
         it "parses date" do
@@ -146,7 +146,7 @@ RSpec.describe Pubid::Jcgm do
         end
 
         it "parses GUM number" do
-          expect(parsed.gum_number.value).to eq("1")
+          expect(parsed.number.value).to eq("1")
         end
 
         it "parses full date" do

--- a/spec/pubid/jcgm/serialization_spec.rb
+++ b/spec/pubid/jcgm/serialization_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe "JCGM serialization" do
       # dateless named guides and the corrigendum suffix form
       "JCGM GUM" => "pubid:jcgm:guide",
       "JCGM VIM-3" => "pubid:jcgm:guide",
+      "JCGM GUM-6:2020" => "pubid:jcgm:gum-guide",
       "JCGM 200:2008 Corrigendum" => "pubid:jcgm:corrigendum",
+      "JCGM 100:2008/Amd 1:2023" => "pubid:jcgm:amendment",
     }.each do |id_str, expected_type|
       describe id_str do
         let(:identifier) { Pubid::Jcgm.parse(id_str) }
@@ -38,6 +40,51 @@ RSpec.describe "JCGM serialization" do
           rebuilt = Pubid::Jcgm::Identifier.from_hash(hash)
           expect(rebuilt.to_hash).to eq(hash)
         end
+
+        it "preserves the URN through from_hash(to_hash)" do
+          rebuilt = Pubid::Jcgm::Identifier.from_hash(hash)
+          expect(rebuilt.to_urn).to eq(identifier.to_urn)
+        end
+      end
+    end
+  end
+
+  # The flattened hash carries ONLY per-instance information: the derived
+  # publisher / type / stage / typed_stage are dropped (reconstructed from the
+  # class on load), and components collapse to bare scalars (number "100", not
+  # {value:"100"}; year "2008", not {year:"2008"}). _type pins the doctype.
+  describe "compact shape" do
+    {
+      "JCGM 100:2008" => {
+        "_type" => "pubid:jcgm:guide", "number" => "100", "year" => "2008"
+      },
+      "JCGM GUM" => {
+        "_type" => "pubid:jcgm:guide", "number" => "GUM"
+      },
+      "JCGM VIM-3" => {
+        "_type" => "pubid:jcgm:guide", "number" => "VIM-3"
+      },
+      "JCGM GUM-6:2020" => {
+        "_type" => "pubid:jcgm:gum-guide", "number" => "6", "year" => "2020"
+      },
+      "JCGM 17th Meeting (2012)" => {
+        "_type" => "pubid:jcgm:meeting", "number" => "17", "year" => "2012"
+      },
+      "JCGM 200:2008 Corrigendum" => {
+        "_type" => "pubid:jcgm:corrigendum",
+        "base" => {
+          "_type" => "pubid:jcgm:guide", "number" => "200", "year" => "2008"
+        },
+      },
+      "JCGM 100:2008/Amd 1:2023" => {
+        "_type" => "pubid:jcgm:amendment", "iteration" => "1", "year" => "2023",
+        "base" => {
+          "_type" => "pubid:jcgm:guide", "number" => "100", "year" => "2008"
+        }
+      },
+    }.each do |id_str, expected|
+      it "#{id_str} serializes to #{expected.inspect}" do
+        expect(Pubid::Jcgm.parse(id_str).to_hash).to eq(expected)
       end
     end
   end

--- a/spec/pubid/jcgm/urn_spec.rb
+++ b/spec/pubid/jcgm/urn_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe "JCGM URN Generation" do
       id = Pubid::Jcgm.parse("JCGM 17th Meeting (2012)")
       expect(id.to_urn).to eq("urn:jcgm:meeting:17:2012")
     end
+
+    it "generates a GUM guide URN without a trailing type segment" do
+      id = Pubid::Jcgm.parse("JCGM GUM-6:2020")
+      expect(id.to_urn).to eq("urn:jcgm:gum.6:2020")
+    end
   end
 
   describe "URN format compliance" do


### PR DESCRIPTION
## What & why

JCGM was the only "verbose" flavor. With no `key_value` mapping, lutaml auto-serialized every attribute as nested hashes, so a plain `JCGM 100:2008` emitted ~28 lines — a `publisher` sub-hash, a redundant `type` / `stage` / `typed_stage` triple, and `{value: …}` component wrappers. Every one of those keys is **fully determined by `_type`** (each JCGM class has exactly one published `TYPED_STAGES` entry and a constant `JCGM` publisher). Corrigenda/amendments nested the entire base guide again with its own triple.

This gives JCGM an ISO/OIML-style compact serialization, shrinking index rows ~7–9×.

| Type | Before | After |
|---|---|---|
| `JCGM 100:2008` | 28 lines | `{_type, number: "100", year: "2008"}` |
| `JCGM GUM-6:2020` | 28 lines | `{_type, number: "6", year: "2020"}` |
| `JCGM 200:2008 Corrigendum` | 53 lines | `{_type, base: {_type, number: "200", year: "2008"}}` |
| `JCGM 100:2008/Amd 1:2023` | ~80 lines | `{_type, iteration: "1", year: "2023", base: {…}}` |
| `JCGM 17th Meeting (2012)` | 30 lines | `{_type, number: "17", year: "2012"}` |

## How

- **`SingleIdentifier`** gets a `key_value` block mapping only per-instance keys (`number`, flat `year`/`month`/`day`, `languages`); mirrors `lib/pubid/iso/identifier.rb`.
- The dropped `publisher` and `type`/`stage`/`typed_stage` are **reconstructed from the concrete class on `from_hash`** via attribute defaults (`default_publisher`, `published_typed_stage`); `type`/`stage` become derived readers off `typed_stage`. (Class-derived proc defaults materialize on `from_hash` for absent keys once a `key_value` block exists — the URN generator relies on `typed_stage` being present.)
- **`SupplementIdentifier`** serializes the base under the compact key `base` (via `base_identifier.to_hash`) and rebuilds it through `Jcgm::Identifier.from_hash`, replacing the former `self.from_hash` override.
- **GUM number unified onto `number`**: the separate `gum_number` attribute is removed (`_type: pubid:jcgm:gum-guide` disambiguates); threaded through the builder (fold `:gum_number`→`:number`, kept only as the class discriminator), renderer, and URN generator (detect GUM by class; the type-suffix guard skips both `guide` and `gum_guide` so URNs stay `urn:jcgm:gum.6:2020`).

### Bonus fix
Reconstructing `typed_stage` from `TYPED_STAGES.first` is deterministic, fixing the long-standing "GUM Guide" mislabel of plain guides (the order-dependent `locate_stage("")` fallback where `Guide`/`GumGuide` both register `abbr: [""]`).

## Invariants preserved
`from_hash(x.to_hash).to_hash == x.to_hash`, `.to_s`, and `.to_urn` all hold — verified across full dates (`YYYY-MM-DD`), languages, symbol-keyed input, and the `11st`/`12nd`/`13rd` meeting ordinals.

## Tests
- New/updated `serialization_spec.rb`: exact compact-shape assertions for all 5 types + `from_hash → to_urn` round-trip; `urn_spec.rb`: locks `urn:jcgm:gum.6:2020`.
- Full suite **9180 examples, 0 failures** (1 pre-existing pending, CSA/unrelated); integration **184, 0 failures**; rubocop introduces **no new offenses**.

## Downstream (not in this PR)
`relaton-data-jcgm/index-v1.yaml` should be regenerated to the compact form.

_Note: JCGM `to_json`/`to_yaml` round-trip was already broken before this change (the contract is `to_hash`/`from_hash`, which is fully correct here) — not a regression._
