### PR TITLE
feat(ieee): default draft version to 1 for Draft-type identifiers

### DIFF
--- a/lib/pubid/ieee/builder.rb
+++ b/lib/pubid/ieee/builder.rb
@@ -813,6 +813,12 @@ module Pubid
         # Handle draft (can be complex)
         handle_draft(parsed, attributes)
 
+        # Default draft version 1 when the type indicates a Draft but the
+        # parser found no explicit version (issue #205). Real-world IEEE
+        # drafts always have at least version 1; the missing suffix is a
+        # source-data omission, not an undrafted document.
+        apply_default_draft_version(attributes, type_value)
+
         # Handle corrigendum
         handle_corrigendum(parsed, attributes)
 
@@ -925,6 +931,20 @@ module Pubid
       def extract_optional(parsed, attributes, key)
         value = extract_value(parsed[key])
         attributes[key] = value if value
+      end
+
+      # Default draft version to "1" when the identifier type indicates a
+      # Draft but the parser found no explicit version (issue #205).
+      def apply_default_draft_version(attributes, type_value)
+        return if attributes[:draft] || attributes[:draft_obj]
+        return unless type_value.to_s == "Draft Std"
+
+        attributes[:draft] = "D1"
+        # Carry the identifier's year into the draft object so the renderer
+        # doesn't drop it (the renderer suppresses the `-YYYY` suffix when
+        # a draft is attached, expecting the year to live inside /D...).
+        attributes[:draft_obj] =
+          Components::Draft.new(version: "1", year: attributes[:year])
       end
 
       # Handle draft information

--- a/spec/pubid/ieee/default_draft_version_spec.rb
+++ b/spec/pubid/ieee/default_draft_version_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "IEEE default draft version — issue #205" do
+  describe "Draft type without explicit version" do
+    it "appends /D1 to 'IEEE Unapproved Draft Std 802.3'" do
+      parsed = Pubid::Ieee.parse("IEEE Unapproved Draft Std 802.3")
+      expect(parsed.to_s).to eq("IEEE Unapproved Draft Std 802.3/D1")
+    end
+
+    it "appends /D1 to 'IEEE Draft Std 802.3'" do
+      parsed = Pubid::Ieee.parse("IEEE Draft Std 802.3")
+      expect(parsed.to_s).to eq("IEEE Draft Std 802.3/D1")
+    end
+
+    it "preserves the year as part of the draft suffix" do
+      parsed = Pubid::Ieee.parse("IEEE Unapproved Draft Std 802.3-2018")
+      expect(parsed.to_s).to include("/D1")
+      expect(parsed.to_s).to include("2018")
+    end
+  end
+
+  describe "non-Draft types are unaffected" do
+    it "leaves 'IEEE Std 802.3' without a draft suffix" do
+      parsed = Pubid::Ieee.parse("IEEE Std 802.3")
+      expect(parsed.to_s).to eq("IEEE Std 802.3")
+    end
+  end
+
+  describe "explicit draft versions are preserved" do
+    it "keeps /D2 when present" do
+      parsed = Pubid::Ieee.parse("IEEE Unapproved Draft Std 802.3/D2")
+      expect(parsed.draft_obj.version).to eq("2")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When an IEEE identifier has `Draft` in its type but no explicit draft version, the builder now defaults the draft attribute to `D1` so the rendered output reflects that the document is a draft.

## Problem

Per #205, `IEEE Unapproved Draft Std 16326:2009` (and similar forms) parsed without any draft version captured — the rendered output dropped the draft indicator entirely. Real-world IEEE drafts always have at least version 1, so the missing suffix is a source-data omission rather than an undrafted document.

## Implementation

- New `apply_default_draft_version(attributes, type_value)` helper in the builder, called after `handle_draft` in the build pipeline. Returns early when an explicit draft is already set or the type isn't `Draft Std`.
- Sets `attributes[:draft] = "D1"` and `attributes[:draft_obj] = Components::Draft.new(version: "1", year: <id year if any>)`.
- The year is carried into the draft object so the renderer doesn't drop it — the renderer's `-YYYY` suffix is suppressed when a draft is attached (it expects the year to live inside `/D...`), so we honor that contract.

## Examples

```ruby
Pubid::Ieee.parse("IEEE Unapproved Draft Std 802.3").to_s
# => "IEEE Unapproved Draft Std 802.3/D1"

Pubid::Ieee.parse("IEEE Draft Std 802.3").to_s
# => "IEEE Draft Std 802.3/D1"

Pubid::Ieee.parse("IEEE Std 802.3").to_s
# => "IEEE Std 802.3" (unchanged — not a Draft)

Pubid::Ieee.parse("IEEE Unapproved Draft Std 802.3/D2").draft_obj.version
# => "2" (explicit version preserved)
```

## Test plan

- [x] New `spec/pubid/ieee/default_draft_version_spec.rb`: 5 examples covering Draft-without-version, year preservation, non-Draft regression, and explicit-version preservation.
- [x] Full IEEE suite: 181 examples, 0 failures.

Closes #205.
