### PR TITLE
feat(nist): normalize "Monograph" long-form series name to MONO

### DIFF
--- a/data/nist/update_codes.yaml
+++ b/data/nist/update_codes.yaml
@@ -25,6 +25,8 @@
 # by earlier ones. Run `bundle exec rspec spec/pubid/nist/` after edits.
 NBS MN: NBS MONO
 NIST MN: NIST MONO
+# Long-form series names — normalize to the abbreviated form the parser expects.
+/\bMonograph\b/: MONO
 NIST MP: NBS MP
 NIST SP 260-162 2006ed.: NIST SP 260-162e2006
 NBS CIRC 154suprev: NBS CIRC 154r1sup

--- a/spec/pubid/nist/monograph_longform_spec.rb
+++ b/spec/pubid/nist/monograph_longform_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "NIST Monograph long-form series name — issue #189" do
+  it "normalizes 'Monograph' to 'MONO' for NIST publisher" do
+    parsed = Pubid::Nist.parse("NIST Monograph 125")
+    expect(parsed.series.value).to eq("MONO")
+    expect(parsed.to_s).to eq("NIST MONO 125")
+  end
+
+  it "normalizes 'Monograph' to 'MONO' for NBS publisher" do
+    parsed = Pubid::Nist.parse("NBS Monograph 125")
+    expect(parsed.series.value).to eq("MONO")
+    expect(parsed.to_s).to eq("NBS MONO 125")
+  end
+
+  it "parses the abbreviated form unchanged" do
+    parsed = Pubid::Nist.parse("NIST MONO 125")
+    expect(parsed.to_s).to eq("NIST MONO 125")
+  end
+end


### PR DESCRIPTION
## Summary

Adds a one-line regex normalization in `data/nist/update_codes.yaml` that rewrites the spelled-out series name "Monograph" to its canonical abbreviation "MONO" before parsing.

## Problem

Per #189, `NIST Monograph 125` (the long-form spelling used in NIST source data) failed to parse — only the abbreviated `NIST MONO 125` form was accepted.

## Implementation

A single regex entry:

```yaml
/\bMonograph\b/: MONO
```

This converts any `Monograph` token (with word boundaries) to `MONO` before the parser sees it. Both `NIST Monograph 125` and `NBS Monograph 125` now parse identically to their abbreviated forms.

## Test plan

- [x] New `spec/pubid/nist/monograph_longform_spec.rb`: 3 examples (NIST, NBS, abbreviated-form regression check).
- [x] Full NIST suite: 1148 examples, 0 failures.

Closes #189.
