### PR TITLE
feat(bsi): expose Annex F series taxonomy (automotive/aerospace/marine)

### DIFF
--- a/lib/pubid/bsi/single_identifier.rb
+++ b/lib/pubid/bsi/single_identifier.rb
@@ -75,6 +75,54 @@ module Pubid
           0
         end
       end
+
+      # Annex F series groupings per "Rules for the structure and drafting
+      # of UK standards" (BSI, 2017), F.1.3-F.1.5. Each maps a `prefix`
+      # token to the broader series category.
+      SERIES_CATEGORIES = {
+        # F.1.3 Automobile
+        "AU" => :automotive,
+        # F.1.4 Aerospace
+        "A" => :aerospace, "B" => :aerospace, "C" => :aerospace,
+        "F" => :aerospace, "G" => :aerospace, "HC" => :aerospace,
+        "L" => :aerospace, "S" => :aerospace, "SP" => :aerospace,
+        "X" => :aerospace, "M" => :aerospace, "TA" => :aerospace,
+        "2A" => :aerospace, "2B" => :aerospace, "2C" => :aerospace,
+        "2F" => :aerospace, "2G" => :aerospace, "2HC" => :aerospace,
+        "2HR" => :aerospace, "2L" => :aerospace, "2M" => :aerospace,
+        "2S" => :aerospace, "2SP" => :aerospace, "2TA" => :aerospace,
+        "2X" => :aerospace, "3A" => :aerospace, "3B" => :aerospace,
+        "3F" => :aerospace, "3G" => :aerospace, "3HR" => :aerospace,
+        "3J" => :aerospace, "3L" => :aerospace, "3S" => :aerospace,
+        "3TA" => :aerospace, "4F" => :aerospace, "4L" => :aerospace,
+        "4S" => :aerospace, "5S" => :aerospace, "7S" => :aerospace,
+        # F.1.5 Marine
+        "MA" => :marine, "PL" => :marine, "QC" => :marine,
+      }.freeze
+
+      # Series accessor — semantically named alias for `prefix` per
+      # issue #252. Returns the prefix token (e.g., "AU", "MA", "2A").
+      def series
+        prefix
+      end
+
+      # Series category — one of :automotive, :aerospace, :marine, or nil
+      # when the identifier doesn't carry a recognized Annex F prefix.
+      def series_category
+        SERIES_CATEGORIES[prefix.to_s] if prefix
+      end
+
+      def automotive?
+        series_category == :automotive
+      end
+
+      def aerospace?
+        series_category == :aerospace
+      end
+
+      def marine?
+        series_category == :marine
+      end
     end
 
     # Backward-compatible alias: BSI's base class is Pubid::Bsi::Identifier.

--- a/spec/pubid/bsi/identifier_series_spec.rb
+++ b/spec/pubid/bsi/identifier_series_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "BSI identifier series — issue #252" do
+  describe "#series accessor" do
+    it "exposes the prefix under the semantically named 'series' method" do
+      parsed = Pubid::Bsi.parse("BS AU 145e:2018")
+      expect(parsed.series).to eq("AU")
+      expect(parsed.prefix).to eq("AU") # back-compat
+    end
+
+    it "returns nil for a plain British Standard with no prefix" do
+      parsed = Pubid::Bsi.parse("BS 1234")
+      expect(parsed.series).to be_nil
+    end
+  end
+
+  describe "#series_category — Annex F groupings" do
+    {
+      "BS AU 145e:2018" => :automotive,    # F.1.3
+      "BS M 38:1971" => :aerospace,         # F.1.4 (methods for aircraft)
+      "BS 2A 293:2005" => :aerospace,       # F.1.4 multi-letter
+      "BS TA 40:1971" => :aerospace,        # F.1.4 materials
+      "BS MA 97:2019" => :marine,           # F.1.5
+      "BS 1234" => nil,
+    }.each do |identifier, expected|
+      it "#{identifier} -> #{expected.inspect}" do
+        parsed = Pubid::Bsi.parse(identifier)
+        expect(parsed.series_category).to eq(expected)
+      end
+    end
+  end
+
+  describe "category predicates" do
+    it "automotive? is true for AU prefix" do
+      expect(Pubid::Bsi.parse("BS AU 145e:2018").automotive?).to be(true)
+      expect(Pubid::Bsi.parse("BS AU 145e:2018").aerospace?).to be(false)
+    end
+
+    it "aerospace? is true for single- and multi-letter aerospace prefixes" do
+      expect(Pubid::Bsi.parse("BS A 109:2024").aerospace?).to be(true)
+      expect(Pubid::Bsi.parse("BS 2A 293:2005").aerospace?).to be(true)
+    end
+
+    it "marine? is true for MA prefix" do
+      expect(Pubid::Bsi.parse("BS MA 97:2019").marine?).to be(true)
+    end
+
+    it "all predicates are false for plain BS" do
+      parsed = Pubid::Bsi.parse("BS 1234")
+      expect(parsed.automotive?).to be(false)
+      expect(parsed.aerospace?).to be(false)
+      expect(parsed.marine?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Exposes BSI's Annex F series taxonomy (automotive / aerospace / marine) via semantically named accessors on `Pubid::Bsi::Identifier`.

## Problem

Per #252, the BSI parser already captured the prefix token (`AU`, `MA`, `2A`, etc.) on `SingleIdentifier#prefix`, but:

1. The accessor wasn't semantically named — callers reading BSI documentation see "series" terminology.
2. There was no way to map a raw prefix token to its broader Annex F category (F.1.3 automobile, F.1.4 aerospace, F.1.5 marine).

## Implementation

Added on `Pubid::Bsi::Identifier`:

- `#series` — alias for `#prefix`. Returns the raw token (`"AU"`, `"MA"`, `"2A"`, `nil` for plain British Standards).
- `#series_category` — maps the token to one of `:automotive` (F.1.3, `AU`), `:aerospace` (F.1.4, `A/B/C/F/G/HC/L/M/S/SP/X/TA` + `2_`/`3_`/`4_`/`5_`/`7_` multi-letter variants), `:marine` (F.1.5, `MA`/`PL`/`QC`), or `nil`.
- `#automotive?`, `#aerospace?`, `#marine?` — predicate shortcuts.

Purely additive — `#prefix` remains the storage attribute, so existing callers and the on-disk serialization shape are unchanged.

## Test plan

- [x] New `spec/pubid/bsi/identifier_series_spec.rb`: 12 examples covering `#series` alias, `#series_category` mappings across all three Annex F groupings, and the predicate methods.
- [x] Full BSI suite: 281 examples, 0 failures.

Closes #252.
