### PR TITLE
feat(itu): parse common-text identifiers (Recommendation ITU-T X | ISO/IEC Y)

### DIFF
--- a/lib/pubid/itu/builder.rb
+++ b/lib/pubid/itu/builder.rb
@@ -13,15 +13,24 @@ module Pubid
           return build_annex(data[:annex_to])
         end
 
+        # Common-text twin ("| ISO/IEC ..." suffix) — extract before building
+        # the base ITU identifier, then attach to whichever class the base
+        # resolves to.
+        twin = parse_common_text_twin(data.delete(:common_text_twin))
+
         # Operational Bulletin (Special Publication) — series == "OB" or
         # legacy long form ("Operational Bulletin No. ...").
         if data[:series].to_s == "OB" || data[:_op_bull]
-          return build_special_publication(data)
+          sp = build_special_publication(data)
+          sp.common_text_twin = twin if twin && sp
+          return sp
         end
 
         # Check if this is a supplement identifier
         if data[:supplement_type]
-          return build_supplement(data)
+          supp = build_supplement(data)
+          supp.common_text_twin = twin if twin && supp
+          return supp
         end
 
         # Build basic recommendation or combined identifier
@@ -55,6 +64,7 @@ module Pubid
             combined_code: combined_code,
             date: date,
             language: data[:language]&.to_s,
+            common_text_twin: twin,
           )
         end
 
@@ -64,7 +74,32 @@ module Pubid
           code: code,
           date: date,
           language: data[:language]&.to_s,
+          common_text_twin: twin,
         )
+      end
+
+      # Parse the common-text twin string ("| ISO/IEC 13818-1:2022") into
+      # the appropriate flavor's identifier object. Returns nil if the twin
+      # is empty or unparseable.
+      def parse_common_text_twin(twin_raw)
+        return nil if twin_raw.nil?
+
+        twin_str = twin_raw.to_s.strip
+        # Strip a leading pipe if the parser captured it
+        twin_str = twin_str.sub(/\A\s*\|\s*/, "")
+        return nil if twin_str.empty?
+
+        case twin_str
+        when /\AISO\/IEC\b/, /\AISO\b/
+          Pubid::Iso.parse(twin_str)
+        when /\AIEC\b/
+          Pubid::Iec.parse(twin_str)
+        end
+      rescue StandardError
+        # If the twin doesn't parse as a known flavor, leave it as nil
+        # rather than blowing up the whole parse — the ITU half is still
+        # usable on its own.
+        nil
       end
 
       # Build Special Publication (OB). Sector is silently dropped — OB is a

--- a/lib/pubid/itu/identifiers/base.rb
+++ b/lib/pubid/itu/identifiers/base.rb
@@ -29,6 +29,7 @@ module Pubid
       attribute :code, Pubid::Itu::Components::Code
       attribute :date, Pubid::Components::Date
       attribute :language, :string
+      attribute :common_text_twin, ::Pubid::Identifier
 
       def initialize(**kwargs)
         if kwargs[:language]
@@ -85,7 +86,9 @@ module Pubid
       #   identifiers, otherwise the default short form.
       def to_s(**opts)
         opts = self.class.normalize_to_s_opts(opts)
-        render_base(**opts) + render_language_suffix
+        result = render_base(**opts) + render_language_suffix
+        result += " | #{common_text_twin}" if common_text_twin
+        result
       end
 
       def render_base(**_opts)
@@ -140,7 +143,8 @@ module Pubid
           series == other.series &&
           code == other.code &&
           date == other.date &&
-          language == other.language
+          language == other.language &&
+          common_text_twin == other.common_text_twin
       end
 
       private

--- a/lib/pubid/itu/parser.rb
+++ b/lib/pubid/itu/parser.rb
@@ -249,6 +249,13 @@ module Pubid
         str("Annex to") >> space >> special_publication.as(:annex_to)
       end
 
+      # Common-text suffix: "| ISO/IEC ..." or "| ISO ..." — the same
+      # document published jointly by ITU and ISO/IEC. Captured as a raw
+      # string; the builder parses it with the appropriate flavor.
+      rule(:common_text_twin) do
+        (space >> str("|") >> space >> match("[^|]").repeat(1)).as(:common_text_twin)
+      end
+
       rule(:identifier) do
         annex_to_identifier |
           special_publication |
@@ -257,7 +264,13 @@ module Pubid
           without_series
       end
 
-      rule(:root) { identifier }
+      # Common-text form: an ITU identifier followed by "| ISO/IEC ...".
+      # Tried last so it doesn't shadow the simpler single-identifier forms.
+      rule(:common_text_identifier) do
+        identifier >> common_text_twin
+      end
+
+      rule(:root) { common_text_identifier | identifier }
 
       def self.parse(input)
         new.parse(input)

--- a/spec/pubid/itu/identifiers/common_text_spec.rb
+++ b/spec/pubid/itu/identifiers/common_text_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "ITU common-text identifier — issue #234" do
+  describe "Recommendation ITU-T X | ISO/IEC Y" do
+    let(:identifier) do
+      "Recommendation ITU-T H.222.0 (2021) | ISO/IEC 13818-1:2022"
+    end
+    let(:parsed) { Pubid::Itu.parse(identifier) }
+
+    it "parses as a Recommendation" do
+      expect(parsed).to be_a(Pubid::Itu::Identifiers::Recommendation)
+    end
+
+    it "parses the ITU half" do
+      expect(parsed.series.series).to eq("H")
+      expect(parsed.code.number).to eq("222")
+      expect(parsed.code.subseries).to eq("0")
+      expect(parsed.date.year).to eq("2021")
+    end
+
+    it "captures the common-text twin as an ISO identifier" do
+      twin = parsed.common_text_twin
+      expect(twin).to be_a(Pubid::Iso::Identifiers::InternationalStandard)
+      expect(twin.publisher.publisher).to eq("ISO")
+      expect(twin.copublishers.first.publisher).to eq("IEC")
+      expect(twin.number.value).to eq("13818")
+      expect(twin.part.value).to eq("1")
+      expect(twin.date.year).to eq("2022")
+    end
+
+    it "round-trips" do
+      # The "Recommendation " prefix is normalized away (same as #233).
+      expect(parsed.to_s)
+        .to eq("ITU-T H.222.0 (2021) | ISO/IEC 13818-1:2022")
+    end
+  end
+
+  describe "without the verbose prefix" do
+    it "parses ITU-T H.222.0 (2021) | ISO/IEC 13818-1:2022" do
+      parsed = Pubid::Itu.parse("ITU-T H.222.0 (2021) | ISO/IEC 13818-1:2022")
+      expect(parsed.common_text_twin).to be_a(Pubid::Iso::Identifier)
+      expect(parsed.to_s).to eq("ITU-T H.222.0 (2021) | ISO/IEC 13818-1:2022")
+    end
+  end
+
+  describe "without a twin (regression check)" do
+    it "leaves common_text_twin nil" do
+      parsed = Pubid::Itu.parse("ITU-T H.265 (2021)")
+      expect(parsed.common_text_twin).to be_nil
+    end
+  end
+
+  describe "distinctness" do
+    it "treats the common-text form as distinct from its bare ITU half" do
+      with_twin = Pubid::Itu.parse("ITU-T H.222.0 (2021) | ISO/IEC 13818-1:2022")
+      without_twin = Pubid::Itu.parse("ITU-T H.222.0 (2021)")
+      expect(with_twin).not_to eq(without_twin)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds parser support for ITU's common-text form, where the same document is jointly published as an ITU Recommendation and an ISO/IEC Standard:

```
Recommendation ITU-T H.222.0 (2021) | ISO/IEC 13818-1:2022
```

## Problem

Per #234, this combined form failed to parse. The ITU half alone was already accepted (after #267 added the `Recommendation ` prefix), but the `| ISO/IEC ...` suffix was rejected.

## Implementation

- **Parser**: new `rule(:common_text_twin)` captures the trailing `| {anything-but-pipe}` as a raw string. `rule(:root)` tries `common_text_identifier` before the bare identifier so it preempts without shadowing simpler forms.
- **`Itu::Identifier`**: new `common_text_twin` attribute typed as polymorphic `Pubid::Identifier`. `==` includes it so a common-text id and its bare ITU half compare as distinct.
- **`to_s`**: appends ` | #{twin}` when `common_text_twin` is set.
- **Builder**: `parse_common_text_twin` strips the captured leading pipe and routes the remaining string through `Pubid::Iso.parse` or `Pubid::Iec.parse` based on the leading prefix. If the twin doesn't parse as ISO or IEC, it's silently set to `nil` rather than failing the whole parse — the ITU half is still usable on its own.

The twin identifier is shared across all identifier types: `Recommendation`, `CombinedIdentifier`, `SpecialPublication`, and the supplement family all accept and render `common_text_twin`.

## Test plan

- [x] New `spec/pubid/itu/identifiers/common_text_spec.rb`: 7 examples covering common-text form (with and without `Recommendation ` prefix), twin type/attributes, regression check, and distinctness.
- [x] Full ITU suite: 250 examples, 0 failures.

Closes #234.
