### PR TITLE
feat(plateau): parse legacy Latin references, normalizing to canonical

### DIFF
--- a/lib/pubid/plateau/builder.rb
+++ b/lib/pubid/plateau/builder.rb
@@ -29,7 +29,11 @@ module Pubid
         }
 
         params[:annex] = parsed[:annex].to_s.to_i if parsed[:annex]
-        params[:edition] = parsed[:edition].to_s if parsed[:edition]
+        # Only Handbook carries an edition; a legacy Latin TR captures the
+        # edition slice via the shared handbook rule, so drop it here.
+        if parsed[:edition] && klass == Identifiers::Handbook
+          params[:edition] = parsed[:edition].to_s
+        end
 
         klass.new(**params)
       end

--- a/lib/pubid/plateau/parser.rb
+++ b/lib/pubid/plateau/parser.rb
@@ -21,17 +21,23 @@ module Pubid
       # Number: #00, #01, #46, etc.
       rule(:number) { hash >> digits.as(:number) }
 
-      # Annex: -1, -2, etc.
-      rule(:annex) { dash >> digits.as(:annex) }
+      # Annex: -1, -2, etc. Legacy Latin references use "_" as the sub-number
+      # separator (e.g. "#46_1"); both render as the canonical dash.
+      rule(:annex) { (dash | str("_")) >> digits.as(:annex) }
 
-      # Edition: 第1.0版, 第2.3版, etc. (only for Handbook)
+      # Edition (Handbook only). Canonical form is 第X.Y版; legacy Latin
+      # references write the bare X.Y (e.g. "PLATEAU Handbook #00 1.0"). Both
+      # capture the same numeric :edition slice, so they build the same object
+      # and render to the canonical 第X.Y版.
       rule(:edition_part) do
         str("第") >>
           (digits >> str(".") >> digits).as(:edition) >>
           str("版")
       end
 
-      rule(:edition) { space >> edition_part }
+      rule(:edition_latin) { (digits >> str(".") >> digits).as(:edition) }
+
+      rule(:edition) { space >> (edition_part | edition_latin) }
 
       # Annex supplement: "Annex A", "Annex B", etc.
       rule(:annex_letter) { match["A-Z"].as(:annex_letter) }
@@ -45,6 +51,10 @@ module Pubid
           number >> annex.maybe >> edition.maybe
       end
 
+      # Technical Report has no edition. A legacy Latin TR reference carrying a
+      # trailing edition (e.g. "#00 1.0") is matched by the `handbook` rule
+      # (doc_type matches either keyword, tried first); the builder dispatches
+      # on :type and drops the captured edition for Technical Report.
       rule(:technical_report) do
         publisher >> space >> doc_type >> space >>
           number >> annex.maybe

--- a/spec/pubid/plateau/legacy_latin_spec.rb
+++ b/spec/pubid/plateau/legacy_latin_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+
+# Legacy Latin PLATEAU references (as they appear in relaton-data-plateau's
+# index-v1) must parse to the *canonical* identifier, so a Latin query resolves
+# the same record as the canonical one. Latin is an accepted input alias only;
+# to_s/to_hash output stays canonical.
+RSpec.describe "Pubid::Plateau legacy Latin references" do
+  # legacy Latin input  =>  canonical identifier it must equal
+  {
+    # Handbook: Latin edition X.Y  ->  第X.Y版
+    "PLATEAU Handbook #00 1.0" => "PLATEAU Handbook #00 第1.0版",
+    "PLATEAU Handbook #01 5.1" => "PLATEAU Handbook #01 第5.1版",
+    "PLATEAU Handbook #00 6.0" => "PLATEAU Handbook #00 第6.0版",
+    # Handbook with dash annex + Latin edition
+    "PLATEAU Handbook #03-1 3.0" => "PLATEAU Handbook #03-1 第3.0版",
+    # Technical Report: Latin edition dropped
+    "PLATEAU Technical Report #00 1.0" => "PLATEAU Technical Report #00",
+    "PLATEAU Technical Report #101 1.0" => "PLATEAU Technical Report #101",
+    # Technical Report: underscore sub-number -> dash, edition dropped
+    "PLATEAU Technical Report #46_1 1.0" => "PLATEAU Technical Report #46-1",
+    "PLATEAU Technical Report #46_2 1.0" => "PLATEAU Technical Report #46-2",
+    # Technical Report: underscore sub-number, no edition
+    "PLATEAU Technical Report #46_1" => "PLATEAU Technical Report #46-1",
+  }.each do |latin, canonical|
+    context latin.inspect do
+      it "parses to the same identifier as #{canonical.inspect}" do
+        from_latin     = Pubid::Plateau.parse(latin)
+        from_canonical = Pubid::Plateau.parse(canonical)
+
+        expect(from_latin.to_s).to eq(canonical)
+        expect(from_latin.to_s).to eq(from_canonical.to_s)
+        expect(from_latin.to_hash).to eq(from_canonical.to_hash)
+
+        # Canonical no-defaults hash round-trips idempotently (relaton-index
+        # relies on this equality — see CLAUDE.md).
+        expect(from_latin.class.from_hash(from_latin.to_hash).to_hash)
+          .to eq(from_latin.to_hash)
+      end
+    end
+  end
+
+  # A Latin edition / underscore annex combined with an "Annex X" supplement
+  # normalizes through the wrapper too. (Only to_s is asserted: the annex
+  # SupplementIdentifier's to_hash is independently unsupported today — it
+  # raises for the canonical form as well — so serialization equality is out of
+  # scope for this Latin-input change.)
+  {
+    "PLATEAU Handbook #00 1.0 Annex A" =>
+      "PLATEAU Handbook #00 第1.0版 Annex A",
+    "PLATEAU Technical Report #46_1 Annex A" =>
+      "PLATEAU Technical Report #46-1 Annex A",
+  }.each do |latin, canonical|
+    it "normalizes annex-supplement #{latin.inspect} to #{canonical.inspect}" do
+      expect(Pubid::Plateau.parse(latin).to_s).to eq(canonical)
+      expect(Pubid::Plateau.parse(latin).to_s)
+        .to eq(Pubid::Plateau.parse(canonical).to_s)
+    end
+  end
+
+  it "does not regress the canonical forms" do
+    expect(Pubid::Plateau.parse("PLATEAU Handbook #00 第1.0版").to_s)
+      .to eq("PLATEAU Handbook #00 第1.0版")
+    expect(Pubid::Plateau.parse("PLATEAU Technical Report #46-1").to_s)
+      .to eq("PLATEAU Technical Report #46-1")
+    expect(Pubid::Plateau.parse("PLATEAU Technical Report #01").to_s)
+      .to eq("PLATEAU Technical Report #01")
+  end
+end


### PR DESCRIPTION
## Summary

Lets `Pubid::Plateau.parse` accept the **legacy Latin** PLATEAU id forms (as stored in `relaton-data-plateau`'s `index-v1`) as an **input alias**, normalizing them to the existing **canonical** identifier so a Latin query resolves the same record. Output stays canonical (`to_s`/`to_hash` unchanged).

This unblocks the relaton PLATEAU `index-v2` migration, which deliberately added no relaton-side shim and gates on pubid doing the normalization (a `pending` relaton spec un-pends once this ships).

## Accepted legacy inputs → canonical

| Legacy Latin input | Canonical identifier |
|---|---|
| `PLATEAU Handbook #NN X.Y` | `PLATEAU Handbook #NN 第X.Y版` |
| `PLATEAU Handbook #NN-M X.Y` | `PLATEAU Handbook #NN-M 第X.Y版` |
| `PLATEAU Technical Report #NN X.Y` | `PLATEAU Technical Report #NN` (edition dropped) |
| `PLATEAU Technical Report #NN_M X.Y` | `PLATEAU Technical Report #NN-M` |
| `PLATEAU Technical Report #NN_M` | `PLATEAU Technical Report #NN-M` |

## Approach (grammar extension, no `update_codes` regex)

- **`parser.rb`**: add an `edition_latin` alternative (bare `X.Y`) capturing the same `:edition` slice as the canonical `第X.Y版`; accept `_` alongside `-` as the annex separator.
- **`builder.rb`**: the shared `handbook` rule also matches Technical Report strings (`doc_type` matches either keyword and is tried first), so a Latin TR captures an `:edition` slice. Technical Report has no `edition` attribute, so the builder only applies `:edition` when building a Handbook — dropping it for TR.

`Renderer` is untouched; canonical forms parse byte-identically (the `第X.Y版` / dash branches still win first).

## Tests

New `spec/pubid/plateau/legacy_latin_spec.rb` asserts `parse(latin).to_s == parse(canonical).to_s`, `.to_hash` equality, and no-defaults hash idempotency for every row (incl. real-data variants `#01 5.1`, `#03-1 3.0`, `#46_1`/`#46_2`, and annex-supplement combinations), plus a canonical-forms non-regression check. Full `spec/pubid/plateau/` suite green (30 examples).