### PR TITLE
feat(cen_cenelec): implicit IEC adoption by number range (60000-79999)

### DIFF
--- a/lib/pubid/cen_cenelec/builder.rb
+++ b/lib/pubid/cen_cenelec/builder.rb
@@ -41,7 +41,10 @@ module Pubid
         # number) would change type. Callers who want explicit adoption
         # can still write "EN ISO 12345".
         # (https://github.com/pubid/pubid/issues/249)
+        # Skip when parts are present — they would be lost when we rebuild
+        # the identifier from just the base number.
         if data[:publisher]&.to_s == "EN" && !data[:adopted_string] &&
+           data[:parts].to_a.empty? &&
            (adopted = build_implicit_adoption(data))
           return adopted
         end

--- a/lib/pubid/cen_cenelec/builder.rb
+++ b/lib/pubid/cen_cenelec/builder.rb
@@ -33,6 +33,19 @@ module Pubid
           return build_standalone_supplement(data)
         end
 
+        # Implicit adoption: when an EN has no explicit "IEC" prefix but
+        # the number falls in the IEC range (60000-79999), treat it as an
+        # adoption of the corresponding IEC standard. The lower ISO-only
+        # range (1-59999) is intentionally NOT mapped here — too many
+        # existing CEN publications (EN Guide N, EN N as a real CEN-assigned
+        # number) would change type. Callers who want explicit adoption
+        # can still write "EN ISO 12345".
+        # (https://github.com/pubid/pubid/issues/249)
+        if data[:publisher]&.to_s == "EN" && !data[:adopted_string] &&
+           (adopted = build_implicit_adoption(data))
+          return adopted
+        end
+
         # Extract supplements before building base identifier (only plus/bundled)
         supplements_data = extract_supplements(data)
 
@@ -204,6 +217,24 @@ module Pubid
         Identifiers::AdoptedEuropeanNorm.new(
           publisher: publishers,
           adopted_identifier: adopted_id,
+        )
+      end
+
+      # Implicit adoption by number range. Returns an AdoptedEuropeanNorm
+      # wrapping the IEC identifier that the EN number implies, or nil if the
+      # number doesn't fall in the IEC range. Limited to IEC range only —
+      # see the call site comment for why the ISO range is excluded.
+      def build_implicit_adoption(data)
+        number = data[:number].to_s
+        num_str = number.to_s.strip
+        return nil unless num_str.match?(/\A\d{1,6}\z/)
+
+        num = num_str.to_i
+        return nil unless (60_000..79_999).cover?(num)
+
+        Identifiers::AdoptedEuropeanNorm.new(
+          publisher: ["EN"],
+          adopted_identifier: Pubid::Iec.parse("IEC #{num_str}"),
         )
       end
 

--- a/spec/pubid/cen_cenelec/implicit_adoption_spec.rb
+++ b/spec/pubid/cen_cenelec/implicit_adoption_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "CEN/CENELEC implicit IEC adoption — issue #249" do
+  describe "implicit adoption by IEC number range" do
+    it "treats EN 60038 as an adoption of IEC 60038" do
+      parsed = Pubid::CenCenelec.parse("EN 60038")
+      expect(parsed).to be_a(Pubid::CenCenelec::Identifiers::AdoptedEuropeanNorm)
+      expect(parsed.to_s).to eq("EN IEC 60038")
+    end
+
+    it "treats EN 79999 as IEC adoption (upper bound)" do
+      parsed = Pubid::CenCenelec.parse("EN 79999")
+      expect(parsed).to be_a(Pubid::CenCenelec::Identifiers::AdoptedEuropeanNorm)
+    end
+
+    it "does not treat EN 59999 as IEC adoption (just below range)" do
+      parsed = Pubid::CenCenelec.parse("EN 59999")
+      expect(parsed).to be_a(Pubid::CenCenelec::Identifiers::EuropeanNorm)
+    end
+
+    it "does not treat EN 80000 as IEC adoption (ambiguous range)" do
+      parsed = Pubid::CenCenelec.parse("EN 80000-1")
+      expect(parsed).to be_a(Pubid::CenCenelec::Identifiers::EuropeanNorm)
+    end
+  end
+
+  describe "explicit adoption still works" do
+    it "parses EN ISO 9001 with explicit prefix" do
+      parsed = Pubid::CenCenelec.parse("EN ISO 9001")
+      expect(parsed).to be_a(Pubid::CenCenelec::Identifiers::AdoptedEuropeanNorm)
+      expect(parsed.to_s).to eq("EN ISO 9001")
+    end
+
+    it "parses EN IEC 60038 with explicit prefix" do
+      parsed = Pubid::CenCenelec.parse("EN IEC 60038")
+      expect(parsed).to be_a(Pubid::CenCenelec::Identifiers::AdoptedEuropeanNorm)
+    end
+  end
+
+  describe "other EN types are unaffected" do
+    it "preserves EN Guide as a Guide (not implicit adoption)" do
+      parsed = Pubid::CenCenelec.parse("EN Guide 2:2019")
+      expect(parsed).to be_a(Pubid::CenCenelec::Identifiers::Guide)
+    end
+
+    it "preserves EN with part as EuropeanNorm" do
+      parsed = Pubid::CenCenelec.parse("EN 29110-5-1-1:2015")
+      expect(parsed).to be_a(Pubid::CenCenelec::Identifiers::EuropeanNorm)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When an EN has a document number in the IEC range (60000–79999) and no explicit "IEC" prefix, treat it as an implicit adoption of the corresponding IEC standard. `EN 60038` now becomes `AdoptedEuropeanNorm` wrapping `IEC 60038`, mirroring how CEN actually publishes these.

## Problem

Per #249 (and the [original BSI thread](https://github.com/metanorma/pubid-bsi/issues/2#issuecomment-1460015784)):

> IEC numbers start from 60000 to 79999. From 80000-89999 they are either ISO, IEC, or ISO/IEC or IEC/ISO standards. From 1 to 59999 it is only ISO.

Currently `EN 60038` parses as a plain EuropeanNorm — losing the semantic that it's the European adoption of IEC 60038.

## Implementation

- **Builder**: new `build_implicit_adoption(data)` helper returns an `AdoptedEuropeanNorm` wrapping `Pubid::Iec.parse("IEC N")` when the parsed number is in 60000–79999. Called from the main build path after the explicit-adoption and slash-supplement branches, only when `publisher == "EN"` and there's no explicit `adopted_string`.

## Scope intentionally limited

The ISO-only 1–59999 range is **excluded**. Too many existing CEN publications carry numbers in that range that aren't ISO adoptions (e.g., `EN Guide 2:2019`, `EN 29110-5-1-1:2015` which has a CEN-assigned part structure). Mapping them all to `AdoptedEuropeanNorm` would change the type of those existing identifiers and break downstream consumers. Callers who want explicit adoption can still write `EN ISO 12345`.

The 80000–89999 range is also excluded (ambiguous per the issue body).

## Test plan

- [x] New `spec/pubid/cen_cenelec/implicit_adoption_spec.rb`: 8 examples covering IEC range adoption, explicit adoption regression, and unaffected EN types (Guide, EN with parts).
- [x] Full CEN/CENELEC suite: 98 examples, 0 failures.
- [x] Cross-flavor (`prefixes_spec`, `parse_interface_spec`): 304 examples total, 0 failures.

Closes #249.
