### PR TITLE
feat(nist): parse long notation references (Rev.1, Part.1)

### DIFF
--- a/lib/pubid/nist/parser.rb
+++ b/lib/pubid/nist/parser.rb
@@ -448,7 +448,8 @@ module Pubid
 
       # Part - enhanced to support patterns like p1adde1 AND pt3r1 (part with revision)
       rule(:part) do
-        ((space.maybe >> (str("pt") | str("p") | str("P"))) | str(" Part ")) >>
+        (str(" Part. ") | str(" Part.") | str(" Part ") |
+         (space.maybe >> (str("pt") | str("p") | str("P")))) >>
           (digits >>
            # NEW: Revision after part number: pt3r1, p1r1 (space.maybe for preprocessing)
            (space.maybe >> str("r") >> digits).maybe >>
@@ -474,7 +475,8 @@ module Pubid
           # Enhanced to accept letter-only revisions and space before r
           # ENHANCED: Accept BOTH lowercase and uppercase letters in suffix
           # ENHANCED: Capture original format prefix for format preservation (e.g., " Rev. 5")
-          ((str(" rev ") | str("rev") | str(" r") | str("r") | str(" Rev. ") | str(" Revision (r)")).as(:revision_prefix) >>
+          ((str(" rev ") | str("rev") | str(" r") | str("r") | str(" Rev. ") | str(" Rev.") | str(" Revision (r)")).as(:revision_prefix) >>
+           space.maybe >>
             ((digits >> match("[a-zA-Z]").maybe) | match("[a-zA-Z]").repeat(1)).as(:revision_id)).as(:revision) |
           # NEW: Standalone 'r' - MUST BE LAST to avoid consuming from other patterns
           # Matches " r" at end of input (after preprocessing: "800-56a r", "800-27 r")

--- a/spec/pubid/nist/revision_format_preservation_spec.rb
+++ b/spec/pubid/nist/revision_format_preservation_spec.rb
@@ -53,4 +53,41 @@ RSpec.describe "NIST Revision Format Preservation" do
       expect(identifier.to_s).to eq("NIST SP 800-53 r5A")
     end
   end
+
+  describe "long notation references (issue #155)" do
+    # Long notation uses "Rev." / "Part." prefixes with optional separators
+    # between the prefix and the digit. Short form ("r1", "pt1") is unaffected.
+
+    it "parses 'Rev.1' (period, no space)" do
+      identifier = Pubid::Nist.parse("NIST SP 800-67 Rev.1")
+      expect(identifier.to_s).to eq("NIST SP 800-67 Rev.1")
+    end
+
+    it "parses 'Rev. 1' (period and space — already supported)" do
+      identifier = Pubid::Nist.parse("NIST SP 800-67 Rev. 1")
+      expect(identifier.to_s).to eq("NIST SP 800-67 Rev. 1")
+    end
+
+    it "parses 'Part. 1' (period and space)" do
+      identifier = Pubid::Nist.parse("NIST SP 800-57 Part. 1")
+      expect(identifier.to_s).to eq("NIST SP 800-57pt1")
+    end
+
+    it "parses 'Part.1' (period, no space)" do
+      identifier = Pubid::Nist.parse("NIST SP 800-57 Part.1")
+      expect(identifier.to_s).to eq("NIST SP 800-57pt1")
+    end
+
+    it "parses 'Part 1' (space, no period — already supported)" do
+      identifier = Pubid::Nist.parse("NIST SP 800-57 Part 1")
+      expect(identifier.to_s).to eq("NIST SP 800-57pt1")
+    end
+
+    it "round-trips 'Rev.1' form through parse-serialize-parse" do
+      original = "NIST SP 800-67 Rev.1"
+      first = Pubid::Nist.parse(original)
+      expect(first.to_s).to eq(original)
+      expect(Pubid::Nist.parse(first.to_s).to_s).to eq(original)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds parser support for NIST long-notation suffixes that were previously rejected: ` Rev.1` (no space after period) and ` Part.1` / ` Part. 1` (period variants).
- Revision preserves the original spelling via the existing `original_prefix` mechanism; `Part.` forms normalize to the short `pt1` rendering, matching the existing `Part 1` behavior.

## Problem

Per #155 (originally pubid-nist#194), these long-notation forms failed:

```ruby
Pubid::Nist.parse("NIST SP 800-67 Rev.1")     # => parse error
Pubid::Nist.parse("NIST SP 800-57 Part. 1")   # => parse error
```

These forms appear in relaton-nist lookup queries (see issue body), so the gaps block real lookups.

## Implementation

- **`part` rule**: reordered the alternation so the `Part`-word forms come before the single-letter `p`/`P`/`pt` alternative. Parslet ordered choice commits to the first matching branch — under the old order, `str("P")` consumed the P of `Part`, then the rule failed on the following digits and never tried the long-form alternative.
- **`revision` rule**: added `str(" Rev.")` (no trailing space) as an alternative prefix and inserted `space.maybe` between prefix and revision id, so both ` Rev.1` and ` Rev. 1` parse. Format preservation is automatic via the existing `revision_prefix` capture.

## Test plan

- [x] New specs in `spec/pubid/nist/revision_format_preservation_spec.rb` cover `Rev.1`, `Rev. 1`, `Part.1`, `Part. 1`, `Part 1`, and a round-trip.
- [x] Full NIST suite: 1148 examples, 0 failures.
- [x] Rubocop: no new offenses (baseline is 164 pre-existing long-line offenses in `parser.rb`).

Closes #155.
