### PR TITLE
fix(iec): normalize IECEE TRF semicolon and route module parse through UpdateCodes

### DIFF
--- a/data/iec/update_codes.yaml
+++ b/data/iec/update_codes.yaml
@@ -1,4 +1,7 @@
 IECEx TRF 60079-11v3-4:2002: IECEx TRF 60079-11v4C:2002
+# IECEE TRF data-source anomaly: the OD-010-1 ampersand separator (&) was
+# mistyped as a semicolon (;) in IEC's source data. See pubid/pubid#239.
+IECEE TRF 60335-2-4;7F:2012: IECEE TRF 60335-2-4&7F:2012
 IECEE TRF cispr 15N:2022: IECEE TRF CISPR 15N:2022
 IECEE TRF cispr 15M:2021: IECEE TRF CISPR 15M:2021
 IECEE TRF cispr 15L:2020: IECEE TRF CISPR 15L:2020

--- a/lib/pubid/iec.rb
+++ b/lib/pubid/iec.rb
@@ -23,12 +23,7 @@ module Pubid
     autoload :Renderer, "#{__dir__}/iec/renderer"
 
     def self.parse(identifier_string)
-      if identifier_string.length > Pubid::MAX_INPUT_LENGTH
-        raise ArgumentError, Pubid::INPUT_TOO_LONG_MESSAGE
-      end
-
-      parsed = Parser.new.parse(identifier_string)
-      Builder.new.build(parsed)
+      Identifier.parse(identifier_string)
     end
 
     def self.parse_urn(urn)

--- a/spec/pubid/iec/iecee_semicolon_spec.rb
+++ b/spec/pubid/iec/iecee_semicolon_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "IECEE TRF semicolon normalization — issue #239" do
+  # IEC's source data uses a semicolon (;) where OD-010-1 prescribes an
+  # ampersand (&) for combining test portions. data/iec/update_codes.yaml
+  # normalizes the known case before parsing.
+
+  it "normalizes IECEE TRF 60335-2-4;7F:2012 to the ampersand form" do
+    parsed = Pubid::Iec.parse("IECEE TRF 60335-2-4;7F:2012")
+    expect(parsed.to_s).to eq("IECEE TRF 60335-2-4&7F:2012")
+  end
+
+  it "parses the canonical ampersand form unchanged" do
+    parsed = Pubid::Iec.parse("IECEE TRF 60335-2-4&7F:2012")
+    expect(parsed.to_s).to eq("IECEE TRF 60335-2-4&7F:2012")
+  end
+
+  it "applies the same result via the class-level parse" do
+    via_module = Pubid::Iec.parse("IECEE TRF 60335-2-4;7F:2012")
+    via_class = Pubid::Iec::Identifier.parse("IECEE TRF 60335-2-4;7F:2012")
+    expect(via_module.to_s).to eq(via_class.to_s)
+  end
+end


### PR DESCRIPTION
## Summary

Two-part fix:

1. Add a one-line normalization in `data/iec/update_codes.yaml` mapping `IECEE TRF 60335-2-4;7F:2012` → `IECEE TRF 60335-2-4&7F:2012`. The semicolon is a known data-source anomaly (per the issue, IEC's source DB mistyped the OD-010-1 ampersand separator).
2. Fix a pre-existing API gap: `Pubid::Iec.parse` (the module-level method) was bypassing `Core::UpdateCodes.apply` entirely — only `Pubid::Iec::Identifier.parse` (the class method) applied the normalization. The module method now delegates to `Identifier.parse`, matching the pattern already used by ETSI, ITU, and other flavors.

## Problem

```ruby
Pubid::Iec.parse("IECEE TRF 60335-2-4;7F:2012")  # => parse error
```

Even with the update_codes entry in place, the module-level parse didn't apply it, so the failure persisted through the documented public API.

## Test plan

- [x] New `spec/pubid/iec/iecee_semicolon_spec.rb`: 3 examples covering (a) semicolon → ampersand normalization, (b) canonical form unchanged, (c) module-level and class-level parse agree.
- [x] Full IEC suite: 789 examples, 0 failures.
- [x] Cross-flavor (`prefixes_spec`, `parse_interface_spec`): 206 examples, 0 failures.

Closes #239.
