### PR TITLE
feat(itu): parse edition suffixes bis / ter / quater

### DIFF
--- a/lib/pubid/itu/builder.rb
+++ b/lib/pubid/itu/builder.rb
@@ -41,6 +41,7 @@ module Pubid
           if data[:combined_number]
             combined_code = Components::Code.new(
               number: data[:combined_number].to_s,
+              series_suffix: data[:combined_series_suffix]&.to_s,
               subseries: data[:combined_subseries]&.to_s,
               parts: extract_parts(data[:combined_parts]),
             )
@@ -128,6 +129,7 @@ module Pubid
       def build_code(data)
         Components::Code.new(
           number: data[:number].to_s,
+          series_suffix: data[:series_suffix]&.to_s,
           subseries: data[:subseries]&.to_s,
           parts: extract_parts(data[:parts]),
         )

--- a/lib/pubid/itu/components/code.rb
+++ b/lib/pubid/itu/components/code.rb
@@ -6,19 +6,24 @@ module Pubid
   module Itu
     module Components
       # ITU Code component
-      # Format: NUMBER[.SUBSERIES][-PART]
-      # Examples: 1234, 1234.5, 1234-1, 1234.5-2
+      # Format: NUMBER[SUFFIX][.SUBSERIES][-PART]
+      # Examples: 1234, 1234.5, 1234-1, 1234.5-2, 50bis, 8bis
+      #
+      # SUFFIX is the edition marker "bis" / "ter" / "quater" attached
+      # directly to the number (e.g. X.50bis, V.8bis).
       #
       # Stays independent of Pubid::Components::Code because ITU uses
       # +subseries+ (dot-separated, flavor-specific) and +parts+
       # (dash-separated).
       class Code < Lutaml::Model::Serializable
         attribute :number, :string
+        attribute :series_suffix, :string
         attribute :subseries, :string
         attribute :parts, :string, collection: true, default: []
 
         def to_s
           result = number.to_s
+          result += series_suffix.to_s if series_suffix
           result += ".#{subseries}" if subseries
           result += parts.map { |p| "-#{p}" }.join if parts&.any?
           result
@@ -32,6 +37,7 @@ module Pubid
           return false unless other.is_a?(Code)
 
           number == other.number &&
+            series_suffix == other.series_suffix &&
             subseries == other.subseries &&
             parts == other.parts
         end

--- a/lib/pubid/itu/parser.rb
+++ b/lib/pubid/itu/parser.rb
@@ -40,6 +40,13 @@ module Pubid
         dot >> digits.as(:subseries)
       end
 
+      # Edition suffix attached directly to the recommendation number.
+      # "bis" = 2nd edition, "ter" = 3rd, "quater" = 4th.
+      # Example: X.50bis, V.8bis, V.31bis.
+      rule(:series_suffix) do
+        (str("bis") | str("ter") | str("quater")).as(:series_suffix)
+      end
+
       # Parts
       rule(:part) do
         dash >> digits.as(:part)
@@ -47,9 +54,9 @@ module Pubid
 
       rule(:parts) { part.repeat(0).as(:parts) }
 
-      # Code = number + subseries + parts
+      # Code = number + edition suffix + subseries + parts
       rule(:code) do
-        number >> subseries.maybe >> parts
+        number >> series_suffix.maybe >> subseries.maybe >> parts
       end
 
       # Date

--- a/spec/pubid/itu/identifiers/recommendation_spec.rb
+++ b/spec/pubid/itu/identifiers/recommendation_spec.rb
@@ -383,4 +383,56 @@ RSpec.describe Pubid::Itu::Identifiers::Recommendation do
       end
     end
   end
+
+  describe "edition suffix (bis / ter / quater) — issue #231" do
+    context "ITU-T X.50bis" do
+      subject { "ITU-T X.50bis" }
+
+      let(:parsed) { Pubid::Itu.parse(subject) }
+
+      it "parses as Recommendation" do
+        expect(parsed).to be_a(described_class)
+      end
+
+      it "parses series" do
+        expect(parsed.series.series).to eq("X")
+      end
+
+      it "parses number" do
+        expect(parsed.code.number).to eq("50")
+      end
+
+      it "captures series_suffix" do
+        expect(parsed.code.series_suffix).to eq("bis")
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq(subject)
+      end
+    end
+
+    %w[V.8bis V.31bis].each do |series_num|
+      context "ITU-T #{series_num}" do
+        subject { "ITU-T #{series_num}" }
+
+        let(:parsed) { Pubid::Itu.parse(subject) }
+
+        it "parses number and bis suffix" do
+          number, suffix = series_num.match(/\AV\.(\d+)(bis)\z/).captures
+          expect(parsed.code.number).to eq(number)
+          expect(parsed.code.series_suffix).to eq(suffix)
+        end
+
+        it "round-trips" do
+          expect(parsed.to_s).to eq(subject)
+        end
+      end
+    end
+
+    it "treats X.50 and X.50bis as distinct identifiers" do
+      base = Pubid::Itu.parse("ITU-T X.50")
+      with_suffix = Pubid::Itu.parse("ITU-T X.50bis")
+      expect(base).not_to eq(with_suffix)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds parser support for ITU-T recommendation identifiers that carry an edition suffix attached directly to the number — `bis` (2nd edition), `ter` (3rd), `quater` (4th).

## Problem

Per #231, these identifiers failed to parse:

```ruby
Pubid::Itu.parse("ITU-T X.50bis")   # => parse error
Pubid::Itu.parse("ITU-T V.8bis")    # => parse error
Pubid::Itu.parse("ITU-T V.31bis")   # => parse error
```

These are real ITU-T recommendations (e.g. https://www.itu.int/rec/T-REC-X.50bis-198811-I/en) and block relaton-itu lookups.

## Implementation

- New `series_suffix` attribute on `Pubid::Itu::Components::Code`, rendered directly after the number with no separator (e.g. `50bis`), included in `==` so `X.50` and `X.50bis` compare as distinct.
- New `rule(:series_suffix)` in the parser matching `bis | ter | quater`, slotted into `rule(:code)` between `number` and `subseries` so all existing shapes (`X.50`, `X.509`, `H.222.0`, `BO.600-1`) continue to parse identically.
- Builder passes `series_suffix` through to Code for both primary and combined-identifier codes.

## Test plan

- [x] New specs in `spec/pubid/itu/identifiers/recommendation_spec.rb` cover `X.50bis`, `V.8bis`, `V.31bis` (parse, suffix capture, round-trip), and `X.50` vs `X.50bis` distinction.
- [x] Full ITU suite: 204 examples, 0 failures.
- [x] `prefixes_spec.rb` + `parse_interface_spec.rb` (cross-flavor): 420 examples, 0 failures.
- [x] Rubocop: no new offenses (baseline is 14 pre-existing offenses in the four touched files).

Closes #231.
