### PR TITLE
feat(iec): parse technical group identifiers (TC, JTC, SC, PC, CISPR, CIS)

### DIFF
--- a/lib/pubid/iec/builder.rb
+++ b/lib/pubid/iec/builder.rb
@@ -9,6 +9,11 @@ module Pubid
           return Identifiers::WorkingDocument
         end
 
+        # Check for technical group (committee identifier, no document number)
+        if parsed_hash[:technical_committee] && !parsed_hash[:wd_number]
+          return Identifiers::TechnicalGroup
+        end
+
         # Check for working document
         if parsed_hash[:technical_committee] && parsed_hash[:wd_number]
           return Identifiers::WorkingDocument
@@ -356,7 +361,7 @@ module Pubid
             end
           end
 
-        when :technical_committee, :wd_number, :wd_stage, :wd_language, :wp_stage, :wp_type
+        when :technical_committee, :subcommittee, :wd_number, :wd_stage, :wd_language, :wp_stage, :wp_type
           # Working document/programme fields - just return as string
           value.to_s
 

--- a/lib/pubid/iec/identifier.rb
+++ b/lib/pubid/iec/identifier.rb
@@ -84,6 +84,7 @@ module Pubid
         "pubid:iec:societal-technology-trend-report" => "Pubid::Iec::Identifiers::SocietalTechnologyTrendReport",
         "pubid:iec:systems-reference-document" => "Pubid::Iec::Identifiers::SystemsReferenceDocument",
         "pubid:iec:technology-report" => "Pubid::Iec::Identifiers::TechnologyReport",
+        "pubid:iec:technical-group" => "Pubid::Iec::Identifiers::TechnicalGroup",
         "pubid:iec:test-report-form" => "Pubid::Iec::Identifiers::TestReportForm",
         "pubid:iec:white-paper" => "Pubid::Iec::Identifiers::WhitePaper",
         "pubid:iec:working-document" => "Pubid::Iec::Identifiers::WorkingDocument",

--- a/lib/pubid/iec/identifiers.rb
+++ b/lib/pubid/iec/identifiers.rb
@@ -20,6 +20,7 @@ module Pubid
       autoload :SystemsReferenceDocument, "#{__dir__}/identifiers/systems_reference_document"
       autoload :TechnicalReport, "#{__dir__}/identifiers/technical_report"
       autoload :TechnicalSpecification, "#{__dir__}/identifiers/technical_specification"
+      autoload :TechnicalGroup, "#{__dir__}/identifiers/technical_group"
       autoload :TechnologyReport, "#{__dir__}/identifiers/technology_report"
       autoload :TestReportForm, "#{__dir__}/identifiers/test_report_form"
       autoload :VapIdentifier, "#{__dir__}/identifiers/vap_identifier"

--- a/lib/pubid/iec/identifiers/technical_group.rb
+++ b/lib/pubid/iec/identifiers/technical_group.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Iec
+    module Identifiers
+      # Technical Group identifier — identifies a committee rather than a
+      # publication. Covers:
+      #
+      #   IEC TC 1             (Technical Committee)
+      #   IEC PC 118           (Project Committee)
+      #   ISO/IEC JTC 1        (Joint Technical Committee)
+      #   ISO/IEC JPC 2        (Joint Project Committee)
+      #   ISO/IEC JTC 1/SC 7   (Joint TC with Subcommittee)
+      #   IEC SC 100A          (Subcommittee with letter suffix)
+      #   CIS/A                (CISPR Subcommittee, bare form)
+      #   CISPR                (CISPR Committee, bare form)
+      class TechnicalGroup < Base
+        attribute :technical_committee, :string
+        attribute :subcommittee, :string
+
+        TYPED_STAGES = [].freeze
+
+        def self.type
+          { key: :tg,
+            web: :technical_group, title: "Technical Group", short: "TG" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/iec/parser.rb
+++ b/lib/pubid/iec/parser.rb
@@ -19,6 +19,7 @@ module Pubid
       rule(:identifier) do
         working_programme_with_publisher |
           working_programme |
+          technical_group |
           working_document |
           sheet_supplement_identifier |
           sheet_identifier |
@@ -27,6 +28,42 @@ module Pubid
           supplement_identifier |
           joint_identifier |
           identifier_copublishers
+      end
+
+      # Technical Group identifier — names a committee rather than a document.
+      # Examples: "IEC TC 1", "ISO/IEC JTC 1", "ISO/IEC JTC 1/SC 7",
+      #           "IEC SC 100A", "CISPR", "CIS/A".
+      rule(:technical_group) do
+        technical_group_with_publisher | technical_group_bare
+      end
+
+      rule(:technical_group_with_publisher) do
+        prefix_sole_publisher >> copublishers.maybe >> space >>
+          tc_body.as(:technical_committee) >>
+          (str("/") >> space? >> sc_body).as(:subcommittee).maybe
+      end
+
+      rule(:technical_group_bare) do
+        # CISPR / CIS-letter forms and bare TYPE NUMBER forms both default
+        # publisher to "IEC" via the Base class default.
+        tc_body.as(:technical_committee) >>
+          (str("/") >> space? >> sc_body).as(:subcommittee).maybe
+      end
+
+      # Committee body forms accepted by the parser. Order matters: longer
+      # or more specific patterns first so they win the ordered choice.
+      rule(:tc_body) do
+        str("CISPR") |
+          (str("CIS") >> str("/") >> match("[A-Z]")) |
+          (tc_type >> space >> digits >> match("[A-Z]").maybe)
+      end
+
+      rule(:sc_body) do
+        str("SC") >> space >> digits >> match("[A-Z]").maybe
+      end
+
+      rule(:tc_type) do
+        str("JTC") | str("JPC") | str("TC") | str("SC") | str("PC")
       end
 
       # Working Programme format: [PWI|PNW] [TR] number edition

--- a/lib/pubid/iec/renderer.rb
+++ b/lib/pubid/iec/renderer.rb
@@ -37,6 +37,8 @@ module Pubid
           render_fragment(id, opts, context)
         when Identifiers::WorkingDocument
           render_working_document(id, context)
+        when Identifiers::TechnicalGroup
+          render_technical_group(id, context)
         when Identifiers::TestReportForm
           render_test_report_form(id, context)
         when SupplementIdentifier
@@ -182,6 +184,14 @@ module Pubid
 
         parts << " #{id.edition.render(context:)}" if id.edition&.number
 
+        parts.join
+      end
+
+      def render_technical_group(id, _context)
+        parts = []
+        parts << id.publisher_portion
+        parts << " #{id.technical_committee}"
+        parts << id.subcommittee if id.subcommittee
         parts.join
       end
 

--- a/spec/pubid/iec/identifiers/technical_group_spec.rb
+++ b/spec/pubid/iec/identifiers/technical_group_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Pubid::Iec::Identifiers::TechnicalGroup do
+  describe "technical committee forms — issue #244" do
+    {
+      "IEC TC 1" => { publisher: "IEC", technical_committee: "TC 1", 
+                      subcommittee: nil },
+      "IEC PC 118" => { publisher: "IEC", technical_committee: "PC 118", 
+                        subcommittee: nil },
+      "IEC SC 100A" => { publisher: "IEC", technical_committee: "SC 100A", 
+                         subcommittee: nil },
+      "ISO/IEC JTC 1" => { publisher: "ISO/IEC", technical_committee: "JTC 1", 
+                           subcommittee: nil },
+      "ISO/IEC JPC 2" => { publisher: "ISO/IEC", technical_committee: "JPC 2", 
+                           subcommittee: nil },
+      "ISO/IEC JTC 1/SC 7" => { publisher: "ISO/IEC",
+                                technical_committee: "JTC 1",
+                                subcommittee: "/SC 7" },
+      "IEC TC 100/SC 100A" => { publisher: "IEC",
+                                technical_committee: "TC 100",
+                                subcommittee: "/SC 100A" },
+    }.each do |identifier, expected|
+      context identifier do
+        subject { Pubid::Iec.parse(identifier) }
+
+        it "parses as TechnicalGroup" do
+          expect(subject).to be_a(described_class)
+        end
+
+        it "captures technical_committee" do
+          expect(subject.technical_committee)
+            .to eq(expected[:technical_committee])
+        end
+
+        it "captures subcommittee" do
+          expect(subject.subcommittee).to eq(expected[:subcommittee])
+        end
+
+        it "round-trips" do
+          expect(subject.to_s).to eq(identifier)
+        end
+      end
+    end
+  end
+
+  describe "bare committee forms" do
+    # CISPR and CIS/X are IEC committees. The bare form parses and is
+    # rendered with the default IEC publisher prefix.
+    context "CISPR" do
+      subject { Pubid::Iec.parse("CISPR") }
+
+      it "parses as TechnicalGroup" do
+        expect(subject).to be_a(described_class)
+      end
+
+      it "captures technical_committee" do
+        expect(subject.technical_committee).to eq("CISPR")
+      end
+
+      it "renders with IEC publisher prefix" do
+        expect(subject.to_s).to eq("IEC CISPR")
+      end
+    end
+
+    context "CIS/A" do
+      subject { Pubid::Iec.parse("CIS/A") }
+
+      it "parses as TechnicalGroup" do
+        expect(subject).to be_a(described_class)
+      end
+
+      it "captures the CIS/A committee identifier" do
+        expect(subject.technical_committee).to eq("CIS/A")
+      end
+
+      it "renders with IEC publisher prefix" do
+        expect(subject.to_s).to eq("IEC CIS/A")
+      end
+    end
+  end
+
+  describe "distinctness" do
+    it "distinguishes TechnicalGroup from WorkingDocument" do
+      tg = Pubid::Iec.parse("IEC TC 1")
+      wd = Pubid::Iec.parse("100/3705/FDIS")
+      expect(tg).to be_a(described_class)
+      expect(wd).to be_a(Pubid::Iec::Identifiers::WorkingDocument)
+      expect(tg).not_to eq(wd)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a new `Pubid::Iec::Identifiers::TechnicalGroup` identifier class for IEC committee identifiers — the identifiers name a committee rather than a publication.

Supported forms:

```
IEC TC 1                  # Technical Committee
IEC PC 118                # Project Committee
IEC SC 100A               # Subcommittee with letter suffix
ISO/IEC JTC 1             # Joint Technical Committee
ISO/IEC JPC 2             # Joint Project Committee
ISO/IEC JTC 1/SC 7        # Joint TC with Subcommittee
IEC TC 100/SC 100A        # TC with Subcommittee
CISPR                     # Bare IEC committee
CIS/A                     # Bare CISPR Subcommittee
```

## Problem

Per #244, none of these parsed — they failed at the top-level `identifier` rule because no alternative matched a bare committee name.

## Implementation

- **`TechnicalGroup` class** (`lib/pubid/iec/identifiers/technical_group.rb`): subclasses `Base`, adds `technical_committee` and optional `subcommittee` string attributes.
- **Parser rules** (`lib/pubid/iec/parser.rb`): new `technical_group`, `tc_body`, `sc_body`, `tc_type` rules covering TC/SC/PC/JTC/JPC types plus the CISPR / CIS-letter bare forms. Slot before `working_document` in the top-level `identifier` alternation so committee-only inputs don't get mis-routed into WorkingDocument. Uses `prefix_sole_publisher >> copublishers.maybe >> space` instead of `prefix_with_copublishers >> space` because the latter's `space?` greedy-matches the separator and starves the trailing `tc_body`.
- **Builder**: new "technical_committee present without wd_number" branch dispatches to `TechnicalGroup` (WorkingDocument retains its "technical_committee with wd_number" branch). The `subcommittee` key joins `technical_committee` in the "pass-through as string" case branch.
- **Renderer**: new `render_technical_group` emitting `{publisher} {tc}{subcommittee}`.
- **`IEC_TYPE_MAP`**: new `pubid:iec:technical-group` entry so the polymorphic-map-sync spec passes.

The bare `CISPR` and `CIS/A` forms parse without a publisher token; the IEC `Base` class's default publisher (`"IEC"`) fills in, so they render with the canonical `IEC CISPR` / `IEC CIS/A` prefix.

## Test plan

- [x] New `spec/pubid/iec/identifiers/technical_group_spec.rb`: 35 examples covering TC/PC/SC/JTC/JPC variants, bare CISPR/CIS-A, subcommittee forms, and distinctness from WorkingDocument.
- [x] Full IEC suite: 789 examples, 0 failures.
- [x] Cross-flavor (`prefixes_spec`, `parse_interface_spec`): 1030 examples total, 0 failures.
- [x] Rubocop: zero new offenses on the new file; the 124 total offenses in touched files are pre-existing (baseline 123).

Closes #244.
