### PR TITLE
feat(etsi): parse partial references with optional version/date

### DIFF
--- a/lib/pubid/etsi/builder.rb
+++ b/lib/pubid/etsi/builder.rb
@@ -95,19 +95,23 @@ module Pubid
       end
 
       def build_version(data)
-        # Handle both version and edition
+        # Handle both version and edition. A partial reference omits both, in
+        # which case version is left nil (not defaulted) so exclude/matches?
+        # treat it as a wildcard.
         if data[:version]
           Components::Version.new(version: data[:version].to_s,
                                   is_edition: false)
         elsif data[:edition]
           Components::Version.new(version: data[:edition].to_s,
                                   is_edition: true)
-        else
-          Components::Version.new(version: "1.0.0", is_edition: false)
         end
       end
 
       def build_date(data)
+        # A partial reference omits the date; leave it nil rather than building
+        # an empty Date, so the canonical to_hash drops it entirely.
+        return nil unless data[:year]
+
         Pubid::Components::Date.new(
           year: data[:year].to_s,
           month: data[:month].to_s,

--- a/lib/pubid/etsi/parser.rb
+++ b/lib/pubid/etsi/parser.rb
@@ -114,13 +114,19 @@ module Pubid
       end
 
       # Main identifier
+      #
+      # The mandatory core is `etsi_prefix type number` (+ optional
+      # minor/parts/supplements), mirroring ISO. The version/edition and date
+      # suffixes are optional so a partial reference (e.g. "ETSI GS ZSM 012")
+      # parses with version/date left nil. Each `.maybe` guards its own leading
+      # space so no trailing space is demanded when the suffix is absent.
       rule(:identifier) do
         etsi_prefix >>
           type >> space >>
           number >> minor.maybe >> parts >>
           supplements.maybe >>
-          space >> version_or_edition >>
-          space >> date_part
+          (space >> version_or_edition).maybe >>
+          (space >> date_part).maybe
       end
 
       rule(:root) { identifier }

--- a/lib/pubid/etsi/renderer.rb
+++ b/lib/pubid/etsi/renderer.rb
@@ -27,7 +27,10 @@ module Pubid
 
       def render_base(id)
         result = "#{id.publisher} #{id.type} #{id.code}"
-        result += " #{id.version} (#{id.date.render})"
+        # version/date are optional on partial references; append each only when
+        # present so a partial id renders without a stray " V… ()" suffix.
+        result += " #{id.version}" if id.version
+        result += " (#{id.date.render})" if id.date
         result
       end
 
@@ -35,7 +38,10 @@ module Pubid
         supplement_notations = id.collect_supplement_notations(id, [])
         actual_base = id.find_actual_base(id.base)
         code_with_supplements = "#{actual_base.code}#{supplement_notations.join}"
-        "#{actual_base.publisher} #{actual_base.type} #{code_with_supplements} #{actual_base.version} (#{actual_base.date.render})"
+        result = "#{actual_base.publisher} #{actual_base.type} #{code_with_supplements}"
+        result += " #{actual_base.version}" if actual_base.version
+        result += " (#{actual_base.date.render})" if actual_base.date
+        result
       end
     end
   end

--- a/spec/fixtures/etsi/identifiers/pass/partial.txt
+++ b/spec/fixtures/etsi/identifiers/pass/partial.txt
@@ -1,0 +1,11 @@
+# ETSI partial references - Pass
+# Bare references omitting version and/or date (version/date left nil).
+# These enable relaton to look ETSI documents up by a partial reference,
+# matching candidates via matches?(row_id, ignore: [:version, :date]).
+
+ETSI GS ZSM 012
+ETSI EN 300 175-1
+ETSI EN 300 175
+ETSI TS 102 606-1
+ETSI GR ZSM 009-3
+ETSI GTS GSM 02.01

--- a/spec/pubid/etsi/partial_spec.rb
+++ b/spec/pubid/etsi/partial_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+
+RSpec.describe "ETSI partial reference parsing" do
+  # Bare references that omit version and/or date. relaton needs these to parse
+  # (with version/date left nil) so it can match catalogue rows by excluding the
+  # components the reference omits.
+  partial_refs = [
+    "ETSI GS ZSM 012",
+    "ETSI EN 300 175-1",
+    "ETSI EN 300 175",
+    "ETSI TS 102 606-1",
+    "ETSI GR ZSM 009-3",
+    "ETSI GTS GSM 02.01",
+  ]
+
+  partial_refs.each do |ref|
+    describe ref.inspect do
+      subject(:id) { Pubid::Etsi.parse(ref) }
+
+      it "parses with version and date left nil" do
+        expect(id.version).to be_nil
+        expect(id.date).to be_nil
+      end
+
+      it "round-trips through to_s" do
+        expect(id.to_s).to eq(ref)
+      end
+
+      it "round-trips through to_hash/from_hash" do
+        hash = id.to_hash
+        expect(Pubid::Etsi::Identifier.from_hash(hash).to_hash).to eq(hash)
+      end
+    end
+  end
+
+  describe "#matches? with omitted components ignored" do
+    let(:partial) { Pubid::Etsi.parse("ETSI GS ZSM 012") }
+    let(:full)    { Pubid::Etsi.parse("ETSI GS ZSM 012 V1.1.1 (2022-12)") }
+    let(:other)   { Pubid::Etsi.parse("ETSI GS ZSM 013 V1.1.1 (2022-12)") }
+
+    it "matches a full id of the same document when ignoring version/date" do
+      expect(partial.matches?(full, ignore: %i[version date])).to be true
+    end
+
+    it "does not match a different document" do
+      expect(partial.matches?(other, ignore: %i[version date])).to be false
+    end
+  end
+
+  describe "full ids are unaffected" do
+    subject(:id) { Pubid::Etsi.parse(ref) }
+    let(:ref) { "ETSI GS ZSM 012 V1.1.1 (2022-12)" }
+
+    it "still carries version and date" do
+      expect(id.version).not_to be_nil
+      expect(id.date).not_to be_nil
+    end
+
+    it "round-trips to_s unchanged" do
+      expect(id.to_s).to eq(ref)
+    end
+
+    it "round-trips to_hash/from_hash unchanged" do
+      hash = id.to_hash
+      expect(Pubid::Etsi::Identifier.from_hash(hash).to_hash).to eq(hash)
+    end
+  end
+end


### PR DESCRIPTION
## Goal

Make `Pubid::Etsi.parse` accept a **partial** reference that omits the version and/or date — e.g. `"ETSI GS ZSM 012"`, `"ETSI EN 300 175-1"`, `"ETSI EN 300 175"` — returning an identifier with `version`/`date` left `nil`.

This is the missing piece for relaton to look ETSI documents up by a bare reference the way it already does for ISO: parse the reference into a pubid, narrow the index by number, then match candidates by excluding the omitted components (`matches?(row_id, ignore: [:version, :date])`). The matching side (`#exclude`/`#matches?`) already works on ETSI ids — only the parser could not produce a partial id.

## Changes

- **`lib/pubid/etsi/parser.rb`** — top `identifier` rule makes the version/edition and date suffixes `.maybe`, each guarding its own leading space. The mandatory core is now `etsi_prefix type number` (+ optional minor/parts/supplements), mirroring ISO.
- **`lib/pubid/etsi/builder.rb`** — `build_version` returns `nil` when both version and edition are absent (drops the previously-unreachable `"1.0.0"` default); `build_date` returns `nil` when there is no year, instead of building an empty `Date`.
- **`lib/pubid/etsi/renderer.rb`** — `render_base`/`render_supplement` append version/date only when present, so full ids render byte-identically and partials render without a stray `" V… ()"` suffix.
- New `spec/fixtures/etsi/identifiers/pass/partial.txt` and `spec/pubid/etsi/partial_spec.rb`.

`urn_generator.rb` needed no change (already guards `urn_version`/`urn_date`).

## Invariants preserved

- **Full ids unchanged.** PEG `.maybe` is greedy, so a full ref still consumes version+date; builder/renderer output is identical. Verified against the full ~24.7k fixture corpus: **24,723/24,724 exact `to_s` matches, 0 regressions** (the one miss is a pre-existing corrupt fixture line that also fails on `main`).
- **Partial ⇒ `nil`.** `version`/`date` are left `nil` (not a default), so the canonical `to_hash` drops them and `exclude`/`matches?` treat them as wildcards.
- **Full consumption still enforced.** Trailing garbage (`ETSI GS ZSM 012 garbage`) and near-miss dates (year-only `(1998)`) still fail — no silent-data-loss vector.
- **Supplements** (amendment/corrigendum) keep working; they wrap a base id whose suffixes are now optional.

## Tests

- New spec: 23 examples, 0 failures.
- Full ETSI suite (incl. the ~24.7k-id corpus round-trip): 49 examples, 0 failures.
- Full default suite `bundle exec rake` (test:all + test:integration): green.
- Rubocop: new spec clean; no new offenses introduced.

Acceptance criteria from the hand-off (`ETSI GS ZSM 012` / `EN 300 175-1` / `EN 300 175` parse with nil version/date; partial `matches?` full when ignoring version/date; full corpus round-trips unchanged; pass fixtures added) are all met.