### PR TITLE
fix(ieee): correct ISO/IEC DIS P26511.2 normalization (no phantom part 2)

### DIFF
--- a/data/ieee/update_codes.yaml
+++ b/data/ieee/update_codes.yaml
@@ -32,7 +32,13 @@ ISO/IEC/IEEE P26515 FDIS, May 2018: ISO/IEC/IEEE FDIS P26515, May 2018
 IEEE Std Std 1139-2008: IEEE Std 1139-2008
 IEC/IEEE P60214-2, FDIS 2018: IEC/IEEE FDIS P60214-2-2018(E)
 IEC/IEEE P62582-6, FDIS 2018: IEC/IEEE FDIS P62582-6-2018(E)
-ISO/IEC DIS P26511.2, May 2017: ISO/IEC DIS P26511-2, May 2017
+# ISO/IEC DIS P26511.2 (May 2017) is an IEEE-style citation of an ISO/IEC
+# DIS draft — ".2" is a draft version, not a part, so the prior mapping
+# to "ISO/IEC DIS P26511-2" produced a phantom document that doesn't exist
+# (ISO/IEC 26511 has no part 2). The ISO parser doesn't yet support the
+# IEEE-style "P" prefix or the ", Month Year" date suffix on ISO/IEC DIS
+# citations, so normalize to the bare DIS base + year. See pubid/pubid#212.
+ISO/IEC DIS P26511.2, May 2017: ISO/IEC DIS 26511.2:2017
 ISO/IEC/IEEE P90003_FDIS, August 2018: ISO/IEC/IEEE FDIS P90003, August 2018
 ISO/IEC/IEEE&#xA0;P29119-1/FDIS, September 2021: ISO/IEC/IEEE FDIS P29119-1, September 2021
 ISO/IEC/IEEE/ P12207-2/D3_FDIS, July 2020: ISO/IEC/IEEE FDIS P12207-2/D3, July 2020

--- a/spec/pubid/ieee/p26511_normalization_spec.rb
+++ b/spec/pubid/ieee/p26511_normalization_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "ISO/IEC DIS P26511.2 normalization — issue #212" do
+  # The prior mapping pointed to "ISO/IEC DIS P26511-2", which is a phantom
+  # document — ISO/IEC 26511 has no part 2. The ".2" is an IEEE-style draft
+  # version marker, not an ISO part. The new mapping normalizes to a real
+  # ISO DIS form.
+
+  it "UpdateCodes rewrites the IEEE-style citation to a real ISO DIS form" do
+    normalized = Pubid::Core::UpdateCodes.apply(
+      "ISO/IEC DIS P26511.2, May 2017", :ieee,
+    )
+    expect(normalized).to eq("ISO/IEC DIS 26511.2:2017")
+  end
+
+  it "the normalized form parses as an ISO identifier" do
+    expect { Pubid::Iso.parse("ISO/IEC DIS 26511.2:2017") }.not_to raise_error
+  end
+
+  it "the prior phantom form no longer appears in the rewrite" do
+    normalized = Pubid::Core::UpdateCodes.apply(
+      "ISO/IEC DIS P26511.2, May 2017", :ieee,
+    )
+    expect(normalized).not_to include("P26511-2")
+  end
+end


### PR DESCRIPTION
## Summary

Corrects the existing `update_codes.yaml` entry for `ISO/IEC DIS P26511.2` so it no longer produces a phantom document.

## Problem

Per #212, the existing mapping

```yaml
ISO/IEC DIS P26511.2, May 2017: ISO/IEC DIS P26511-2, May 2017
```

was wrong: `ISO/IEC 26511-2` doesn't exist (the user verified by search). The `.2` in the source citation is an IEEE-style draft version marker, not an ISO part number.

## Fix

```yaml
ISO/IEC DIS P26511.2, May 2017: ISO/IEC DIS 26511.2:2017
```

The new form:
- Drops the IEEE `P` project prefix (unsupported by the ISO parser).
- Uses the ISO `:YYYY` date form instead of IEEE's `, Month YYYY`.
- Preserves the `.2` (which the ISO parser accepts as a subnumber).
- Yields a real, parseable ISO identifier (`Pubid::Iso.parse("ISO/IEC DIS 26511.2:2017")` works).

## Out of scope

The IEEE parser still can't consume the corrected form directly — the broader gap is that the IEEE parser doesn't support full ISO/IEC DIS citations. That's a separate enhancement; this PR just stops claiming a wrong normalization that produced a phantom document.

## Test plan

- [x] New `spec/pubid/ieee/p26511_normalization_spec.rb`: 3 examples verifying the rewrite produces the corrected form, that form parses via ISO, and the prior phantom form no longer appears.
- [x] Full IEEE suite: 178 examples, 0 failures.

Closes #212.
