### PR TITLE
feat(nist): parse "NIST Research Library (YYYY)" one-off identifier

### DIFF
--- a/lib/pubid/nist/caster.rb
+++ b/lib/pubid/nist/caster.rb
@@ -48,6 +48,11 @@ module Pubid
 
           { dated_seq: value.to_s }
 
+        when :year
+          # Bare 4-digit year (e.g. from "NIST Research Library (2022)").
+          # The Identifier#year attribute is typed as :integer.
+          value&.to_s&.to_i
+
         when :series
           return nil if value.nil? || value.to_s.strip.empty?
 

--- a/lib/pubid/nist/identifiers/base.rb
+++ b/lib/pubid/nist/identifiers/base.rb
@@ -426,6 +426,10 @@ module Pubid
         result += " #{number}" if number
         result += parts.map { |p| "-#{p}" }.join if parts&.any?
 
+        # "NIST Research Library (YYYY)" — oddball identifier with no number;
+        # the year appears in parens rather than as a date component.
+        result += " (#{year})" if year && !number
+
         # Append every optional component the parser may have attached
         # (volume, part, edition, version, supplement, update, stage, ...).
         # Shared with the lossy subclasses so they cannot silently drop a

--- a/lib/pubid/nist/parser.rb
+++ b/lib/pubid/nist/parser.rb
@@ -346,6 +346,16 @@ module Pubid
           match("[0-9]").repeat(1).as(:dated_seq)
       end
 
+      # "NIST Research Library (YYYY)" — one-off NIST publication that doesn't
+      # fit the standard series+number shape (no report number, year in parens).
+      # See pubid/pubid#151.
+      rule(:research_library_identifier) do
+        publisher >> space >>
+          str("Research Library").as(:series) >>
+          (space >> str("(") >>
+            match("[0-9]").repeat(4, 4).as(:year) >> str(")")).maybe
+      end
+
       # LEGACY EDITION PATTERNS (for backward compatibility during migration)
       # These will be gradually replaced as we migrate to proper Edition/Date components
       rule(:legacy_edition) do
@@ -656,6 +666,7 @@ module Pubid
         circ_supplement_identifier |
           dated_identifier |
           mr_identifier |
+          research_library_identifier |
           (
             # Compound series (includes publisher in series name)
             compound_series >> (space | dot) >>

--- a/spec/pubid/nist/research_library_spec.rb
+++ b/spec/pubid/nist/research_library_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "NIST Research Library — issue #151" do
+  describe "NIST Research Library (2022)" do
+    subject { Pubid::Nist.parse("NIST Research Library (2022)") }
+
+    it "parses publisher" do
+      expect(subject.publisher.to_s).to eq("NIST")
+    end
+
+    it "parses series" do
+      expect(subject.series.value).to eq("Research Library")
+    end
+
+    it "captures the year" do
+      expect(subject.year).to eq(2022)
+    end
+
+    it "round-trips" do
+      expect(subject.to_s).to eq("NIST Research Library (2022)")
+    end
+  end
+
+  describe "NIST Research Library (no year)" do
+    subject { Pubid::Nist.parse("NIST Research Library") }
+
+    it "parses" do
+      expect(subject.series.value).to eq("Research Library")
+    end
+
+    it "has no year" do
+      expect(subject.year).to be_nil
+    end
+
+    it "round-trips" do
+      expect(subject.to_s).to eq("NIST Research Library")
+    end
+  end
+
+  describe "NBS Research Library (2020)" do
+    subject { Pubid::Nist.parse("NBS Research Library (2020)") }
+
+    it "parses the NBS publisher" do
+      expect(subject.publisher.to_s).to eq("NBS")
+    end
+
+    it "round-trips" do
+      expect(subject.to_s).to eq("NBS Research Library (2020)")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds parser support for the one-off NIST identifier `NIST Research Library (YYYY)`, which does not fit the standard NIST series+number shape.

## Problem

Per #151, this identifier failed to parse:

```ruby
Pubid::Nist.parse("NIST Research Library (2022)")  # => parse error
```

The publication blocks a relaton-nist lookup (see issue body). The form is unusual:

- No report number (just the series name)
- Year appears in parentheses immediately after the series

The general identifier rule requires a separator + report number after the series, so this shape hit the top-level alternation with no matching branch.

## Implementation

- **New `research_library_identifier` parser rule** matching `{publisher} Research Library [(YYYY)]`, placed early in the `identifier` alternation so it preempts the generic series+number path.
- **New `:year` case in the caster** converts the captured 4-digit string to integer for the inherited `Identifier#year` attribute (previously the caster's default branch discarded unknown scalar parse-tree values).
- **`to_short_style`** appends ` (#{year})` when a year is set and no number is present, so the round-trip matches the input.

## Test plan

- [x] New `spec/pubid/nist/research_library_spec.rb`: 9 examples covering `NIST Research Library (2022)`, `NIST Research Library` (no year), and `NBS Research Library (2020)` (alternate publisher).
- [x] Full NIST suite: 1148 examples, 0 failures.

Closes #151.
