### PR TITLE
feat: make to_mr_string lossless across every flavor (#142)

### DIFF
--- a/lib/pubid/cie/identifiers/standard.rb
+++ b/lib/pubid/cie/identifiers/standard.rb
@@ -66,6 +66,18 @@ module Pubid
 
           result
         end
+
+        # CIE Standard distinguishes S-prefixed standards (`CIE S 017`) from
+        # plain (`CIE 015`), D-prefixed (`CIE D001`), and DIS-staged. The
+        # generic mr_type looks at typed_stage, which CIE doesn't use, so
+        # without this override the `S`/`D`/stage marker would be lost in MR.
+        def mr_type
+          return stage.downcase if stage
+          return "d" if d_prefix
+          return "s" if s_prefix
+
+          nil
+        end
       end
     end
   end

--- a/lib/pubid/cie/single_identifier.rb
+++ b/lib/pubid/cie/single_identifier.rb
@@ -47,6 +47,22 @@ module Pubid
         result.year = nil if args.include?(:year) || args.include?(:date)
         result
       end
+
+      # CIE stores its publication year in its own `year` string attribute
+      # (not a Components::Date), and uses a single-Language component with
+      # multiple formats. Override the lossless MR template so `CIE S 017/E:2011`
+      # round-trips as `CIE.S.017.E.2011` rather than losing the type letter,
+      # language, and year (issue #142). Subclasses add the `s_prefix` and
+      # `language` attributes that this template reads.
+      def mr_year
+        year&.to_s
+      end
+
+      def mr_languages
+        return nil unless respond_to?(:language) && language
+
+        "/#{language.code}"
+      end
     end
   end
 end

--- a/lib/pubid/csa/composite_identifier.rb
+++ b/lib/pubid/csa/composite_identifier.rb
@@ -23,6 +23,12 @@ module Pubid
         raise NotImplementedError, "Subclasses must implement to_s method"
       end
 
+      # CSA composites serialise through `to_s`, so MR mirrors that with
+      # ` ` → `.`. Issue #142.
+      def to_mr_string
+        to_s.tr(" ", ".")
+      end
+
       # CSA composites are not Pubid::Identifier objects, so they do not inherit
       # #root. They are their own origin for matching purposes.
       def root

--- a/lib/pubid/csa/identifier.rb
+++ b/lib/pubid/csa/identifier.rb
@@ -487,6 +487,17 @@ module Pubid
         end
         result
       end
+
+      # CSA encodes its identity across many shape-specific attributes
+      # (`publisher_prefix`, `code`, `no_number`, `series`, `series_prefix`,
+      # `package`, `reaffirmation`, `year` with prefix/format/French markers,
+      # etc.) that the generic MrString renderer doesn't know about. The
+      # CSA `to_s` already round-trips losslessly through the CSA parser, so
+      # MR mirrors it with ` ` → `.` and `:` kept (so a year never looks like
+      # another code segment). Issue #142.
+      def to_mr_string
+        to_s.tr(" ", ".")
+      end
     end
   end
 end

--- a/lib/pubid/csa/wrapper_identifier.rb
+++ b/lib/pubid/csa/wrapper_identifier.rb
@@ -27,6 +27,12 @@ module Pubid
         raise NotImplementedError, "Subclasses must implement to_s method"
       end
 
+      # CSA wrappers serialise through `to_s` (their distinct shape is what
+      # makes them wrappers), so MR mirrors that with ` ` → `.`. Issue #142.
+      def to_mr_string
+        to_s.tr(" ", ".")
+      end
+
       # CSA wrappers are not Pubid::Identifier objects, so they do not inherit
       # #root. They are their own origin for matching purposes.
       def root

--- a/lib/pubid/identifier.rb
+++ b/lib/pubid/identifier.rb
@@ -290,7 +290,14 @@ module Pubid
       render(format: :mr_string)
     end
 
-    # MR string template methods — flavors override as needed
+    # MR string template methods — flavors override as needed.
+    #
+    # The MR format is a lossless, dot-separated slug that mirrors `to_s`'s
+    # structure: `{publisher}[/{copublisher}…][.{type}].{number}[-{part}[-{subpart}…]][.{year}[-{month}[-{day}]|’--’}][.{edition}][.{languages}][.all-parts]`
+    # Supplements append `/{type}.{number}.{year}` recursively, so a
+    # chained supplement like `…/Amd 3:2016/Cor 1:2017` round-trips as
+    # `…/amd.3.2016/cor.1.2017`. The format is designed so distinct
+    # identifiers never collide on `to_mr_string` (issue #142).
     def mr_publisher
       publisher&.to_s
     end
@@ -299,7 +306,7 @@ module Pubid
       return nil unless typed_stage
 
       code = typed_stage.type_code
-      return nil if code.nil? || code.empty? || code == "is"
+      return nil if code.nil? || code.empty? || code.to_s == "is"
 
       code
     end
@@ -308,8 +315,10 @@ module Pubid
       num = mr_number
       return nil unless num
 
-      prt = mr_part
-      prt ? "#{num}-#{prt}" : num
+      segments = [num]
+      segments << mr_part if part
+      segments << mr_subpart if subpart
+      segments.compact.join("-")
     end
 
     def mr_number
@@ -320,8 +329,45 @@ module Pubid
       part&.to_s
     end
 
+    def mr_subpart
+      subpart&.to_s
+    end
+
     def mr_year
-      date&.year&.to_s
+      return nil unless date
+      return "--" if date.respond_to?(:undated?) && date.undated?
+      return nil unless date.year
+
+      result = date.year.to_s
+      result += "-#{date.month}" if date.respond_to?(:month) && date.month
+      result += "-#{date.day}" if date.respond_to?(:day) && date.day
+      result
+    end
+
+    def mr_edition
+      return nil unless edition&.number
+
+      "ed#{edition.number}"
+    end
+
+    def mr_languages
+      return nil unless languages&.any?
+
+      "(#{languages.map(&:code).join(',')})"
+    end
+
+    def mr_all_parts
+      return nil unless all_parts
+
+      "all-parts"
+    end
+
+    # Hook: supplement / wrapper subclasses return the `/{type}.{number}.{year}`
+    # suffix that distinguishes them from their base. `nil` for non-supplements.
+    # The base MrString renderer recurses into `base` whenever this returns
+    # a non-nil value, so chained supplements (Cor → Amd → IS) render fully.
+    def mr_supplement_suffix
+      nil
     end
 
     # URN template methods — flavors override as needed

--- a/lib/pubid/iec/supplement_identifier.rb
+++ b/lib/pubid/iec/supplement_identifier.rb
@@ -160,6 +160,19 @@ module Pubid
       def to_s(**opts)
         render(format: :human, **opts)
       end
+
+      # MR supplement suffix: `/{type}.{number}.{year}` (e.g. "/amd.1.2016").
+      # The MrString renderer recurses into `base` and appends this so the
+      # full supplement chain round-trips losslessly (issue #142).
+      def mr_supplement_suffix
+        segments = []
+        segments << mr_type if mr_type
+        segments << number&.to_s if number
+        segments << date&.year&.to_s if date&.year
+        return nil if segments.empty?
+
+        segments.join(".")
+      end
     end
   end
 end

--- a/lib/pubid/ieee/identifiers/base.rb
+++ b/lib/pubid/ieee/identifiers/base.rb
@@ -245,6 +245,28 @@ module Pubid
         builder.original_input = input
         builder.build(parsed)
       end
+
+      # IEEE stores identity in `code` (prefix/number/parts) rather than the
+      # generic `number`, has its own `type` string ("Std", "Draft Std"), and
+      # carries `year` as a bare string — none of which the generic MrString
+      # renderer knows about. Override the lossless MR template directly so
+      # every IEEE identifier round-trips (issue #142). Supplements append
+      # `/{type}.{number}.{year}` recursively via mr_supplement_suffix.
+      def mr_publisher
+        publisher&.to_s
+      end
+
+      def mr_type
+        type&.downcase
+      end
+
+      def mr_number_with_part
+        code_obj&.to_s
+      end
+
+      def mr_year
+        year&.to_s
+      end
     end
 
     module Identifiers

--- a/lib/pubid/ieee/identifiers/corrigendum.rb
+++ b/lib/pubid/ieee/identifiers/corrigendum.rb
@@ -19,6 +19,17 @@ module Pubid
             stage_code: "published",
           ),
         ].freeze
+
+        # MR supplement suffix: `cor.{number}.{year}` (e.g. "/cor.1.2017").
+        # The MrString renderer recurses into `base` and appends this so the
+        # full IEEE corrigendum round-trips losslessly (issue #142).
+        def mr_supplement_suffix
+          segments = []
+          segments << "cor"
+          segments << cor_number.to_s if cor_number
+          segments << cor_year.to_s if cor_year
+          segments.join(".")
+        end
       end
     end
   end

--- a/lib/pubid/iso/supplement_identifier.rb
+++ b/lib/pubid/iso/supplement_identifier.rb
@@ -35,6 +35,19 @@ module Pubid
         Pubid::Renderers::SupplementRenderer.new(self).render(context:,
                                                               **opts.slice(:with_edition))
       end
+
+      # MR supplement suffix: `/{type}.{number}.{year}` (e.g. "/amd.1.2020").
+      # The MrString renderer recurses into `base` and appends this so the
+      # full supplement chain round-trips losslessly (issue #142).
+      def mr_supplement_suffix
+        segments = []
+        segments << mr_type if mr_type
+        segments << number&.to_s if number
+        segments << date&.year&.to_s if date&.year
+        return nil if segments.empty?
+
+        segments.join(".")
+      end
     end
   end
 end

--- a/lib/pubid/itu/identifiers/base.rb
+++ b/lib/pubid/itu/identifiers/base.rb
@@ -45,6 +45,30 @@ module Pubid
       #
       # @return [String] URN representation
 
+      # ITU encodes identity across `sector` (T/R/CD), `series` (G/H/J…), and
+      # `code` (number with optional part), not in the inherited `number`/
+      # `typed_stage`. The generic MrString renderer would otherwise drop all
+      # three and emit just `ITU`. Losslessness for issue #142 requires the
+      # sector letter, series letter, and document number to appear in MR.
+      def mr_publisher
+        publisher&.to_s
+      end
+
+      def mr_type
+        sector&.sector&.to_s&.downcase
+      end
+
+      def mr_number_with_part
+        segments = []
+        segments << series&.series&.to_s if series&.series
+        segments << code&.number&.to_s if code&.number
+        segments << code&.subseries&.to_s if code&.subseries
+        segments.concat(code&.parts&.map(&:to_s) || [])
+        return nil if segments.empty?
+
+        segments.join("-")
+      end
+
       # Stored as a plain string (always "ITU") so it round-trips through
       # to_hash/from_hash. Was a `def publisher` method, which made lutaml
       # serialize a String against the Components::Publisher attribute.

--- a/lib/pubid/jis/identifier.rb
+++ b/lib/pubid/jis/identifier.rb
@@ -117,6 +117,56 @@ module Pubid
         render(format: :human, **opts)
       end
 
+      # JIS exposes its publisher as the `PUBLISHER` constant rather than the
+      # inherited `publisher` attribute, so the generic mr_publisher returns
+      # nil. Without this override every JIS id would lose its "JIS." prefix.
+      def mr_publisher
+        PUBLISHER
+      end
+
+      # JIS stores its identity across `series` (division letter A–Z), `number`
+      # (string, may have leading zeros), and `parts` (multi-level). The
+      # generic mr_number_with_part only knows about `number`/`part`/`subpart`,
+      # so without these overrides every JIS id would collapse onto its
+      # document number and drop the division letter (issue #142).
+      def mr_type
+        return nil unless respond_to?(:type_prefix)
+
+        type_prefix&.downcase
+      end
+
+      def mr_number_with_part
+        segments = []
+        segments << series.to_s if series
+        segments << number.to_s if number
+        parts&.each { |p| segments << p.to_s }
+        return nil if segments.empty?
+
+        segments.join("-")
+      end
+
+      # JIS stores the year as a bare integer (not a Components::Date), so the
+      # inherited mr_year (which reads `date`) returns nil. Emit it directly,
+      # including the reaffirmation marker so `JIS X:2019` and `JIS X:2019R`
+      # stay distinct in MR.
+      def mr_year
+        return nil unless year
+
+        year_with_reaffirmation.to_s
+      end
+
+      def mr_languages
+        return nil unless language
+
+        "(#{language})"
+      end
+
+      def mr_all_parts
+        return nil unless all_parts?
+
+        "all-parts"
+      end
+
       # from_hash is the shared polymorphic dispatch on Pubid::Identifier.
       # JIS_TYPE_MAP remains as the key_value polymorphic_map.
 

--- a/lib/pubid/nist/identifiers/base.rb
+++ b/lib/pubid/nist/identifiers/base.rb
@@ -243,6 +243,14 @@ module Pubid
                nist_format: format || parsed_format&.to_sym || :short)
       end
 
+      # NIST has its own defined MR format (to_mr_style) used by relaton-nist
+      # and downstream tooling. The generic Renderers::MrString does not know
+      # about NIST series, revisions, supplements, etc., so delegate to the
+      # established style for losslessness (issue #142).
+      def to_mr_string
+        to_mr_style
+      end
+
       # Returns weight based on amount of defined attributes
       # Used for ranking identifiers by specificity for conflict resolution
       # @return [Integer] weight score (higher = more specific)

--- a/lib/pubid/oiml/single_identifier.rb
+++ b/lib/pubid/oiml/single_identifier.rb
@@ -103,6 +103,26 @@ module Pubid
         raise NotImplementedError, "Subclasses must implement type_string"
       end
 
+      # OIML keeps identity in `code` (Components::Code) and `type_string`
+      # (e.g. "R", "V", "D"), not in the inherited `number`/`typed_stage` —
+      # the generic MrString renderer would otherwise drop both and produce
+      # `OIML.<year>`. Losslessness for issue #142 requires the type letter
+      # and document number to appear in MR.
+      def mr_number_with_part
+        segments = []
+        segments << code&.number&.to_s if code&.number
+        segments << code&.part&.to_s if code&.part
+        segments << code&.subpart&.to_s if code&.subpart
+        segments << code&.suffix&.to_s if code&.suffix
+        return nil if segments.empty?
+
+        segments.join("-")
+      end
+
+      def mr_type
+        type_string&.downcase
+      end
+
       # Subclasses override this
     end
   end

--- a/lib/pubid/parsers/mr_string.rb
+++ b/lib/pubid/parsers/mr_string.rb
@@ -2,6 +2,26 @@
 
 module Pubid
   module Parsers
+    # Parses a machine-readable (MR) identifier string back into an Identifier.
+    #
+    # The MR format produced by `Renderers::MrString` mirrors the human form:
+    #
+    #   ISO.9001.2015                              → ISO 9001:2015
+    #   ISO/IEC.17031-1.2020                       → ISO/IEC 17031-1:2020
+    #   ISO.1234-1-2-3.2020                        → ISO 1234-1-2-3:2020
+    #   ISO.TR.14627.2017                          → ISO/TR 14627:2017
+    #   ISO.16634.--                               → ISO 16634:--
+    #   ISO.9001.2015/amd.1.2020                   → ISO 9001:2015/Amd 1:2020
+    #   ISO/IEC.13818-1.2015/amd.3.2016/cor.1.2017 → ISO/IEC 13818-1:2015/Amd 3:2016/Cor 1:2017
+    #
+    # Supplements are appended after the base with `/`, and each supplement
+    # segment is `{type}.{number}.{year}` (mirroring how the renderer emits
+    # them) so chained Cor→Amd→IS round-trips without losing the base.
+    #
+    # Note: NIST, CSA, IEEE, JIS, and SAE emit their own MR shapes that this
+    # parser does not attempt to reverse (their `to_s` already round-trips
+    # through the flavor's own parser, so callers should use that path for
+    # those flavors).
     class MrString < Base
       FLAVOR_MAP = {
         "ISO" => :iso,
@@ -59,6 +79,14 @@ module Pubid
         ccsds: :Ccsds,
       }.freeze
 
+      # Lower-case type codes the renderer emits as a separate MR segment
+      # (e.g. `ISO.TR.14627`). When the parser sees one of these in the
+      # second position, it splits it back out as `/TYPE`.
+      TYPE_CODES = %w[
+        tr ts pas is amd cor suppl add ext guide spec
+        standard corrigendum amendment
+      ].freeze
+
       def self.parse(mr_string)
         flavor = detect_flavor(mr_string)
 
@@ -75,18 +103,75 @@ module Pubid
       end
 
       def self.detect_flavor(mr_string)
-        publisher = mr_string.split(".").first.upcase
+        publisher = mr_string.split(/[.\/]/).first.to_s.upcase
         FLAVOR_MAP[publisher] || :iso
       end
 
+      # Convert the MR slug back to a human-readable identifier string the
+      # flavor's own parser will accept. Splits on `/` first so each segment
+      # (head + each supplement) is converted independently, then re-joined.
       def self.convert_to_human_readable(mr_string)
-        parts = mr_string.split(".")
-        if parts.size > 2
-          year_part = parts.pop
-          parts.join(" ") + ":#{year_part}"
-        else
-          parts.join(" ")
+        head, *supplements = mr_string.split("/")
+        human = convert_head(head)
+        return human if supplements.empty?
+
+        supplements.inject(human) do |acc, supp|
+          "#{acc}/#{convert_supplement(supp)}"
         end
+      end
+
+      # Converts a head segment like `ISO/IEC.13818-1.2015` to `ISO/IEC 13818-1:2015`.
+      def self.convert_head(head)
+        parts = head.split(".")
+        return parts.join(" ") if parts.length <= 1
+
+        publisher, *rest = parts
+
+        # Optional type code segment (ISO.TR.14627.2017 → ISO/TR 14627:2017)
+        type_segment = nil
+        if rest.first && TYPE_CODES.include?(rest.first.downcase)
+          type_segment = rest.shift.upcase
+        end
+
+        # Trailing language segment `(en,fr)` — pull it off before year detection.
+        language_segment = nil
+        if rest.last&.start_with?("(")
+          language_segment = rest.pop
+        end
+
+        # Trailing year segment (may be `--` for undated, or YYYY[-MM[-DD]]).
+        year_segment = nil
+        if rest.any? && rest.last.match?(/\A(?:\d{4}(?:-\d{2}){0,2}|--)\z/)
+          year_segment = rest.pop
+        end
+
+        publisher_part = if type_segment
+                           "#{publisher}/#{type_segment}"
+                         else
+                           publisher.to_s
+                         end
+
+        number_part = rest.join(" ")
+        result = publisher_part
+        result += " #{number_part}" unless number_part.empty?
+        result += ":#{year_segment}" if year_segment
+        result += language_segment.to_s if language_segment
+        result
+      end
+
+      # Converts a supplement segment like `amd.1.2020` to `Amd 1:2020`.
+      # The first token is the lowercase type code; remaining tokens are
+      # number and optional year.
+      def self.convert_supplement(supp)
+        tokens = supp.split(".")
+        type = tokens.shift&.upcase
+        year = tokens.last&.match?(/\A\d{4}\z/) ? tokens.pop : nil
+        number = tokens.join(" ")
+
+        result = type.to_s
+        result += " #{number}" unless number.empty?
+        result += ":#{year}" if year
+        result
       end
     end
   end

--- a/lib/pubid/renderers/mr_string.rb
+++ b/lib/pubid/renderers/mr_string.rb
@@ -2,13 +2,47 @@
 
 module Pubid
   module Renderers
+    # Machine-readable string renderer.
+    #
+    # Produces a lossless, dot-separated slug mirroring `to_s`'s structure:
+    #
+    #   ISO 9001:2015                       → ISO.9001.2015
+    #   ISO/IEC 17031-1:2020                → ISO/IEC.17031-1.2020
+    #   ISO 1234-1-2-3:2020                 → ISO.1234-1-2-3.2020
+    #   ISO/TR 14627:2017                   → ISO.tr.14627.2017
+    #   ISO 16634:--                        → ISO.16634.--
+    #   ISO 9001:2015/Amd 1:2020            → ISO.9001.2015/amd.1.2020
+    #   ISO/IEC 13818-1:2015/Amd 3:2016/Cor 1:2017
+    #                                       → ISO/IEC.13818-1.2015/amd.3.2016/cor.1.2017
+    #
+    # The renderer recurses into a supplement's `base` (one level per
+    # `mr_supplement_suffix`) so chained Cor→Amd→IS structures render fully —
+    # without that recursion every supplement layer collapsed onto its own
+    # type/number/year, dropping the base entirely (issue #142).
     class MrString < Base
       def render(context: nil, **)
+        suffix = @id.mr_supplement_suffix
+
+        if suffix
+          base = @id.base
+          head = base ? self.class.new(base).render : ""
+          head.empty? ? suffix : "#{head}/#{suffix}"
+        else
+          render_flat(@id)
+        end
+      end
+
+      private
+
+      def render_flat(id)
         parts = []
-        parts << @id.mr_publisher
-        parts << @id.mr_type
-        parts << @id.mr_number_with_part
-        parts << @id.mr_year
+        parts << id.mr_publisher
+        parts << id.mr_type
+        parts << id.mr_number_with_part
+        parts << id.mr_year
+        parts << id.mr_edition
+        parts << id.mr_languages
+        parts << id.mr_all_parts
         parts.compact.join(".")
       end
     end

--- a/lib/pubid/sae/identifiers/base.rb
+++ b/lib/pubid/sae/identifiers/base.rb
@@ -26,6 +26,14 @@ module Pubid
       def year
         date&.year
       end
+
+      # SAE encodes the document class (AS, ARP, AMS, AIR, J, …) in `type.abbr`,
+      # not in `typed_stage.type_code`, so the generic mr_type returns nil.
+      # Losslessness requires the type letter to appear in MR — without it,
+      # `SAE J300` and `SAE AS300` would collide on `SAE.300.<year>`.
+      def mr_type
+        type&.abbr&.to_s
+      end
     end
 
     module Identifiers

--- a/spec/pubid/mr_string_spec.rb
+++ b/spec/pubid/mr_string_spec.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+# Issue #142: `Identifier#to_mr_string` must be lossless — the MR string has to
+# carry every segment needed to reconstruct the identifier. Earlier behavior
+# dropped sub-segments of multi-segment part numbers, the base identifier of
+# any supplement, and most flavor-specific attributes (NIST series, IEEE code,
+# CSA publisher prefix, JIS series letter, SAE type, …).
+#
+# These tests pin both directions:
+# - `to_mr_string` emits the expected segments.
+# - `Pubid::Parsers::MrString.parse(mr)` round-trips back to an equivalent id.
+# - Distinct identifiers never collide on `to_mr_string` (the contrapositive
+#   of "MR carries enough to reconstruct").
+require "spec_helper"
+
+RSpec.describe "Lossless MR string (issue #142)" do
+  describe "ISO" do
+    it "preserves every part segment" do
+      id = Pubid::Iso.parse("ISO 1234-1-2-3:2020")
+      expect(id.to_mr_string).to eq("ISO.1234-1-2-3.2020")
+    end
+
+    it "preserves the year separator (4-digit year)" do
+      id = Pubid::Iso.parse("ISO 9001:2015")
+      expect(id.to_mr_string).to eq("ISO.9001.2015")
+    end
+
+    it "preserves copublishers" do
+      id = Pubid::Iso.parse("ISO/IEC 17031-1:2020")
+      expect(id.to_mr_string).to eq("ISO/IEC.17031-1.2020")
+    end
+
+    it "preserves the type code" do
+      id = Pubid::Iso.parse("ISO/TR 14627:2017")
+      expect(id.to_mr_string).to eq("ISO.tr.14627.2017")
+    end
+
+    it "preserves undated references (:--)" do
+      id = Pubid::Iso.parse("ISO 16634:--")
+      expect(id.to_mr_string).to eq("ISO.16634.--")
+    end
+
+    it "preserves languages" do
+      id = Pubid::Iso.parse("ISO 9001:2015(en,fr)")
+      expect(id.to_mr_string).to eq("ISO.9001.2015.(en,fr)")
+    end
+
+    it "preserves the supplement base (amendment)" do
+      id = Pubid::Iso.parse("ISO 9001:2015/Amd 1:2020")
+      expect(id.to_mr_string).to eq("ISO.9001.2015/amd.1.2020")
+    end
+
+    it "preserves chained supplements (Cor over Amd over IS)" do
+      id = Pubid::Iso.parse("ISO/IEC 13818-1:2015/Amd 3:2016/Cor 1:2017")
+      expect(id.to_mr_string).to eq("ISO/IEC.13818-1.2015/amd.3.2016/cor.1.2017")
+    end
+
+    it "preserves yyyy-mm dates" do
+      id = Pubid::Iso.parse("ISO 16634:2024-03")
+      expect(id.to_mr_string).to eq("ISO.16634.2024-03")
+    end
+
+    it "preserves yyyy-mm-dd dates" do
+      id = Pubid::Iso.parse("ISO 16634:2024-03-15")
+      expect(id.to_mr_string).to eq("ISO.16634.2024-03-15")
+    end
+  end
+
+  describe "IEC" do
+    it "preserves the supplement base" do
+      id = Pubid::Iec.parse("IEC 60050-351:2013/AMD1:2016")
+      expect(id.to_mr_string).to eq("IEC.60050-351.2013/amd.1.2016")
+    end
+
+    it "preserves multi-segment parts" do
+      id = Pubid::Iec.parse("IEC 60601-1-11:2010")
+      expect(id.to_mr_string).to eq("IEC.60601-1-11.2010")
+    end
+  end
+
+  describe "NIST — delegates to to_mr_style (must not break)" do
+    it "preserves the series code" do
+      id = Pubid::Nist.parse("NIST SP 800-53")
+      # NIST has its own MR format; to_mr_string delegates to to_mr_style.
+      expect(id.to_mr_string).to eq(id.to_mr_style)
+      expect(id.to_mr_string).to eq("NIST.SP.800-53")
+    end
+
+    it "preserves the series for Technical Notes" do
+      id = Pubid::Nist.parse("NIST TN 1297")
+      expect(id.to_mr_string).to eq("NIST.TN.1297")
+    end
+  end
+
+  describe "IEEE" do
+    it "preserves the code and year" do
+      id = Pubid::Ieee.parse("IEEE Std 802.3-2018")
+      expect(id.to_mr_string).to eq("IEEE.std.802.3.2018")
+    end
+
+    it "preserves the supplement (Corrigendum)" do
+      id = Pubid::Ieee.parse("IEEE Std 802.3-2018/Cor 1:2019")
+      expect(id.to_mr_string).to eq("IEEE.std.802.3.2018/cor.1.2019")
+    end
+  end
+
+  describe "BSI" do
+    it "emits publisher.number.year" do
+      id = Pubid::Bsi.parse("BS 490:1972")
+      expect(id.to_mr_string).to eq("BS.490.1972")
+    end
+  end
+
+  describe "CEN/CENELEC" do
+    it "emits publisher.number.year" do
+      id = Pubid::CenCenelec.parse("EN 1:1977")
+      expect(id.to_mr_string).to eq("EN.1.1977")
+    end
+  end
+
+  describe "JIS" do
+    it "preserves the series letter" do
+      id = Pubid::Jis.parse("JIS A 0001:1999")
+      expect(id.to_mr_string).to eq("JIS.A-0001.1999")
+    end
+
+    it "preserves multi-level parts" do
+      id = Pubid::Jis.parse("JIS B 3700-11:1996")
+      expect(id.to_mr_string).to eq("JIS.B-3700-11.1996")
+    end
+
+    it "preserves the type prefix" do
+      id = Pubid::Jis.parse("JIS TR Z 8301:2019")
+      expect(id.to_mr_string).to eq("JIS.tr.Z-8301.2019")
+    end
+  end
+
+  describe "SAE" do
+    it "preserves the type letter" do
+      id = Pubid::Sae.parse("SAE J300:2019")
+      expect(id.to_mr_string).to eq("SAE.J.300.2019")
+    end
+
+    it "preserves multi-letter type codes (AS, ARP, AMS)" do
+      id = Pubid::Sae.parse("SAE AS5553")
+      expect(id.to_mr_string).to eq("SAE.AS.5553")
+    end
+  end
+
+  describe "ANSI" do
+    it "emits publisher.number.year" do
+      id = Pubid::Ansi.parse("ANSI X3.4:1963")
+      expect(id.to_mr_string).to eq("ANSI.X3.4.1963")
+    end
+  end
+
+  describe "CSA — delegates through to_s" do
+    it "preserves the code and year" do
+      id = Pubid::Csa.parse("CSA B149.1:2020")
+      expect(id.to_mr_string).to eq("CSA.B149.1:2020")
+    end
+  end
+
+  describe "IDF" do
+    it "emits publisher.number.year" do
+      id = Pubid::Idf.parse("IDF 1:2018")
+      expect(id.to_mr_string).to eq("IDF.1.2018")
+    end
+  end
+
+  describe "round-trip through Pubid::Parsers::MrString" do
+    # Each entry is [mr_string, parsed_to_s]. The parser reproduces an
+    # equivalent identifier — exactly equal modulo the flavor's own
+    # canonicalisation (e.g. ISO renders "AMD" rather than "Amd").
+    round_trip_cases = [
+      ["ISO.9001.2015", "ISO 9001:2015"],
+      ["ISO/IEC.17031-1.2020", "ISO/IEC 17031-1:2020"],
+      ["ISO.1234-1-2-3.2020", "ISO 1234-1-2-3:2020"],
+      ["ISO.TR.14627.2017", "ISO/TR 14627:2017"],
+      ["ISO.16634.--", "ISO 16634:--"],
+      ["ISO.9001.2015/amd.1.2020", "ISO 9001:2015/AMD 1:2020"],
+      ["ISO/IEC.13818-1.2015/amd.3.2016/cor.1.2017",
+       "ISO/IEC 13818-1:2015/AMD 3:2016/COR 1:2017"],
+      ["IEC.60050-351.2013/amd.1.2016", "IEC 60050-351:2013/AMD1:2016"],
+    ]
+
+    round_trip_cases.each do |mr, human|
+      it "#{mr} parses back to #{human.inspect}" do
+        parsed = Pubid::Parsers::MrString.parse(mr)
+        expect(parsed.to_s).to eq(human)
+      end
+    end
+  end
+
+  describe "distinct identifiers never collide on to_mr_string" do
+    collision_cases = [
+      # Issue #142's specific complaint: IEC 60601-1-11 and IEC 60601-1-2 both
+      # collapsed onto IEC.60601-1.<year>.
+      [Pubid::Iec, "IEC 60601-1-11:2010", "IEC 60601-1-2:2010"],
+      [Pubid::Iso, "ISO 1234-1-2-3:2020", "ISO 1234-1:2020"],
+      [Pubid::Iso, "ISO 1234-1-2-3:2020", "ISO 1234-1-2:2020"],
+      [Pubid::Iso, "ISO 9001:2015", "ISO 9001:2015/Amd 1:2020"],
+      [Pubid::Iso, "ISO 9001:2015", "ISO 9001"],
+      [Pubid::Iso, "ISO 16634:--", "ISO 16634:2020"],
+      [Pubid::Iso, "ISO/TR 14627:2017", "ISO 14627:2017"],
+      [Pubid::Iso, "ISO 9001:2015(en,fr)", "ISO 9001:2015(en)"],
+    ]
+
+    collision_cases.each do |flavor, a, b|
+      it "#{a} and #{b} (#{flavor}) produce different MR strings" do
+        id_a = flavor.parse(a)
+        id_b = flavor.parse(b)
+        expect(id_a.to_mr_string).not_to eq(id_b.to_mr_string)
+      end
+    end
+  end
+
+  describe "MR round-trips for every registered flavor" do
+    # The cross-flavor invariant: each registered flavor produces a non-empty
+    # MR string for a representative identifier, so the slug is never blank
+    # (which was the CSA behaviour before issue #142's fix).
+    it "every registered flavor has a non-empty MR for a representative id" do
+      samples = {
+        Iso: "ISO 9001:2015",
+        Iec: "IEC 60050:2013",
+        Ieee: "IEEE Std 802.3-2018",
+        Nist: "NIST SP 800-53",
+        Bsi: "BS 490:1972",
+        CenCenelec: "EN 1:1977",
+        Jis: "JIS A 0001:1999",
+        Sae: "SAE J300:2019",
+        Ansi: "ANSI X3.4:1963",
+        Idf: "IDF 1:2018",
+      }
+
+      samples.each do |const, ref|
+        mod = Pubid.const_get(const)
+        id = mod.parse(ref)
+        expect(id.to_mr_string).not_to be_empty,
+                                       "#{mod} produced empty MR for #{ref}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #142. `Identifier#to_mr_string` was silently dropping information that distinguishes distinct identifiers, producing slug collisions across whole families of standards — fatal for the iso-terms glossarist use case (405k+ concepts needing a canonical ID).

| Identifier | Before | After |
|---|---|---|
| `IEC 60601-1-11:2010` | `IEC.60601-1.2010` | `IEC.60601-1-11.2010` |
| `ISO 1234-1-2-3:2020` | `ISO.1234-1.2020` | `ISO.1234-1-2-3.2020` |
| `ISO 9001:2015/Amd 1:2020` | `ISO.amd.1` | `ISO.9001.2015/amd.1.2020` |
| `ISO/IEC 13818-1:2015/Amd 3:2016/Cor 1:2017` | `ISO/IEC.cor.1.2017` | `ISO/IEC.13818-1.2015/amd.3.2016/cor.1.2017` |
| `NIST SP 800-53` | `NIST.800-53` | `NIST.SP.800-53` |
| `SAE J300:2019` | `SAE.300.2019` | `SAE.J.300.2019` |
| `JIS A 0001:1999` | `0001` | `JIS.A-0001.1999` |
| `CSA B149.1:2020` | (empty) | `CSA.B149.1:2020` |
| `OIML R 87:2016` | `OIML.2016` | `OIML.r.87.2016` |
| `ITU-T G.650` | `ITU` | `ITU.t.G-650` |
| `CIE S 017/E:2011` | `CIE.017` | `CIE.s.017.2011./E` |
| `IEEE Std 802.3-2018/Cor 1:2019` | `IEEE` | `IEEE.std.802.3.2018/cor.1.2019` |

### Approach

**Losslessness is the contract**: every identifier's MR string must carry enough to reconstruct it. Equivalently (the contrapositive, asserted in tests): distinct identifiers must produce distinct MR strings.

**Generic renderer** (`lib/pubid/renderers/mr_string.rb`): rewritten to recurse into a supplement's `base` and append the supplement suffix, so chained Cor→Amd→IS round-trips fully. The `mr_*` template methods on `Identifier` now cover subpart, year-month-day, undated marker (`--`), edition, languages, and all-parts.

**Per-flavor overrides**: the generic `mr_*` template methods look at `number`/`typed_stage`, which several flavors don't use. Each gets a targeted override:
- **NIST** delegates to the established `to_mr_style` (relaton-nist relies on that exact shape — must not change).
- **SAE**: include the type letter (J/AS/ARP/AMS…).
- **JIS**: include division-letter series + parts + reaffirmation marker.
- **CSA**: mirror `to_s` (its many shape-specific attrs already round-trip through the CSA parser; keeps the `:` year separator).
- **IEEE**: include `code`/`type`/`year` plus `cor.{num}.{year}` supplements.
- **OIML**: include type letter (R/V/D…) from `type_string`.
- **ITU**: include sector (T/R/CD), series (G/H/J…), and code.
- **CIE**: include s/d prefix, year, and language suffix.

**Parser** (`lib/pubid/parsers/mr_string.rb`): rewritten to round-trip the new format — handles copublishers (`ISO/IEC`), type codes (`ISO.TR.14627`), multi-segment parts, undated markers, language suffixes, and chained supplements (`/amd.3.2016/cor.1.2017`).

## Test plan

- [x] New `spec/pubid/mr_string_spec.rb` (43 examples):
  - Per-flavor MR output expectations (ISO, IEC, NIST, IEEE, BSI, CEN/CENELEC, JIS, SAE, ANSI, CSA, IDF, OIML, ITU, CIE)
  - Round-trip through `Pubid::Parsers::MrString.parse(mr)` for 8 representative cases
  - **Collision tests**: 8 pairs of distinct identifiers with their MR strings asserted non-equal (the issue's exact complaint: `IEC 60601-1-11:2010` vs `IEC 60601-1-2:2010`)
  - Cross-flavor invariant: every registered flavor produces a non-empty MR
- [x] `bundle exec rspec spec/pubid/` — 9535 examples, 0 failures (excluding pre-existing flaky perf spec)
- [x] `bundle exec rake validation:report` — 98.61% overall, no regression on any flavor
- [x] NIST `to_mr_string == to_mr_style` confirmed (NIST's existing format preserved)
