### PR TITLE
fix(ieee): correct rendering of co-published identifiers

### DIFF
--- a/lib/pubid/ieee/renderer.rb
+++ b/lib/pubid/ieee/renderer.rb
@@ -138,7 +138,7 @@ module Pubid
           result += ", #{id.month}"
           result += " #{id.day}" if id.day
           if id.year && !id.edition
-            result += ", #{id.year}"
+            result += " #{id.year}"
           end
         end
 
@@ -294,7 +294,16 @@ module Pubid
         end
 
         # Relationships (if present)
-        result = parts.join(" ")
+        # Join parts with spaces, but don't insert a space before parts
+        # that start with "-" or "," (e.g., "-2010", ", July 2014") so the
+        # SI form renders as "SI 10-2010" not "SI 10 -2010".
+        result = parts.each_with_object([]) do |part, acc|
+          if acc.empty? || part.to_s.start_with?("-", ",")
+            acc << part.to_s
+          else
+            acc << " " << part.to_s
+          end
+        end.join
         if id.relationships && !id.relationships.empty?
           rel_strs = id.relationships.map(&:to_s)
           result += " (#{rel_strs.join(' / ')})"

--- a/spec/pubid/ieee/copublished_rendering_spec.rb
+++ b/spec/pubid/ieee/copublished_rendering_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "IEEE co-published PubIDs — issue #224" do
+  # Many PubIDs are co-published — different orgs share the same standard
+  # number. The parser already accepts these; this spec locks in the
+  # corrected rendering (no extra space before "-YYYY", no extra comma
+  # between month and year on the identifier-level date).
+
+  describe "IEEE/ASTM SI" do
+    it "renders without extra space before year" do
+      parsed = Pubid::Ieee.parse("IEEE/ASTM SI 10-2010")
+      expect(parsed.to_s).to eq("IEEE/ASTM SI 10-2010")
+    end
+
+    it "tolerates a stray space after the slash" do
+      parsed = Pubid::Ieee.parse("IEEE/ ASTM SI 10-2010")
+      expect(parsed.to_s).to eq("IEEE/ASTM SI 10-2010")
+    end
+  end
+
+  describe "IEEE/ANSI" do
+    it "parses and round-trips" do
+      parsed = Pubid::Ieee.parse("IEEE/ANSI Std 24-1984")
+      expect(parsed.to_s).to eq("IEEE/ANSI Std 24-1984")
+    end
+  end
+
+  describe "IEEE/IEC co-published with month-year date" do
+    it "renders 'July 2014' without an extra comma" do
+      parsed = Pubid::Ieee.parse("IEEE/IEC P60076-57-1202, July 2014")
+      expect(parsed.to_s).to eq("IEEE/IEC Std P60076-57-1202, July 2014")
+    end
+  end
+
+  describe "regression: month-year date on a plain IEEE Std" do
+    it "still renders correctly" do
+      parsed = Pubid::Ieee.parse("IEEE Std 802.3, June 2018")
+      expect(parsed.to_s).to eq("IEEE Std 802.3, June 2018")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two rendering fixes for IEEE co-published identifiers (the parser already accepted these forms — issue #224 was about parse coverage, but the output had quality bugs).

## Problems

```ruby
Pubid::Ieee.parse("IEEE/ASTM SI 10-2010").to_s
# => "IEEE/ASTM SI 10 -2010"  (extra space before "-2010")

Pubid::Ieee.parse("IEEE/IEC P60076-57-1202, July 2014").to_s
# => "IEEE/IEC Std P60076-57-1202, July, 2014"  (extra comma before year)
```

## Fixes

1. **SI standard renderer** joined parts with `" "` unconditionally, producing `SI 10 -2010`. Replaced with a smarter join that doesn't insert a space before parts starting with `-` or `,`.
2. **Identifier-level month-year date** used `, #{year}` after the month, producing `July, 2014`. Real IEEE convention is `July 2014` (just space). Changed to ` #{year}`.

## Out of scope

The draft-level date rendering (e.g., `/D5, January, 2022`) still uses the existing heuristic (full month → comma before year). Real-world IEEE fixtures use both `January, 2022` and `January 2022` conventions inconsistently, so changing the draft-level logic needs more analysis. This PR only touches the identifier-level date format.

## Test plan

- [x] New `spec/pubid/ieee/copublished_rendering_spec.rb`: 5 examples covering IEEE/ASTM SI (with and without stray space), IEEE/ANSI, IEEE/IEC with month-year, and a plain-Std regression.
- [x] Full IEEE suite: 181 examples, 0 failures.

Closes #224.
