### PR TITLE
feat(itu): accept "Recommendation " long-form prefix

### DIFF
--- a/lib/pubid/itu/parser.rb
+++ b/lib/pubid/itu/parser.rb
@@ -13,8 +13,13 @@ module Pubid
       rule(:dash) { str("-") }
       rule(:dot) { str(".") }
 
-      # ITU prefix
-      rule(:itu_prefix) { str("ITU") >> (dash | space) }
+      # ITU prefix — accepts an optional leading "Recommendation " long-form
+      # prefix that appears in ITU's own citation style (e.g. the twin-text
+      # and common-text forms in issues #233 / #234).
+      rule(:itu_prefix) do
+        (str("Recommendation ") >> str("ITU") >> (dash | space)) |
+          (str("ITU") >> (dash | space))
+      end
 
       # Sector (R, T, or D)
       rule(:sector) do

--- a/spec/pubid/itu/identifiers/recommendation_prefix_spec.rb
+++ b/spec/pubid/itu/identifiers/recommendation_prefix_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "ITU 'Recommendation' long-form prefix — issue #233" do
+  describe "accepts the verbose prefix and normalizes it away" do
+    {
+      "Recommendation ITU-T H.265 (2021)" => "ITU-T H.265 (2021)",
+      "Recommendation ITU-T H.222.0 (2021)" => "ITU-T H.222.0 (2021)",
+      "Recommendation ITU-R BO.600-1" => "ITU-R BO.600-1",
+    }.each do |input, expected|
+      it "parses #{input.inspect} -> #{expected.inspect}" do
+        parsed = Pubid::Itu.parse(input)
+        expect(parsed.to_s).to eq(expected)
+      end
+    end
+  end
+
+  describe "bare form (no prefix) still works" do
+    it "parses ITU-T H.265 (2021) unchanged" do
+      parsed = Pubid::Itu.parse("ITU-T H.265 (2021)")
+      expect(parsed.to_s).to eq("ITU-T H.265 (2021)")
+    end
+  end
+
+  describe "twin-text reference" do
+    it "parses the ITU side of an H.265 twin-text reference" do
+      # Full twin-text form "... | ISO/IEC ..." is tracked separately in #234;
+      # this just verifies the ITU half parses once the prefix is stripped.
+      parsed = Pubid::Itu.parse("Recommendation ITU-T H.265 (2021)")
+      expect(parsed.series.series).to eq("H")
+      expect(parsed.code.number).to eq("265")
+      expect(parsed.date.year).to eq("2021")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds parser support for the `Recommendation ` long-form prefix that ITU uses in its own citation style.

## Problem

Per #233, the twin-text example

```ruby
Pubid::Itu.parse("Recommendation ITU-T H.265 (2021)")  # => parse error
```

failed because the parser only accepted the bare `ITU-{T|R|D}` prefix.

## Implementation

`rule(:itu_prefix)` now matches either `Recommendation ITU-{T|R|D}` or the bare `ITU-{T|R|D}`. The verbose prefix is normalized away in the canonical output (consistent with how the parser handles other long-form prefixes).

## Scope

This unblocks the **ITU half** of #233's twin-text example. The full `... | ISO/IEC ...` combined form is tracked separately in #234 — that requires modeling the cross-organization link, which is a bigger design question.

## Test plan

- [x] New `spec/pubid/itu/identifiers/recommendation_prefix_spec.rb`: 5 examples covering `Recommendation ITU-T ...`, `Recommendation ITU-R ...`, bare form regression, and twin-text reference.
- [x] Full ITU suite: 245 examples, 0 failures.

Closes #233.
