### PR TITLE
feat(itu): parse Implementers' Guide identifiers (G.Imp712, X.ImpOSI)

### DIFF
--- a/lib/pubid/itu/builder.rb
+++ b/lib/pubid/itu/builder.rb
@@ -130,6 +130,7 @@ module Pubid
 
       def build_code(data)
         Components::Code.new(
+          imp_marker: data[:imp_marker]&.to_s,
           number: data[:number].to_s,
           series_suffix: data[:series_suffix]&.to_s,
           subseries: data[:subseries]&.to_s,

--- a/lib/pubid/itu/components/code.rb
+++ b/lib/pubid/itu/components/code.rb
@@ -6,8 +6,12 @@ module Pubid
   module Itu
     module Components
       # ITU Code component
-      # Format: NUMBER[SUFFIX][.SUBSERIES][-PART]
-      # Examples: 1234, 1234.5, 1234-1, 1234.5-2, 50bis, 8bis
+      # Format: [Imp]NUMBER[SUFFIX][.SUBSERIES][-PART]
+      # Examples: 1234, 1234.5, 1234-1, 1234.5-2, 50bis, 8bis, Imp712, ImpOSI
+      #
+      # The optional "Imp" marker identifies an Implementers' Guide for the
+      # series (e.g. G.Imp712, X.ImpOSI); the NUMBER that follows may be
+      # digits or a short letter string.
       #
       # SUFFIX is the edition marker "bis" / "ter" / "quater" attached
       # directly to the number (e.g. X.50bis, V.8bis).
@@ -16,13 +20,14 @@ module Pubid
       # +subseries+ (dot-separated, flavor-specific) and +parts+
       # (dash-separated).
       class Code < Lutaml::Model::Serializable
+        attribute :imp_marker, :string
         attribute :number, :string
         attribute :series_suffix, :string
         attribute :subseries, :string
         attribute :parts, :string, collection: true, default: []
 
         def to_s
-          result = number.to_s
+          result = "#{imp_marker}#{number}"
           result += series_suffix.to_s if series_suffix
           result += ".#{subseries}" if subseries
           result += parts.map { |p| "-#{p}" }.join if parts&.any?
@@ -36,7 +41,8 @@ module Pubid
         def ==(other)
           return false unless other.is_a?(Code)
 
-          number == other.number &&
+          imp_marker == other.imp_marker &&
+            number == other.number &&
             series_suffix == other.series_suffix &&
             subseries == other.subseries &&
             parts == other.parts

--- a/lib/pubid/itu/parser.rb
+++ b/lib/pubid/itu/parser.rb
@@ -54,9 +54,25 @@ module Pubid
 
       rule(:parts) { part.repeat(0).as(:parts) }
 
-      # Code = number + edition suffix + subseries + parts
+      # Code = imp-prefixed code (Implementers' Guide) or standard code.
+      # The imp_code alternative is tried first because the standard code's
+      # number rule requires digits, which "Imp712" / "ImpOSI" would not
+      # satisfy.
       rule(:code) do
+        imp_code | standard_code
+      end
+
+      rule(:standard_code) do
         number >> series_suffix.maybe >> subseries.maybe >> parts
+      end
+
+      # Implementers' Guide code: "Imp" prefix followed by digits or a
+      # short letter string. Examples: Imp712 (G.Imp712), ImpOSI (X.ImpOSI).
+      rule(:imp_code) do
+        str("Imp").as(:imp_marker) >>
+          (digits | letter.repeat(1, 3)).as(:number) >>
+          subseries.maybe >>
+          parts
       end
 
       # Date

--- a/spec/pubid/itu/identifiers/implementers_guide_spec.rb
+++ b/spec/pubid/itu/identifiers/implementers_guide_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "ITU Implementers' Guide identifiers — issue #235" do
+  context "ITU-T G.Imp712" do
+    subject { "ITU-T G.Imp712" }
+
+    let(:parsed) { Pubid::Itu.parse(subject) }
+
+    it "parses as Recommendation" do
+      expect(parsed).to be_a(Pubid::Itu::Identifiers::Recommendation)
+    end
+
+    it "parses series" do
+      expect(parsed.series.series).to eq("G")
+    end
+
+    it "captures imp_marker" do
+      expect(parsed.code.imp_marker).to eq("Imp")
+    end
+
+    it "parses number after Imp" do
+      expect(parsed.code.number).to eq("712")
+    end
+
+    it "round-trips" do
+      expect(parsed.to_s).to eq(subject)
+    end
+  end
+
+  context "ITU-T X.ImpOSI" do
+    subject { "ITU-T X.ImpOSI" }
+
+    let(:parsed) { Pubid::Itu.parse(subject) }
+
+    it "parses series" do
+      expect(parsed.series.series).to eq("X")
+    end
+
+    it "captures imp_marker" do
+      expect(parsed.code.imp_marker).to eq("Imp")
+    end
+
+    it "parses the letter string after Imp" do
+      expect(parsed.code.number).to eq("OSI")
+    end
+
+    it "round-trips" do
+      expect(parsed.to_s).to eq(subject)
+    end
+  end
+
+  it "treats G.712 and G.Imp712 as distinct" do
+    plain = Pubid::Itu.parse("ITU-T G.712")
+    imp = Pubid::Itu.parse("ITU-T G.Imp712")
+    expect(plain).not_to eq(imp)
+  end
+
+  it "distinguishes Imp from a series that happens to start with I" do
+    # Make sure Imp-prefixed code doesn't accidentally swallow series like
+    # "IP" or "IT" (those remain plain identifiers).
+    plain = Pubid::Itu.parse("ITU-T G.712")
+    expect(plain.code.imp_marker).to be_nil
+  end
+end


### PR DESCRIPTION
## Summary

Adds support for ITU-T Implementers' Guide identifiers, which prefix the code with `Imp` (e.g. `G.Imp712`, `X.ImpOSI`).

## Problem

Per #235, these identifiers failed to parse:

```ruby
Pubid::Itu.parse("ITU-T G.Imp712")  # => parse error
Pubid::Itu.parse("ITU-T X.ImpOSI")  # => parse error (Imp followed by letters, not digits)
```

Both are real ITU-T publications:
- https://www.itu.int/rec/T-REC-G.Imp712
- https://www.itu.int/rec/T-REC-X.ImpOSI-200612-I/en

## Implementation

- New `imp_marker` attribute on `Pubid::Itu::Components::Code`, rendered directly before the number with no separator and included in `==` so `G.712` and `G.Imp712` compare as distinct.
- New `imp_code` rule in the parser; `rule(:code)` tries `imp_code` first then `standard_code` (the existing digits-only form). The `imp_code`'s number alternative accepts either digits or a 1–3 letter string to accommodate both `Imp712` and `ImpOSI`.
- Builder passes `imp_marker` through to `Code`.

## Test plan

- [x] New `spec/pubid/itu/identifiers/implementers_guide_spec.rb`: 11 examples covering `G.Imp712` and `X.ImpOSI` parse + round-trip, plus distinctness checks vs plain `G.712`.
- [x] Full ITU suite: 204 examples, 0 failures.
- [x] Rubocop: 0 offenses on `code.rb` (simplified `to_s` to keep it clean); other touched files unchanged from baseline.

Closes #235.
