### PR TITLE
feat(nist): parse long-form Vol. prefix and strip citation-form commas

### DIFF
--- a/data/nist/update_codes.yaml
+++ b/data/nist/update_codes.yaml
@@ -27,6 +27,9 @@ NBS MN: NBS MONO
 NIST MN: NIST MONO
 # Long-form series names — normalize to the abbreviated form the parser expects.
 /\bMonograph\b/: MONO
+# Citation-form comma before long parameter prefixes — strip so the parser's
+# " Rev. " / " Part. " / " Vol. " prefix rules match (issue #197).
+'/,\s+(Rev\.|Part\.|Vol\.|Revision|Volume|Part)(?=\s|\d)/': ' \1'
 NIST MP: NBS MP
 NIST SP 260-162 2006ed.: NIST SP 260-162e2006
 NBS CIRC 154suprev: NBS CIRC 154r1sup

--- a/lib/pubid/nist/parser.rb
+++ b/lib/pubid/nist/parser.rb
@@ -448,7 +448,12 @@ module Pubid
 
       # Volume
       rule(:volume) do
-        (space.maybe >> (str("v") | str(" Vol. "))) >>
+        # Long-form "Vol." comes FIRST so PEG ordered choice doesn't commit to
+        # the bare "v" alternative after consuming the leading space via
+        # space.maybe (which would then starve the " Vol. " form). Both
+        # "Vol. 4" (period + space) and "Vol.4" (period only) are accepted.
+        (space.maybe >>
+          (str("Vol. ") | str("Vol.") | str("v"))) >>
           (digits >>
            # Support letter ranges (lowercase normalized in preprocessing)
            (str("a-l") | str("m-z") | str("A-L") | str("M-Z")).maybe >>

--- a/spec/pubid/nist/long_parameters_spec.rb
+++ b/spec/pubid/nist/long_parameters_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "NIST long-form parameters — issue #197" do
+  describe "Volume with long-form 'Vol.' prefix" do
+    it "parses 'Vol. 4' (period and space)" do
+      parsed = Pubid::Nist.parse("NIST IR 8011 Vol. 4")
+      expect(parsed.volume.value).to eq("4")
+      expect(parsed.to_s).to eq("NIST IR 8011v4")
+    end
+
+    it "parses 'Vol.4' (period, no space)" do
+      parsed = Pubid::Nist.parse("NIST IR 8011 Vol.4")
+      expect(parsed.volume.value).to eq("4")
+      expect(parsed.to_s).to eq("NIST IR 8011v4")
+    end
+
+    it "parses the short 'v4' form unchanged" do
+      parsed = Pubid::Nist.parse("NIST IR 8011v4")
+      expect(parsed.volume.value).to eq("4")
+      expect(parsed.to_s).to eq("NIST IR 8011v4")
+    end
+  end
+
+  describe "citation-form comma before long parameter prefixes" do
+    it "strips comma before 'Rev.'" do
+      parsed = Pubid::Nist.parse("NIST SP 800-53, Rev. 4")
+      expect(parsed.revision).to eq("r4")
+      expect(parsed.to_s).to eq("NIST SP 800-53 Rev. 4")
+    end
+
+    it "strips comma before 'Vol.'" do
+      parsed = Pubid::Nist.parse("NIST IR 8011, Vol. 4")
+      expect(parsed.volume.value).to eq("4")
+      expect(parsed.to_s).to eq("NIST IR 8011v4")
+    end
+
+    it "strips comma before 'Part'" do
+      parsed = Pubid::Nist.parse("NIST SP 800-57, Part 1")
+      expect(parsed.to_s).to eq("NIST SP 800-57pt1")
+    end
+
+    it "leaves the no-comma form unchanged" do
+      parsed = Pubid::Nist.parse("NIST SP 800-53 Rev. 4")
+      expect(parsed.to_s).to eq("NIST SP 800-53 Rev. 4")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two related fixes that close the residual gap from #155 for NIST long-form parameters:

1. **`Vol.` prefix**: parser rule reordered so `Vol. 4` and `Vol.4` parse, alongside the existing short `v4`.
2. **Citation-form commas**: regex in `update_codes.yaml` strips `, ` before long-form parameter prefixes so prose references like `NIST SP 800-53, Rev. 4` parse.

## Problem

Per #197, these forms failed:

```ruby
Pubid::Nist.parse("NIST IR 8011 Vol. 4")        # => parse error
Pubid::Nist.parse("NIST SP 800-53, Rev. 4")     # => parse error
Pubid::Nist.parse("NIST SP 800-57, Part 1")     # => parse error
```

These appear in real relaton-nist lookup queries (see issue body).

## Implementation

- **`volume` rule** (`lib/pubid/nist/parser.rb`): reordered to `(str("Vol. ") | str("Vol.") | str("v"))` so the longer Vol-prefixed alternatives win the PEG ordered choice over bare `v`. Previously, `space.maybe` consumed the leading space that ` Vol. ` required, starving the long-form match.
- **`data/nist/update_codes.yaml`**: new regex `'/,\s+(Rev\.|Part\.|Vol\.|Revision|Volume|Part)(?=\s|\d)/': ' \1'` strips the citation-form comma before any long-form parameter prefix. Lookahead `(?=\s|\d)` ensures we only strip when the prefix is actually being used as a parameter (followed by space or digit), not mid-word.

Both forms normalize to the short canonical rendering (`Vol. 4` → `v4`, comma dropped) — consistent with how the previously merged `Rev.`/`Part.` fixes (PR #253) normalize.

## Test plan

- [x] New `spec/pubid/nist/long_parameters_spec.rb`: 7 examples covering Vol. with period+space, period only, short form, and comma-stripping for Rev./Vol./Part.
- [x] Full NIST suite: 1166 examples, 0 failures.

Closes #197.
