### PR TITLE
feat(ieee): mirror /Cor rule's separator flexibility for /Amd

### DIFF
--- a/lib/pubid/ieee/parser.rb
+++ b/lib/pubid/ieee/parser.rb
@@ -261,10 +261,16 @@ module Pubid
          ((dash | str(":") | space) >> year_digits.as(:cor_year)).maybe).as(:corrigendum)
       end
 
-      # Amendment
+      # Amendment — mirrors the corrigendum rule's separator flexibility so
+      # IEEE-format "/Amd 2-2004" and "/Amd2-2004" parse the same way as
+      # their Cor counterparts (issue #210).
       rule(:amendment) do
-        (slash >> str("Amd") >> digits.as(:amd_number) >>
-         (dash >> year_digits.as(:amd_year)).maybe).as(:amendment)
+        ((str("_") | slash | dash | space) >>
+         (str("Amendment") | str("Amd")) >>
+         (dash | dot | space).maybe >>
+         space? >>
+         digits.as(:amd_number).maybe >>
+         ((dash | str(":") | space) >> year_digits.as(:amd_year)).maybe).as(:amendment)
       end
 
       # Interpretation notation (/INT)

--- a/spec/pubid/ieee/identifiers/amendment_slash_spec.rb
+++ b/spec/pubid/ieee/identifiers/amendment_slash_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "IEEE /Amd parser parity with /Cor — issue #210" do
+  # The parser historically accepted /Cor N-YYYY in IEEE format but rejected
+  # the parallel /Amd N-YYYY form. The fix mirrors the Corrigendum rule's
+  # separator flexibility for amendments.
+
+  {
+    "IEEE Std 1003.1-2001/Amd 2-2004" => "slash + space + dash",
+    "IEEE Std 802.3-2018/Amd 1-2019" => "slash + space + dash",
+    "IEEE Std 802.3-2018/Amd1-2019" => "slash + attached number",
+    "IEEE Std 802.3-2018/Amd8-2019" => "slash + attached multi-digit",
+  }.each do |identifier, desc|
+    describe "#{identifier} (#{desc})" do
+      it "parses without raising" do
+        expect { Pubid::Ieee.parse(identifier) }.not_to raise_error
+      end
+
+      it "parses the base IEEE Standard" do
+        parsed = Pubid::Ieee.parse(identifier)
+        expect(parsed.to_s).to start_with("IEEE Std 802.3-2018")
+          .or start_with("IEEE Std 1003.1-2001")
+      end
+    end
+  end
+
+  describe "regression: /Cor still works" do
+    it "parses IEEE Std 1003.1-2001/Cor 2-2004" do
+      parsed = Pubid::Ieee.parse("IEEE Std 1003.1-2001/Cor 2-2004")
+      expect(parsed).to be_a(Pubid::Ieee::Identifiers::Corrigendum)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Mirrors the IEEE parser's `/Cor` separator flexibility for `/Amd`, so IEEE-format amendments parse the same way their corrigendum counterparts already do.

## Problem

Per #210, these forms failed to parse:

```ruby
Pubid::Ieee.parse("IEEE Std 1003.1-2001/Amd 2-2004")  # => parse error
Pubid::Ieee.parse("IEEE Std 802.3-2018/Amd 1-2019")   # => parse error
Pubid::Ieee.parse("IEEE Std 802.3-2018/Amd8-2019")    # => parse error
```

The corrigendum rule accepted slash/dash/space/underscore separators with optional spacing around the digits, but the amendment rule only accepted the narrow `/Amd{digits}-{year}` form.

## Implementation

`rule(:amendment)` now mirrors `rule(:corrigendum)`:

- Separator alternatives before the keyword: slash, dash, space, underscore.
- Accepts both `Amd` and `Amendment` (parallel to `Cor` / `Corrigendum`).
- Optional separator + space after the keyword.
- Optional year suffix with dash / colon / space separator.

## Out of scope

Parser-only fix. The amendment attributes are captured on the base Identifier (mirroring how the existing narrow `/Amd` rule stored them) but the renderer does not yet emit them. That rendering gap is orthogonal to #210 (which is about parsing parity) and deserves its own change.

## Test plan

- [x] New `spec/pubid/ieee/identifiers/amendment_slash_spec.rb`: 9 examples covering `/Amd N-YYYY`, `/AmdN-YYYY`, attached-digit forms, plus a regression check that `/Cor N-YYYY` still produces a Corrigendum.
- [x] Full IEEE suite: 169 examples, 0 failures.

Closes #210.
