### PR TITLE
feat: make to_mr_string all-lowercase and filename-safe; add to_slug

### DIFF
--- a/lib/pubid/cie/single_identifier.rb
+++ b/lib/pubid/cie/single_identifier.rb
@@ -61,7 +61,8 @@ module Pubid
       def mr_languages
         return nil unless respond_to?(:language) && language
 
-        "/#{language.code}"
+        # Lowercase + filename-safe: drop the leading `/` (path-unsafe).
+        language.code.to_s.downcase
       end
     end
   end

--- a/lib/pubid/csa/composite_identifier.rb
+++ b/lib/pubid/csa/composite_identifier.rb
@@ -24,9 +24,13 @@ module Pubid
       end
 
       # CSA composites serialise through `to_s`, so MR mirrors that with
-      # ` ` → `.`. Issue #142.
+      # ` ` → `.`, `:` → `.`, `/` → `-`, then lowercased (issue #142).
       def to_mr_string
-        to_s.tr(" ", ".")
+        to_s.tr(" ", ".").tr(":", ".").tr("/", "-").downcase
+      end
+
+      def to_slug
+        to_mr_string
       end
 
       # CSA composites are not Pubid::Identifier objects, so they do not inherit

--- a/lib/pubid/csa/identifier.rb
+++ b/lib/pubid/csa/identifier.rb
@@ -493,10 +493,15 @@ module Pubid
       # `package`, `reaffirmation`, `year` with prefix/format/French markers,
       # etc.) that the generic MrString renderer doesn't know about. The
       # CSA `to_s` already round-trips losslessly through the CSA parser, so
-      # MR mirrors it with ` ` → `.` and `:` kept (so a year never looks like
-      # another code segment). Issue #142.
+      # MR mirrors it: ` ` → `.`, `:` → `.` (so the year never looks like
+      # another code segment), `/` → `-` (CAN/CSA- prefix), then lowercased
+      # to match the all-lowercase MR convention (issue #142).
       def to_mr_string
-        to_s.tr(" ", ".")
+        to_s.tr(" ", ".").tr(":", ".").tr("/", "-").downcase
+      end
+
+      def to_slug
+        to_mr_string
       end
     end
   end

--- a/lib/pubid/csa/wrapper_identifier.rb
+++ b/lib/pubid/csa/wrapper_identifier.rb
@@ -28,9 +28,14 @@ module Pubid
       end
 
       # CSA wrappers serialise through `to_s` (their distinct shape is what
-      # makes them wrappers), so MR mirrors that with ` ` → `.`. Issue #142.
+      # makes them wrappers), so MR mirrors that with ` ` → `.`, `:` → `.`,
+      # `/` → `-`, then lowercased (issue #142).
       def to_mr_string
-        to_s.tr(" ", ".")
+        to_s.tr(" ", ".").tr(":", ".").tr("/", "-").downcase
+      end
+
+      def to_slug
+        to_mr_string
       end
 
       # CSA wrappers are not Pubid::Identifier objects, so they do not inherit

--- a/lib/pubid/identifier.rb
+++ b/lib/pubid/identifier.rb
@@ -290,16 +290,33 @@ module Pubid
       render(format: :mr_string)
     end
 
+    # Filesystem-/URL-safe slug derived from the MR string. Defaults to
+    # `to_mr_string` because every flavor except NIST already emits an
+    # all-lowercase, filename-safe MR (only `[a-z0-9.-]` characters, plus
+    # `_` as the supplement separator and `-` as the copublisher separator).
+    # Flavors whose MR is not slug-safe (notably NIST, whose MR format is
+    # fixed by the pubid standard) override this to project the MR into a
+    # slug-safe form.
+    def to_slug
+      to_mr_string
+    end
+
     # MR string template methods — flavors override as needed.
     #
-    # The MR format is a lossless, dot-separated slug that mirrors `to_s`'s
-    # structure: `{publisher}[/{copublisher}…][.{type}].{number}[-{part}[-{subpart}…]][.{year}[-{month}[-{day}]|’--’}][.{edition}][.{languages}][.all-parts]`
-    # Supplements append `/{type}.{number}.{year}` recursively, so a
-    # chained supplement like `…/Amd 3:2016/Cor 1:2017` round-trips as
-    # `…/amd.3.2016/cor.1.2017`. The format is designed so distinct
-    # identifiers never collide on `to_mr_string` (issue #142).
+    # The MR format is a lossless, dot-separated, all-lowercase, filename-safe
+    # slug mirroring `to_s`'s structure:
+    #
+    #   {publisher}[-{copublisher}…][.{type}].{number}[-{part}[-{subpart}…]]
+    #   [.{year}[-{month}[-{day}]]|’--’}][.{edition}][.{language}-{language}…]
+    #   [.all-parts][_supplements…]
+    #
+    # Supplements append `_{type}.{number}.{year}` recursively, so a chained
+    # supplement like `…/Amd 3:2016/Cor 1:2017` round-trips as
+    # `…_amd.3.2016_cor.1.2017`. Copublishers join with `-`
+    # (`iso-iec.17031-1.2020`) so the slug never contains a path separator.
+    # Distinct identifiers never collide on `to_mr_string` (issue #142).
     def mr_publisher
-      publisher&.to_s
+      publisher&.to_s&.downcase&.tr("/", "-")
     end
 
     def mr_type
@@ -308,7 +325,7 @@ module Pubid
       code = typed_stage.type_code
       return nil if code.nil? || code.empty? || code.to_s == "is"
 
-      code
+      code.to_s.downcase
     end
 
     def mr_number_with_part
@@ -318,19 +335,19 @@ module Pubid
       segments = [num]
       segments << mr_part if part
       segments << mr_subpart if subpart
-      segments.compact.join("-")
+      segments.compact.join("-").downcase
     end
 
     def mr_number
-      number&.to_s
+      number&.to_s&.downcase
     end
 
     def mr_part
-      part&.to_s
+      part&.to_s&.downcase
     end
 
     def mr_subpart
-      subpart&.to_s
+      subpart&.to_s&.downcase
     end
 
     def mr_year
@@ -353,7 +370,8 @@ module Pubid
     def mr_languages
       return nil unless languages&.any?
 
-      "(#{languages.map(&:code).join(',')})"
+      # Hyphen-joined, no parens — parens are shell-/URL-unsafe.
+      languages.map { |l| l.code.to_s.downcase }.join("-")
     end
 
     def mr_all_parts
@@ -362,10 +380,11 @@ module Pubid
       "all-parts"
     end
 
-    # Hook: supplement / wrapper subclasses return the `/{type}.{number}.{year}`
+    # Hook: supplement / wrapper subclasses return the `{type}.{number}.{year}`
     # suffix that distinguishes them from their base. `nil` for non-supplements.
     # The base MrString renderer recurses into `base` whenever this returns
     # a non-nil value, so chained supplements (Cor → Amd → IS) render fully.
+    # The suffix is appended with `_` (not `/`) so the MR stays filename-safe.
     def mr_supplement_suffix
       nil
     end

--- a/lib/pubid/ieee/identifiers/base.rb
+++ b/lib/pubid/ieee/identifiers/base.rb
@@ -251,9 +251,10 @@ module Pubid
       # carries `year` as a bare string — none of which the generic MrString
       # renderer knows about. Override the lossless MR template directly so
       # every IEEE identifier round-trips (issue #142). Supplements append
-      # `/{type}.{number}.{year}` recursively via mr_supplement_suffix.
+      # `_{type}.{number}.{year}` recursively via mr_supplement_suffix.
+      # Lowercased to match the all-lowercase MR convention.
       def mr_publisher
-        publisher&.to_s
+        publisher&.to_s&.downcase
       end
 
       def mr_type
@@ -261,7 +262,7 @@ module Pubid
       end
 
       def mr_number_with_part
-        code_obj&.to_s
+        code_obj&.to_s&.downcase
       end
 
       def mr_year

--- a/lib/pubid/itu/identifiers/base.rb
+++ b/lib/pubid/itu/identifiers/base.rb
@@ -50,8 +50,9 @@ module Pubid
       # `typed_stage`. The generic MrString renderer would otherwise drop all
       # three and emit just `ITU`. Losslessness for issue #142 requires the
       # sector letter, series letter, and document number to appear in MR.
+      # Lowercased to match the all-lowercase MR convention.
       def mr_publisher
-        publisher&.to_s
+        publisher&.to_s&.downcase
       end
 
       def mr_type
@@ -60,7 +61,7 @@ module Pubid
 
       def mr_number_with_part
         segments = []
-        segments << series&.series&.to_s if series&.series
+        segments << series&.series&.to_s&.downcase if series&.series
         segments << code&.number&.to_s if code&.number
         segments << code&.subseries&.to_s if code&.subseries
         segments.concat(code&.parts&.map(&:to_s) || [])

--- a/lib/pubid/jis/identifier.rb
+++ b/lib/pubid/jis/identifier.rb
@@ -120,8 +120,9 @@ module Pubid
       # JIS exposes its publisher as the `PUBLISHER` constant rather than the
       # inherited `publisher` attribute, so the generic mr_publisher returns
       # nil. Without this override every JIS id would lose its "JIS." prefix.
+      # Lowercased to match the all-lowercase MR convention.
       def mr_publisher
-        PUBLISHER
+        PUBLISHER.downcase
       end
 
       # JIS stores its identity across `series` (division letter A–Z), `number`
@@ -129,6 +130,7 @@ module Pubid
       # generic mr_number_with_part only knows about `number`/`part`/`subpart`,
       # so without these overrides every JIS id would collapse onto its
       # document number and drop the division letter (issue #142).
+      # Lowercased to match the all-lowercase MR convention.
       def mr_type
         return nil unless respond_to?(:type_prefix)
 
@@ -137,7 +139,7 @@ module Pubid
 
       def mr_number_with_part
         segments = []
-        segments << series.to_s if series
+        segments << series.to_s.downcase if series
         segments << number.to_s if number
         parts&.each { |p| segments << p.to_s }
         return nil if segments.empty?

--- a/lib/pubid/nist/identifiers/base.rb
+++ b/lib/pubid/nist/identifiers/base.rb
@@ -251,6 +251,13 @@ module Pubid
         to_mr_style
       end
 
+      # NIST's MR shape is fixed by the pubid standard and stays uppercase
+      # (e.g. `NIST.SP.800-53`). The slug, however, must be lowercase to
+      # match the cross-flavor convention; project the MR through `downcase`.
+      def to_slug
+        to_mr_string.downcase
+      end
+
       # Returns weight based on amount of defined attributes
       # Used for ranking identifiers by specificity for conflict resolution
       # @return [Integer] weight score (higher = more specific)

--- a/lib/pubid/parsers/mr_string.rb
+++ b/lib/pubid/parsers/mr_string.rb
@@ -4,19 +4,21 @@ module Pubid
   module Parsers
     # Parses a machine-readable (MR) identifier string back into an Identifier.
     #
-    # The MR format produced by `Renderers::MrString` mirrors the human form:
+    # The MR format produced by `Renderers::MrString` mirrors the human form,
+    # lowercased and filename-safe:
     #
-    #   ISO.9001.2015                              → ISO 9001:2015
-    #   ISO/IEC.17031-1.2020                       → ISO/IEC 17031-1:2020
-    #   ISO.1234-1-2-3.2020                        → ISO 1234-1-2-3:2020
-    #   ISO.TR.14627.2017                          → ISO/TR 14627:2017
-    #   ISO.16634.--                               → ISO 16634:--
-    #   ISO.9001.2015/amd.1.2020                   → ISO 9001:2015/Amd 1:2020
-    #   ISO/IEC.13818-1.2015/amd.3.2016/cor.1.2017 → ISO/IEC 13818-1:2015/Amd 3:2016/Cor 1:2017
+    #   iso.9001.2015                              → ISO 9001:2015
+    #   iso-iec.17031-1.2020                       → ISO/IEC 17031-1:2020
+    #   iso.1234-1-2-3.2020                        → ISO 1234-1-2-3:2020
+    #   iso.tr.14627.2017                          → ISO/TR 14627:2017
+    #   iso.16634.--                               → ISO 16634:--
+    #   iso.9001.2015_amd.1.2020                   → ISO 9001:2015/Amd 1:2020
+    #   iso-iec.13818-1.2015_amd.3.2016_cor.1.2017 → ISO/IEC 13818-1:2015/Amd 3:2016/Cor 1:2017
     #
-    # Supplements are appended after the base with `/`, and each supplement
-    # segment is `{type}.{number}.{year}` (mirroring how the renderer emits
-    # them) so chained Cor→Amd→IS round-trips without losing the base.
+    # Copublishers join with `-` (`iso-iec`), supplements append with `_`
+    # (`iso.9001.2015_amd.1.2020`). Both round-trip back to `/` here. The
+    # flavor's own parser is case-insensitive on the type/publisher tokens
+    # we emit, so the lowercased slug re-parses cleanly.
     #
     # Note: NIST, CSA, IEEE, JIS, and SAE emit their own MR shapes that this
     # parser does not attempt to reverse (their `to_s` already round-trips
@@ -80,7 +82,7 @@ module Pubid
       }.freeze
 
       # Lower-case type codes the renderer emits as a separate MR segment
-      # (e.g. `ISO.TR.14627`). When the parser sees one of these in the
+      # (e.g. `iso.tr.14627`). When the parser sees one of these in the
       # second position, it splits it back out as `/TYPE`.
       TYPE_CODES = %w[
         tr ts pas is amd cor suppl add ext guide spec
@@ -103,15 +105,17 @@ module Pubid
       end
 
       def self.detect_flavor(mr_string)
-        publisher = mr_string.split(/[.\/]/).first.to_s.upcase
+        publisher = mr_string.split(/[._-]/).first.to_s.upcase
         FLAVOR_MAP[publisher] || :iso
       end
 
       # Convert the MR slug back to a human-readable identifier string the
-      # flavor's own parser will accept. Splits on `/` first so each segment
-      # (head + each supplement) is converted independently, then re-joined.
+      # flavor's own parser will accept. Splits on `_` first so each segment
+      # (head + each supplement) is converted independently, then re-joined
+      # with `/`. Within the head, the copublisher separator `-` (first
+      # segment only) is restored to `/`.
       def self.convert_to_human_readable(mr_string)
-        head, *supplements = mr_string.split("/")
+        head, *supplements = mr_string.split("_")
         human = convert_head(head)
         return human if supplements.empty?
 
@@ -120,22 +124,24 @@ module Pubid
         end
       end
 
-      # Converts a head segment like `ISO/IEC.13818-1.2015` to `ISO/IEC 13818-1:2015`.
+      # Converts a head segment like `iso-iec.13818-1.2015` to
+      # `ISO/IEC 13818-1:2015`.
       def self.convert_head(head)
         parts = head.split(".")
-        return parts.join(" ") if parts.length <= 1
+        return parts.join(" ").upcase if parts.length <= 1
 
         publisher, *rest = parts
 
-        # Optional type code segment (ISO.TR.14627.2017 → ISO/TR 14627:2017)
+        # Optional type code segment (iso.tr.14627.2017 → ISO/TR 14627:2017).
         type_segment = nil
         if rest.first && TYPE_CODES.include?(rest.first.downcase)
           type_segment = rest.shift.upcase
         end
 
-        # Trailing language segment `(en,fr)` — pull it off before year detection.
+        # Trailing language segment — bare language code(s) with no parens.
+        # Detect by length <= 5 and all-alpha (en, fr, en-fr, ru).
         language_segment = nil
-        if rest.last&.start_with?("(")
+        if rest.last&.match?(/\A[a-z]{2}(-[a-z]{2})*\z/)
           language_segment = rest.pop
         end
 
@@ -145,17 +151,19 @@ module Pubid
           year_segment = rest.pop
         end
 
-        publisher_part = if type_segment
-                           "#{publisher}/#{type_segment}"
-                         else
-                           publisher.to_s
-                         end
+        # Copublishers in the first segment: `iso-iec` → `ISO/IEC`. Multi-word
+        # publisher bodies (e.g. `cen-cenelec`) round-trip the same way.
+        publisher_part = publisher.split("-").map(&:upcase).join("/")
+        publisher_part = "#{publisher_part}/#{type_segment}" if type_segment
 
         number_part = rest.join(" ")
         result = publisher_part
         result += " #{number_part}" unless number_part.empty?
         result += ":#{year_segment}" if year_segment
-        result += language_segment.to_s if language_segment
+        if language_segment
+          langs = language_segment.split("-").join(",")
+          result += "(#{langs})"
+        end
         result
       end
 
@@ -176,3 +184,4 @@ module Pubid
     end
   end
 end
+

--- a/lib/pubid/renderers/mr_string.rb
+++ b/lib/pubid/renderers/mr_string.rb
@@ -4,29 +4,37 @@ module Pubid
   module Renderers
     # Machine-readable string renderer.
     #
-    # Produces a lossless, dot-separated slug mirroring `to_s`'s structure:
+    # Produces a lossless, dot-separated, all-lowercase, filename-safe slug:
     #
-    #   ISO 9001:2015                       → ISO.9001.2015
-    #   ISO/IEC 17031-1:2020                → ISO/IEC.17031-1.2020
-    #   ISO 1234-1-2-3:2020                 → ISO.1234-1-2-3.2020
-    #   ISO/TR 14627:2017                   → ISO.tr.14627.2017
-    #   ISO 16634:--                        → ISO.16634.--
-    #   ISO 9001:2015/Amd 1:2020            → ISO.9001.2015/amd.1.2020
-    #   ISO/IEC 13818-1:2015/Amd 3:2016/Cor 1:2017
-    #                                       → ISO/IEC.13818-1.2015/amd.3.2016/cor.1.2017
+    #   iso 9001:2015                       -> iso.9001.2015
+    #   iso/iec 17031-1:2020                -> iso-iec.17031-1.2020
+    #   iso 1234-1-2-3:2020                 -> iso.1234-1-2-3.2020
+    #   iso/tr 14627:2017                   -> iso.tr.14627.2017
+    #   iso 16634:--                        -> iso.16634.--
+    #   iso 9001:2015/amd 1:2020            -> iso.9001.2015_amd.1.2020
+    #   iso/iec 13818-1:2015/amd 3:2016/cor 1:2017
+    #                                       -> iso-iec.13818-1.2015_amd.3.2016_cor.1.2017
     #
     # The renderer recurses into a supplement's `base` (one level per
-    # `mr_supplement_suffix`) so chained Cor→Amd→IS structures render fully —
-    # without that recursion every supplement layer collapsed onto its own
-    # type/number/year, dropping the base entirely (issue #142).
+    # `mr_supplement_suffix`) so chained Cor-Amd-IS structures render fully,
+    # instead of every supplement layer collapsing onto its own
+    # type/number/year and dropping the base (issue #142).
+    #
+    # Character set is restricted to [a-z0-9.-] plus `_` (supplement
+    # separator), so `to_mr_string` doubles as a filesystem-/URL-safe slug.
+    # `Identifier#to_slug` delegates here; NIST is the one flavor that
+    # overrides `to_slug` because its MR shape is fixed by the pubid standard
+    # and stays uppercase.
     class MrString < Base
+      SEPARATOR_SUPPLEMENT = "_"
+
       def render(context: nil, **)
         suffix = @id.mr_supplement_suffix
 
         if suffix
           base = @id.base
           head = base ? self.class.new(base).render : ""
-          head.empty? ? suffix : "#{head}/#{suffix}"
+          head.empty? ? suffix : "#{head}#{SEPARATOR_SUPPLEMENT}#{suffix}"
         else
           render_flat(@id)
         end

--- a/lib/pubid/sae/identifiers/base.rb
+++ b/lib/pubid/sae/identifiers/base.rb
@@ -31,8 +31,9 @@ module Pubid
       # not in `typed_stage.type_code`, so the generic mr_type returns nil.
       # Losslessness requires the type letter to appear in MR — without it,
       # `SAE J300` and `SAE AS300` would collide on `SAE.300.<year>`.
+      # Lowercased to match the all-lowercase MR convention (issue #142).
       def mr_type
-        type&.abbr&.to_s
+        type&.abbr&.to_s&.downcase
       end
     end
 

--- a/spec/pubid/mr_string_spec.rb
+++ b/spec/pubid/mr_string_spec.rb
@@ -11,160 +11,232 @@
 # - `Pubid::Parsers::MrString.parse(mr)` round-trips back to an equivalent id.
 # - Distinct identifiers never collide on `to_mr_string` (the contrapositive
 #   of "MR carries enough to reconstruct").
+#
+# Follow-up convention: MR is ALL LOWERCASE and filename-safe
+# (`[a-z0-9.-]` + `_` as supplement separator + `-` as copublisher separator)
+# for every flavor except NIST (whose MR shape is fixed by the pubid
+# standard). `to_slug` projects the MR into a lowercase slug; for non-NIST
+# flavors that is just `to_mr_string`, for NIST it lowercases.
 require "spec_helper"
 
 RSpec.describe "Lossless MR string (issue #142)" do
   describe "ISO" do
     it "preserves every part segment" do
       id = Pubid::Iso.parse("ISO 1234-1-2-3:2020")
-      expect(id.to_mr_string).to eq("ISO.1234-1-2-3.2020")
+      expect(id.to_mr_string).to eq("iso.1234-1-2-3.2020")
     end
 
     it "preserves the year separator (4-digit year)" do
       id = Pubid::Iso.parse("ISO 9001:2015")
-      expect(id.to_mr_string).to eq("ISO.9001.2015")
+      expect(id.to_mr_string).to eq("iso.9001.2015")
     end
 
-    it "preserves copublishers" do
+    it "preserves copublishers as `-` (filename-safe)" do
       id = Pubid::Iso.parse("ISO/IEC 17031-1:2020")
-      expect(id.to_mr_string).to eq("ISO/IEC.17031-1.2020")
+      expect(id.to_mr_string).to eq("iso-iec.17031-1.2020")
     end
 
-    it "preserves the type code" do
+    it "preserves the type code (lowercase)" do
       id = Pubid::Iso.parse("ISO/TR 14627:2017")
-      expect(id.to_mr_string).to eq("ISO.tr.14627.2017")
+      expect(id.to_mr_string).to eq("iso.tr.14627.2017")
     end
 
     it "preserves undated references (:--)" do
       id = Pubid::Iso.parse("ISO 16634:--")
-      expect(id.to_mr_string).to eq("ISO.16634.--")
+      expect(id.to_mr_string).to eq("iso.16634.--")
     end
 
-    it "preserves languages" do
+    it "preserves languages as hyphen-joined, no parens" do
       id = Pubid::Iso.parse("ISO 9001:2015(en,fr)")
-      expect(id.to_mr_string).to eq("ISO.9001.2015.(en,fr)")
+      expect(id.to_mr_string).to eq("iso.9001.2015.en-fr")
     end
 
-    it "preserves the supplement base (amendment)" do
+    it "preserves the supplement base (amendment) via `_` separator" do
       id = Pubid::Iso.parse("ISO 9001:2015/Amd 1:2020")
-      expect(id.to_mr_string).to eq("ISO.9001.2015/amd.1.2020")
+      expect(id.to_mr_string).to eq("iso.9001.2015_amd.1.2020")
     end
 
     it "preserves chained supplements (Cor over Amd over IS)" do
       id = Pubid::Iso.parse("ISO/IEC 13818-1:2015/Amd 3:2016/Cor 1:2017")
-      expect(id.to_mr_string).to eq("ISO/IEC.13818-1.2015/amd.3.2016/cor.1.2017")
+      expect(id.to_mr_string).to eq("iso-iec.13818-1.2015_amd.3.2016_cor.1.2017")
     end
 
     it "preserves yyyy-mm dates" do
       id = Pubid::Iso.parse("ISO 16634:2024-03")
-      expect(id.to_mr_string).to eq("ISO.16634.2024-03")
+      expect(id.to_mr_string).to eq("iso.16634.2024-03")
     end
 
     it "preserves yyyy-mm-dd dates" do
       id = Pubid::Iso.parse("ISO 16634:2024-03-15")
-      expect(id.to_mr_string).to eq("ISO.16634.2024-03-15")
+      expect(id.to_mr_string).to eq("iso.16634.2024-03-15")
     end
   end
 
   describe "IEC" do
     it "preserves the supplement base" do
       id = Pubid::Iec.parse("IEC 60050-351:2013/AMD1:2016")
-      expect(id.to_mr_string).to eq("IEC.60050-351.2013/amd.1.2016")
+      expect(id.to_mr_string).to eq("iec.60050-351.2013_amd.1.2016")
     end
 
     it "preserves multi-segment parts" do
       id = Pubid::Iec.parse("IEC 60601-1-11:2010")
-      expect(id.to_mr_string).to eq("IEC.60601-1-11.2010")
+      expect(id.to_mr_string).to eq("iec.60601-1-11.2010")
     end
   end
 
-  describe "NIST — delegates to to_mr_style (must not break)" do
-    it "preserves the series code" do
+  describe "NIST — keeps its own MR shape, slug lowercases it" do
+    it "to_mr_string preserves the series code (uppercase, per standard)" do
       id = Pubid::Nist.parse("NIST SP 800-53")
       # NIST has its own MR format; to_mr_string delegates to to_mr_style.
       expect(id.to_mr_string).to eq(id.to_mr_style)
       expect(id.to_mr_string).to eq("NIST.SP.800-53")
     end
 
-    it "preserves the series for Technical Notes" do
+    it "to_mr_string preserves the series for Technical Notes" do
       id = Pubid::Nist.parse("NIST TN 1297")
       expect(id.to_mr_string).to eq("NIST.TN.1297")
+    end
+
+    it "to_slug lowercases the MR for filesystem/URL use" do
+      id = Pubid::Nist.parse("NIST SP 800-53")
+      expect(id.to_slug).to eq("nist.sp.800-53")
     end
   end
 
   describe "IEEE" do
-    it "preserves the code and year" do
+    it "preserves the code and year (lowercase)" do
       id = Pubid::Ieee.parse("IEEE Std 802.3-2018")
-      expect(id.to_mr_string).to eq("IEEE.std.802.3.2018")
+      expect(id.to_mr_string).to eq("ieee.std.802.3.2018")
     end
 
     it "preserves the supplement (Corrigendum)" do
       id = Pubid::Ieee.parse("IEEE Std 802.3-2018/Cor 1:2019")
-      expect(id.to_mr_string).to eq("IEEE.std.802.3.2018/cor.1.2019")
+      expect(id.to_mr_string).to eq("ieee.std.802.3.2018_cor.1.2019")
     end
   end
 
   describe "BSI" do
     it "emits publisher.number.year" do
       id = Pubid::Bsi.parse("BS 490:1972")
-      expect(id.to_mr_string).to eq("BS.490.1972")
+      expect(id.to_mr_string).to eq("bs.490.1972")
     end
   end
 
   describe "CEN/CENELEC" do
     it "emits publisher.number.year" do
       id = Pubid::CenCenelec.parse("EN 1:1977")
-      expect(id.to_mr_string).to eq("EN.1.1977")
+      expect(id.to_mr_string).to eq("en.1.1977")
     end
   end
 
   describe "JIS" do
-    it "preserves the series letter" do
+    it "preserves the series letter (lowercase)" do
       id = Pubid::Jis.parse("JIS A 0001:1999")
-      expect(id.to_mr_string).to eq("JIS.A-0001.1999")
+      expect(id.to_mr_string).to eq("jis.a-0001.1999")
     end
 
     it "preserves multi-level parts" do
       id = Pubid::Jis.parse("JIS B 3700-11:1996")
-      expect(id.to_mr_string).to eq("JIS.B-3700-11.1996")
+      expect(id.to_mr_string).to eq("jis.b-3700-11.1996")
     end
 
-    it "preserves the type prefix" do
+    it "preserves the type prefix and series" do
       id = Pubid::Jis.parse("JIS TR Z 8301:2019")
-      expect(id.to_mr_string).to eq("JIS.tr.Z-8301.2019")
+      expect(id.to_mr_string).to eq("jis.tr.z-8301.2019")
     end
   end
 
   describe "SAE" do
-    it "preserves the type letter" do
+    it "preserves the type letter (lowercase)" do
       id = Pubid::Sae.parse("SAE J300:2019")
-      expect(id.to_mr_string).to eq("SAE.J.300.2019")
+      expect(id.to_mr_string).to eq("sae.j.300.2019")
     end
 
-    it "preserves multi-letter type codes (AS, ARP, AMS)" do
+    it "preserves multi-letter type codes (as, arp, ams)" do
       id = Pubid::Sae.parse("SAE AS5553")
-      expect(id.to_mr_string).to eq("SAE.AS.5553")
+      expect(id.to_mr_string).to eq("sae.as.5553")
     end
   end
 
   describe "ANSI" do
-    it "emits publisher.number.year" do
+    it "emits publisher.number.year (code lowercased)" do
       id = Pubid::Ansi.parse("ANSI X3.4:1963")
-      expect(id.to_mr_string).to eq("ANSI.X3.4.1963")
+      expect(id.to_mr_string).to eq("ansi.x3.4.1963")
     end
   end
 
-  describe "CSA — delegates through to_s" do
-    it "preserves the code and year" do
+  describe "CSA — mirrors to_s through filename-safe transform" do
+    it "preserves the code and year (lowercase, `:` → `.`)" do
       id = Pubid::Csa.parse("CSA B149.1:2020")
-      expect(id.to_mr_string).to eq("CSA.B149.1:2020")
+      expect(id.to_mr_string).to eq("csa.b149.1.2020")
     end
   end
 
   describe "IDF" do
     it "emits publisher.number.year" do
       id = Pubid::Idf.parse("IDF 1:2018")
-      expect(id.to_mr_string).to eq("IDF.1.2018")
+      expect(id.to_mr_string).to eq("idf.1.2018")
+    end
+  end
+
+  describe "to_slug defaults and overrides" do
+    it "every non-NIST flavor has to_slug == to_mr_string" do
+      samples = {
+        Iso: "ISO 9001:2015",
+        Iec: "IEC 60050:2013",
+        Ieee: "IEEE Std 802.3-2018",
+        Bsi: "BS 490:1972",
+        CenCenelec: "EN 1:1977",
+        Jis: "JIS A 0001:1999",
+        Sae: "SAE J300:2019",
+        Ansi: "ANSI X3.4:1963",
+        Csa: "CSA B149.1:2020",
+        Idf: "IDF 1:2018",
+        Oiml: "OIML R 87:2016",
+        Itu: "ITU-T G.650",
+        Cie: "CIE S 017/E:2011",
+      }
+      samples.each do |const, ref|
+        id = Pubid.const_get(const).parse(ref)
+        expect(id.to_slug).to eq(id.to_mr_string),
+                               "#{const} should have to_slug == to_mr_string"
+      end
+    end
+
+    it "NIST overrides to_slug to lowercase its MR" do
+      id = Pubid::Nist.parse("NIST SP 800-53")
+      expect(id.to_slug).to eq(id.to_mr_string.downcase)
+      expect(id.to_slug).to eq("nist.sp.800-53")
+    end
+  end
+
+  describe "MR strings are filename-safe (only [a-z0-9.-])" do
+    # The slug must not contain `/`, `:`, `(`, `)`, `,`, or any uppercase.
+    # NIST is the documented exception (its MR is fixed by the standard) —
+    # but its to_slug is still safe.
+    safe_slug_cases = [
+      [Pubid::Iso, "ISO 9001:2015"],
+      [Pubid::Iso, "ISO/IEC 17031-1:2020"],
+      [Pubid::Iso, "ISO 9001:2015/Amd 1:2020"],
+      [Pubid::Iso, "ISO/IEC 13818-1:2015/Amd 3:2016/Cor 1:2017"],
+      [Pubid::Iso, "ISO 9001:2015(en,fr)"],
+      [Pubid::Iso, "ISO 16634:--"],
+      [Pubid::Iec, "IEC 60050:2013/AMD1:2016"],
+      [Pubid::Ieee, "IEEE Std 802.3-2018/Cor 1:2019"],
+      [Pubid::Jis, "JIS TR Z 8301:2019"],
+      [Pubid::Sae, "SAE ARP4754A"],
+      [Pubid::Ansi, "ANSI X3.4:1963"],
+      [Pubid::Csa, "CSA B149.1:2020"],
+      [Pubid::Oiml, "OIML R 87:2016"],
+      [Pubid::Itu, "ITU-T G.650"],
+      [Pubid::Cie, "CIE S 017/E:2011"],
+      [Pubid::Nist, "NIST SP 800-53"],
+    ]
+    safe_slug_cases.each do |flavor, ref|
+      it "#{ref} (#{flavor}) slug matches /\\A[a-z0-9._-]+\\z/" do
+        id = flavor.parse(ref)
+        expect(id.to_slug).to match(/\A[a-z0-9._-]+\z/)
+      end
     end
   end
 
@@ -173,15 +245,16 @@ RSpec.describe "Lossless MR string (issue #142)" do
     # equivalent identifier — exactly equal modulo the flavor's own
     # canonicalisation (e.g. ISO renders "AMD" rather than "Amd").
     round_trip_cases = [
-      ["ISO.9001.2015", "ISO 9001:2015"],
-      ["ISO/IEC.17031-1.2020", "ISO/IEC 17031-1:2020"],
-      ["ISO.1234-1-2-3.2020", "ISO 1234-1-2-3:2020"],
-      ["ISO.TR.14627.2017", "ISO/TR 14627:2017"],
-      ["ISO.16634.--", "ISO 16634:--"],
-      ["ISO.9001.2015/amd.1.2020", "ISO 9001:2015/AMD 1:2020"],
-      ["ISO/IEC.13818-1.2015/amd.3.2016/cor.1.2017",
+      ["iso.9001.2015", "ISO 9001:2015"],
+      ["iso-iec.17031-1.2020", "ISO/IEC 17031-1:2020"],
+      ["iso.1234-1-2-3.2020", "ISO 1234-1-2-3:2020"],
+      ["iso.tr.14627.2017", "ISO/TR 14627:2017"],
+      ["iso.16634.--", "ISO 16634:--"],
+      ["iso.9001.2015_amd.1.2020", "ISO 9001:2015/AMD 1:2020"],
+      ["iso-iec.13818-1.2015_amd.3.2016_cor.1.2017",
        "ISO/IEC 13818-1:2015/AMD 3:2016/COR 1:2017"],
-      ["IEC.60050-351.2013/amd.1.2016", "IEC 60050-351:2013/AMD1:2016"],
+      ["iec.60050-351.2013_amd.1.2016", "IEC 60050-351:2013/AMD1:2016"],
+      ["iso.9001.2015.en-fr", "ISO 9001:2015(en,fr)"],
     ]
 
     round_trip_cases.each do |mr, human|
@@ -215,11 +288,8 @@ RSpec.describe "Lossless MR string (issue #142)" do
     end
   end
 
-  describe "MR round-trips for every registered flavor" do
-    # The cross-flavor invariant: each registered flavor produces a non-empty
-    # MR string for a representative identifier, so the slug is never blank
-    # (which was the CSA behaviour before issue #142's fix).
-    it "every registered flavor has a non-empty MR for a representative id" do
+  describe "every registered flavor has a non-empty MR" do
+    it "produces a non-empty MR for a representative id of each flavor" do
       samples = {
         Iso: "ISO 9001:2015",
         Iec: "IEC 60050:2013",

--- a/spec/pubid/serialization_spec.rb
+++ b/spec/pubid/serialization_spec.rb
@@ -61,26 +61,26 @@ RSpec.describe "Lutaml::Model serialization round-trip" do
   describe "MR string" do
     it "renders basic identifier" do
       id = Pubid::Iso.parse("ISO 9001:2015")
-      expect(id.to_mr_string).to eq("ISO.9001.2015")
+      expect(id.to_mr_string).to eq("iso.9001.2015")
     end
 
     it "renders with part" do
       id = Pubid::Iso.parse("ISO/IEC 17031-1:2020")
-      expect(id.to_mr_string).to eq("ISO/IEC.17031-1.2020")
+      expect(id.to_mr_string).to eq("iso-iec.17031-1.2020")
     end
 
     it "renders undated" do
       id = Pubid::Iso.parse("ISO 9001")
-      expect(id.to_mr_string).to eq("ISO.9001")
+      expect(id.to_mr_string).to eq("iso.9001")
     end
 
     it "parses MR string back to identifier" do
-      id = Pubid::Parsers::MrString.parse("ISO.9001.2015")
+      id = Pubid::Parsers::MrString.parse("iso.9001.2015")
       expect(id.to_s).to eq("ISO 9001:2015")
     end
 
     it "parses MR string with part" do
-      id = Pubid::Parsers::MrString.parse("IEC.61131-3.2013")
+      id = Pubid::Parsers::MrString.parse("iec.61131-3.2013")
       expect(id.to_s).to eq("IEC 61131-3:2013")
     end
   end


### PR DESCRIPTION
## Summary

Addresses the casing inconsistency and filename-safety issues from the #142 follow-up discussion. Establishes one convention for every flavor: **all lowercase, filename-safe** — with NIST as the single documented exception (its MR shape is fixed by the pubid standard).

### Convention

- **All lowercase, always** — publishers, types, series letters, document numbers, language codes.
- **Character set restricted to `[a-z0-9.-]`** plus `_` (supplement separator) and `-` (copublisher separator within the head segment).
- **No `/`, `:`, `(`, `)`, `,`** anywhere in the output.

| Input | Old MR | New MR | Slug |
|---|---|---|---|
| `ISO 9001:2015` | `ISO.9001.2015` | `iso.9001.2015` | `iso.9001.2015` |
| `ISO/IEC 17031-1:2020` | `ISO/IEC.17031-1.2020` | `iso-iec.17031-1.2020` | `iso-iec.17031-1.2020` |
| `ISO/TR 14627:2017` | `ISO.tr.14627.2017` | `iso.tr.14627.2017` | `iso.tr.14627.2017` |
| `ISO 9001:2015/Amd 1:2020` | `ISO.9001.2015/amd.1.2020` | `iso.9001.2015_amd.1.2020` | `iso.9001.2015_amd.1.2020` |
| `ISO 9001:2015(en,fr)` | `ISO.9001.2015.(en,fr)` | `iso.9001.2015.en-fr` | `iso.9001.2015.en-fr` |
| `SAE ARP4754A` | `SAE.ARP.4754A` | `sae.arp.4754a` | `sae.arp.4754a` |
| `JIS TR Z 8301:2019` | `JIS.tr.Z-8301.2019` | `jis.tr.z-8301.2019` | `jis.tr.z-8301.2019` |
| `ITU-T G.650` | `ITU.t.G-650` | `itu.t.g-650` | `itu.t.g-650` |
| `CIE S 017/E:2011` | `CIE.s.017.2011./E` | `cie.s.017.2011.e` | `cie.s.017.2011.e` |
| `CSA B149.1:2020` | `CSA.B149.1:2020` | `csa.b149.1.2020` | `csa.b149.1.2020` |
| `NIST SP 800-53` (MR) | `NIST.SP.800-53` | `NIST.SP.800-53` (unchanged) | `nist.sp.800-53` |

### Changes

1. **`Identifier#to_mr_string` template methods** — every `mr_*` method now returns lowercase output. Copublishers join with `-` (was `/`). Languages emit as `en-fr` (was `(en,fr)`).

2. **`Renderers::MrString`** — supplement separator changed from `/` to `_`.

3. **Per-flavor overrides**:
   - **SAE**: lowercase `type.abbr` (was uppercase).
   - **JIS**: lowercase `series` letter and `PUBLISHER` constant.
   - **ITU**: lowercase `series.series`.
   - **IEEE**: lowercase `publisher` and `code_obj`.
   - **CSA**: lowercase + replace `:` → `.`, `/` → `-`.
   - **CIE**: drop `/` prefix from language suffix.

4. **`Identifier#to_slug`** (new) — defaults to `to_mr_string` (already slug-safe after the changes above).

5. **`Nist::Identifier#to_slug`** (override) — lowercases NIST's uppercase MR.

6. **`Parsers::MrString`** — rewritten to round-trip the new format: copublishers via `-` (first segment), supplements via `_`, lowercase-tolerant throughout.

### Why NIST is excepted

NIST's MR format (`NIST.SP.800-53.supp`) is defined by the pubid standard and consumed by relaton-nist with that exact shape. Changing it would break downstream tooling. The new `to_slug` override on NIST projects the uppercase MR through `downcase`, so NIST identifiers get a lowercase slug without disturbing their MR contract.

## Test plan

- [x] `spec/pubid/mr_string_spec.rb` (63 examples):
  - All per-flavor MR expectations updated to lowercase + new separators
  - New **`to_slug defaults and overrides`** group: every non-NIST flavor `to_slug == to_mr_string`; NIST's `to_slug == to_mr_string.downcase`
  - New **`MR strings are filename-safe`** group: 16 sample identifiers assert their slug matches `/^[a-z0-9._-]+$/`
  - Round-trip through `Pubid::Parsers::MrString` updated for new separators
- [x] `spec/pubid/serialization_spec.rb` — old uppercase MR expectations updated
- [x] `bundle exec rspec spec/pubid/` — 9555 examples, 0 failures (1 pre-existing pending CSA)
- [x] `bundle exec rake validation:report` — 98.61% overall, no regression
