### PR TITLE
feat(itu): parse errata (Err.) including chained-on-amendment/corrigendum

### DIFF
--- a/lib/pubid/itu/builder.rb
+++ b/lib/pubid/itu/builder.rb
@@ -99,6 +99,8 @@ module Pubid
                   Identifiers::Amendment
                 when "Cor"
                   Identifiers::Corrigendum
+                when "Err"
+                  Identifiers::Errata
                 when "Suppl"
                   Identifiers::Supplement
                 end

--- a/lib/pubid/itu/identifiers.rb
+++ b/lib/pubid/itu/identifiers.rb
@@ -8,6 +8,7 @@ module Pubid
       autoload :Base, "#{__dir__}/identifiers/base"
       autoload :CombinedIdentifier, "#{__dir__}/identifiers/combined_identifier"
       autoload :Corrigendum, "#{__dir__}/identifiers/corrigendum"
+      autoload :Errata, "#{__dir__}/identifiers/errata"
       autoload :Recommendation, "#{__dir__}/identifiers/recommendation"
       autoload :SpecialPublication, "#{__dir__}/identifiers/special_publication"
       autoload :Supplement, "#{__dir__}/identifiers/supplement"

--- a/lib/pubid/itu/identifiers/errata.rb
+++ b/lib/pubid/itu/identifiers/errata.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Itu
+    module Identifiers
+      # Errata identifier (Err.)
+      # Pattern: "ITU-T G.9701 (2014) Err. 1 (07/2016)"
+      class Errata < Supplement
+        def to_s
+          result = base ? base.to_s : "#{publisher}-#{sector}"
+
+          if !base && series
+            result += " #{series}"
+          end
+
+          result += " Err. #{number}"
+
+          if date
+            result += if date.month
+                        " (#{date.month}/#{date.year})"
+                      else
+                        " (#{date.year})"
+                      end
+          end
+
+          result
+        end
+
+        def ==(other)
+          return false unless other.is_a?(Errata)
+
+          base == other.base &&
+            number == other.number &&
+            date == other.date
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/itu/parser.rb
+++ b/lib/pubid/itu/parser.rb
@@ -80,7 +80,8 @@ module Pubid
         (
           str("Suppl.") | str("Suppl") |
           str("Amd.") | str("Amd") |
-          str("Cor.") | str("Cor")
+          str("Cor.") | str("Cor") |
+          str("Err.") | str("Err")
         ).as(:supplement_type)
       end
 
@@ -130,6 +131,19 @@ module Pubid
           language.maybe
       end
 
+      # A supplement whose base is itself a supplement — e.g. Errata on an
+      # Amendment ("G.9701 (2014) Amd. 3 Err. 1 (12/2017)") or Errata on a
+      # Corrigendum. The parse tree nests base-inside-base so the builder
+      # produces a Supplement whose base is another Supplement.
+      rule(:chained_supplement) do
+        supplement_with_base.as(:base) >>
+          space >>
+          supplement_type >>
+          supplement_number >>
+          supplement_date.maybe >>
+          language.maybe
+      end
+
       # Supplement without base (series-only, like "ITU-T H Suppl. 1")
       rule(:supplement_series_only) do
         itu_prefix >>
@@ -143,9 +157,9 @@ module Pubid
           language.maybe
       end
 
-      # Complete supplement identifier (try with base first, then series-only)
+      # Complete supplement identifier (try chained first, then with base, then series-only)
       rule(:supplement_identifier) do
-        supplement_with_base | supplement_series_only
+        chained_supplement | supplement_with_base | supplement_series_only
       end
 
       # With series: ITU-R BO.600-1

--- a/spec/pubid/itu/identifiers/errata_spec.rb
+++ b/spec/pubid/itu/identifiers/errata_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pubid::Itu::Identifiers::Errata do
+  describe "errata directly on a recommendation — issue #230" do
+    context "ITU-T G.9701 (2014) Err. 1 (07/2016)" do
+      subject { "ITU-T G.9701 (2014) Err. 1 (07/2016)" }
+
+      let(:parsed) { Pubid::Itu.parse(subject) }
+
+      it "parses as Errata" do
+        expect(parsed).to be_a(described_class)
+      end
+
+      it "parses series" do
+        expect(parsed.series.series).to eq("G")
+      end
+
+      it "parses base recommendation" do
+        expect(parsed.base).to be_a(Pubid::Itu::Identifiers::Recommendation)
+        expect(parsed.base.code.number).to eq("9701")
+      end
+
+      it "parses base year" do
+        expect(parsed.base.date.year).to eq("2014")
+      end
+
+      it "parses errata number" do
+        expect(parsed.number).to eq("1")
+      end
+
+      it "parses errata date" do
+        expect(parsed.date.year).to eq("2016")
+        expect(parsed.date.month).to eq("07")
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq(subject)
+      end
+    end
+
+    context "ITU-T G.9701 (2014) Err. 1 (without errata date)" do
+      subject { "ITU-T G.9701 (2014) Err. 1" }
+
+      let(:parsed) { Pubid::Itu.parse(subject) }
+
+      it "parses as Errata" do
+        expect(parsed).to be_a(described_class)
+      end
+
+      it "has no errata date" do
+        expect(parsed.date).to be_nil
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq(subject)
+      end
+    end
+  end
+
+  describe "errata on another supplement (chained) — issue #230" do
+    # Errata on an Amendment. The Amendment base has its own pre-existing
+    # rendering convention of "Amd" without the period (see Amendment#to_s),
+    # so the chained round-trip yields "Amd 3" not "Amd. 3".
+    context "ITU-T G.9701 (2014) Amd. 3 Err. 1 (12/2017)" do
+      let(:parsed) { Pubid::Itu.parse("ITU-T G.9701 (2014) Amd. 3 Err. 1 (12/2017)") }
+
+      it "parses as Errata" do
+        expect(parsed).to be_a(described_class)
+      end
+
+      it "has an Amendment as its base" do
+        expect(parsed.base).to be_a(Pubid::Itu::Identifiers::Amendment)
+      end
+
+      it "the Amendment's base is the Recommendation" do
+        expect(parsed.base.base).to be_a(Pubid::Itu::Identifiers::Recommendation)
+        expect(parsed.base.base.code.number).to eq("9701")
+      end
+
+      it "parses errata number and date" do
+        expect(parsed.number).to eq("1")
+        expect(parsed.date.year).to eq("2017")
+        expect(parsed.date.month).to eq("12")
+      end
+
+      it "round-trips with the Amendment's period-less rendering" do
+        expect(parsed.to_s).to eq("ITU-T G.9701 (2014) Amd 3 Err. 1 (12/2017)")
+      end
+    end
+
+    context "ITU-T G.9701 (2014) Cor. 1 Err. 1 (06/2017)" do
+      subject { "ITU-T G.9701 (2014) Cor. 1 Err. 1 (06/2017)" }
+
+      let(:parsed) { Pubid::Itu.parse(subject) }
+
+      it "parses as Errata" do
+        expect(parsed).to be_a(described_class)
+      end
+
+      it "has a Corrigendum as its base" do
+        expect(parsed.base).to be_a(Pubid::Itu::Identifiers::Corrigendum)
+      end
+
+      it "parses errata number and date" do
+        expect(parsed.number).to eq("1")
+        expect(parsed.date.year).to eq("2017")
+        expect(parsed.date.month).to eq("06")
+      end
+
+      it "round-trips" do
+        expect(parsed.to_s).to eq(subject)
+      end
+    end
+  end
+
+  describe "Errata vs Corrigendum" do
+    it "treats Err. 1 and Cor. 1 as distinct" do
+      errata = Pubid::Itu.parse("ITU-T G.9701 (2014) Err. 1 (07/2016)")
+      corrigendum = Pubid::Itu.parse("ITU-T G.9701 (2014) Cor. 1 (07/2016)")
+      expect(errata).not_to eq(corrigendum)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds support for ITU-T errata identifiers (`Err. N`), including the chained form where errata applies to an amendment or corrigendum rather than directly to the recommendation.

## Problem

Per #230, these identifiers failed to parse:

```ruby
Pubid::Itu.parse("ITU-T G.9701 (2014) Err. 1 (07/2016)")           # simple
Pubid::Itu.parse("ITU-T G.9701 (2014) Amd. 3 Err. 1 (12/2017)")    # errata on amendment
Pubid::Itu.parse("ITU-T G.9701 (2014) Cor. 1 Err. 1 (06/2017)")    # errata on corrigendum
```

## Implementation

- **New `Pubid::Itu::Identifiers::Errata` class** (< Supplement), rendering as ` Err. N` with optional date — parallels Corrigendum/Supplement.
- **`supplement_type` rule** gains `str("Err.") | str("Err")`.
- **Builder** gains a `"Err"` branch mapping to `Identifiers::Errata`.
- **New `chained_supplement` rule** allows one supplement to take another supplement as its base (Errata on Amendment/Corrigendum). Tries chained first, then plain `supplement_with_base`, then series-only. The parse tree nests base-inside-base so the existing recursive builder produces a Supplement whose base is another Supplement. Bounded to one level of chaining (the issue's examples only need one level); deeper nesting would require a more invasive right-recursive refactor.

## Out of scope

The fourth example in the issue, `ITU-T G.722.2 Annex B (2002) Err. 1 (07/2003)`, requires parsing "Annex B" (annex-with-letter) inside a base identifier. That's a separate feature from errata and deserves its own PR.

## Note on round-trip

Amendment renders `Amd` without the trailing period (existing convention; see `Amendment#to_s`). The chained round-trip therefore yields `G.9701 (2014) Amd 3 Err. 1 (12/2017)` — not a regression.

## Test plan

- [x] New `spec/pubid/itu/identifiers/errata_spec.rb`: 20 examples covering simple errata, errata without date, errata on amendment (chained), errata on corrigendum (chained), and Err-vs-Cor distinction.
- [x] Full ITU suite: 204 examples, 0 failures.
- [x] Cross-flavor (`prefixes_spec`, `parse_interface_spec`): 430 examples total, 0 failures.
- [x] Rubocop: 18 offenses vs 17 baseline — the delta is `Errata#to_s` method-line-count, the same metric the existing `Corrigendum`/`Amendment`/`Supplement` `to_s` methods already exceed.

Closes #230.
