### PR TITLE
feat(etsi): propagate ParseFailed and support part exclusion

### DIFF
--- a/lib/pubid/etsi/identifiers/base.rb
+++ b/lib/pubid/etsi/identifiers/base.rb
@@ -6,11 +6,12 @@ module Pubid
     # (Identifiers::Base is a back-compat alias); every concrete ETSI identifier
     # descends from it.
     class Identifier < ::Pubid::Identifier
+      # Let Parslet::ParseFailed propagate on a bad reference (matching ISO), so
+      # relaton-cli's `rescue Parslet::ParseFailed` fetch handler catches it
+      # instead of a bare RuntimeError.
       def self.parse(identifier)
         parsed = Parser.parse(identifier)
         Builder.build(parsed)
-      rescue Parslet::ParseFailed => e
-        raise "Failed to parse ETSI identifier '#{identifier}': #{e.message}"
       end
 
       attribute :type, :string
@@ -30,6 +31,29 @@ module Pubid
           code == other.code &&
           version == other.version &&
           date == other.date
+      end
+
+      private
+
+      # ETSI keeps the number and part together inside one Code component
+      # (unlike ISO's separate `part` attribute), so a top-level exclude(:part)
+      # can't reach the part. Handle it during the nested-exclusion pass: when
+      # :part/:parts is excluded, return a copy of the Code with its parts
+      # cleared while keeping the number/minor. This propagates into supplement
+      # wrappers too, because the base #exclude recurses through here with the
+      # original args. It lets a part-less reference match all parts via
+      # matches?(ignore: [..., :part]).
+      def exclude_from_nested(value, args)
+        part_keys = args & %i[part parts]
+        if value.is_a?(Pubid::Etsi::Components::Code) && !part_keys.empty?
+          return Pubid::Etsi::Components::Code.new(
+            number: value.number,
+            minor: value.minor,
+            parts: [],
+          )
+        end
+
+        super
       end
     end
 

--- a/spec/pubid/etsi/parse_error_spec.rb
+++ b/spec/pubid/etsi/parse_error_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+RSpec.describe "ETSI parse error class" do
+  # An unrecognized reference must raise Parslet::ParseFailed (matching ISO and
+  # what relaton-cli's fetch handler rescues) rather than a bare RuntimeError.
+  it "raises Parslet::ParseFailed for an unrecognized reference" do
+    expect { Pubid::Etsi.parse("this is not an etsi ref!!!") }
+      .to raise_error(Parslet::ParseFailed)
+  end
+
+  it "raises Parslet::ParseFailed from the class-level parse too" do
+    expect { Pubid::Etsi::Identifier.parse("garbage@@@") }
+      .to raise_error(Parslet::ParseFailed)
+  end
+
+  it "still parses a valid full reference" do
+    expect { Pubid::Etsi.parse("ETSI EN 300 175-1 V1.9.1 (2005-09)") }
+      .not_to raise_error
+  end
+
+  it "still parses a valid partial reference" do
+    expect { Pubid::Etsi.parse("ETSI EN 300 175") }.not_to raise_error
+  end
+end

--- a/spec/pubid/etsi/part_exclusion_spec.rb
+++ b/spec/pubid/etsi/part_exclusion_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+RSpec.describe "ETSI part exclusion" do
+  # ETSI keeps number + part inside one Code component, so exclude(:part) must
+  # clear the part while keeping the number, letting a part-less reference match
+  # all parts of a document via matches?(ignore: [..., :part]).
+
+  describe "#exclude(:part)" do
+    subject(:excluded) do
+      Pubid::Etsi.parse("ETSI EN 300 175-1 V1.9.1 (2005-09)").exclude(:part)
+    end
+
+    it "clears the part but keeps the number" do
+      expect(excluded.code.number).to eq("300 175")
+      expect(excluded.code.parts).to eq([])
+      expect(excluded.code.to_s).to eq("300 175")
+    end
+
+    it "accepts :parts as an alias" do
+      also = Pubid::Etsi.parse("ETSI EN 300 175-1 V1.9.1 (2005-09)")
+        .exclude(:parts)
+      expect(also.code.parts).to eq([])
+    end
+
+    it "leaves a part-less identifier unchanged" do
+      base = Pubid::Etsi.parse("ETSI EN 300 175")
+      expect(base.exclude(:part).code.to_s).to eq("300 175")
+    end
+  end
+
+  describe "#matches? ignoring the part" do
+    let(:partless) { Pubid::Etsi.parse("ETSI EN 300 175") }
+    let(:with_part) do
+      Pubid::Etsi.parse("ETSI EN 300 175-1 V1.9.1 (2005-09)")
+    end
+    let(:other_doc) do
+      Pubid::Etsi.parse("ETSI GS 300 176-1 V1.1.1 (2020-01)")
+    end
+
+    it "matches all parts when part/version/date are ignored" do
+      expect(
+        partless.matches?(with_part, ignore: %i[version date part]),
+      ).to be true
+    end
+
+    it "still distinguishes a different type/number" do
+      expect(
+        partless.matches?(other_doc, ignore: %i[version date part]),
+      ).to be false
+    end
+
+    it "does not match different parts when the part is NOT ignored" do
+      part1 = Pubid::Etsi.parse("ETSI EN 300 175-1 V1.9.1 (2005-09)")
+      part2 = Pubid::Etsi.parse("ETSI EN 300 175-2 V1.9.1 (2005-09)")
+      expect(part1.matches?(part2, ignore: %i[version date])).to be false
+      expect(part1.matches?(part2, ignore: %i[version date part])).to be true
+    end
+  end
+end


### PR DESCRIPTION
Two ETSI follow-ups surfaced while wiring relaton's ETSI `Bibliography` to the ISO-style pubid lookup (partial-ref parsing already landed via #130). Both were optional — relaton works around them today — but closing them makes ETSI behave uniformly with ISO.

## 1. `Pubid::Etsi.parse` raises `Parslet::ParseFailed`, not `RuntimeError`

`Etsi::Identifier.parse` previously rescued `Parslet::ParseFailed` and re-raised a bare `RuntimeError`, so an invalid ETSI ref escaped relaton-cli's friendly-message handler (`rescue Parslet::ParseFailed`). This lets `Parslet::ParseFailed` propagate, matching ISO. `ParseFailed < StandardError`, so relaton's existing broad rescue still works, and the CLI message now works for ETSI too. No spec depended on the old message.

## 2. Exclude the part while keeping the number (all-parts refs)

ETSI stores number **and** part inside one `Components::Code` (unlike ISO's separate `part` attribute), so `exclude(:part)` couldn't reach the part and `exclude(:code)` over-matched by dropping the number too. A part-less query therefore couldn't match all parts.

This overrides the private `exclude_from_nested` on `Pubid::Etsi::Identifier`: when `:part`/`:parts` is excluded, the `Code` is rebuilt with `parts: []` (keeping number/minor). It propagates into supplement wrappers (Amendment/Corrigendum) via the base `#exclude` recursion, so relaton can add `:part` to its `ignore` list when a ref omits the part.

## Acceptance

- `Pubid::Etsi.parse("garbage")` raises `Parslet::ParseFailed`; valid full/partial refs still parse.
- `parse("ETSI EN 300 175").matches?(parse("ETSI EN 300 175-1 V1.9.1 (2005-09)"), ignore: [:version, :date, :part])` → `true`, while against `ETSI GS 300 176-1 …` → `false` (type/number still distinguish).

## Tests

- New specs `spec/pubid/etsi/parse_error_spec.rb` + `part_exclusion_spec.rb` (10 examples, 0 failures).
- Full ETSI suite: 99 examples, 0 failures. Full default suite (`bundle exec rake`): green.
- Ruby 3.0-safe: uses the `(args & %i[part parts]).empty?` idiom (not `Array#intersect?`, which is 3.1+), consistent with `identifier.rb`.

## How relaton consumes both

relaton's ETSI `Bibliography` can drop its broad `rescue StandardError` and propagate `Parslet::ParseFailed`, and add the omitted `:part` to its `ignore` list so a part-less ref matches all parts (latest per part).