### PR TITLE
fix(ieee): parse IEC-led dual form with colon-year on IEC number

### DIFF
--- a/lib/pubid/ieee/parser.rb
+++ b/lib/pubid/ieee/parser.rb
@@ -865,10 +865,21 @@ module Pubid
         # NEW: Convert IEC/IEEE space-separated to semicolon format
         # Pattern: "IEC 61523-3 First edition 2004-09; IEEE 1497" → already semicolon
         # Pattern: "IEC 62539 First Edition 2007-07 IEEE 930" → needs semicolon
-        # Match: IEC identifier (with edition) + space + IEEE identifier
-        # Be conservative: only convert if IEC has "First edition" or similar and followed by IEEE
+        # Pattern: "IEC 60076-21:2011 Edition 1.0 2011-12 IEEE Std C57.15" → needs semicolon (issue #202)
+        # Match: IEC identifier (with optional colon-year, optional "First"/numeric
+        # Edition + YYYY-MM) + space + IEEE identifier.
         cleaned = cleaned.gsub(
-          /(IEC\s+\d+(?:-\d+)?(?:\s+First?\s+Edition\s+\d{4}-\d{2})?)\s+(IEEE\s+\S+)/, '\1; \2'
+          /(IEC\s+\d+(?:-\d+)?(?::\d{4})?(?:\s+(?:First\s+)?[Ee]dition\s+\d+(?:\.\d+)?\s+\d{4}-\d{2})?)\s+(IEEE\s+Std\s+\S+|IEEE\s+\S+)/,
+          '\1; \2'
+        )
+
+        # Strip ":YYYY" from IEC numbers when an Edition clause follows — the
+        # IEEE parser's number rule doesn't accept the colon-year form, but
+        # the year is preserved in the "Edition N.M YYYY-MM" suffix.
+        # (issue #202)
+        cleaned = cleaned.gsub(
+          /^(IEC\s+\d+(?:-\d+)?):\d{4}(\s+(?:First\s+)?[Ee]dition\s+\d+(?:\.\d+)?\s+\d{4}-\d{2})/,
+          '\1\2'
         )
 
         # NEW Phase 1 (Session 141): Remove literal trademark symbol

--- a/spec/pubid/ieee/iec_led_dual_form_spec.rb
+++ b/spec/pubid/ieee/iec_led_dual_form_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "IEC-led dual-form identifier — issue #202" do
+  # The form
+  #   IEC 60076-21:2011 Edition 1.0 2011-12 IEEE Std C57.15
+  # is an IEC-led dual publication (IEC is lead, IEEE is co-publisher).
+  # The IEEE parser's IEC-led branch accepts "Edition N.M YYYY-MM" but
+  # not when the IEC number carries a colon-year suffix (":YYYY"). The
+  # pre-parser now strips the redundant ":YYYY" — the year is preserved
+  # in the Edition clause — so the existing dual-form parser handles it.
+
+  it "parses 'IEC 60076-21:2011 Edition 1.0 2011-12 IEEE Std C57.15'" do
+    parsed = Pubid::Ieee.parse(
+      "IEC 60076-21:2011 Edition 1.0 2011-12 IEEE Std C57.15",
+    )
+    expect(parsed.to_s)
+      .to eq("IEC 60076-21 Edition 1.0 2011-12 and IEEE Std C57.15")
+  end
+
+  it "preserves the edition month and year" do
+    parsed = Pubid::Ieee.parse(
+      "IEC 60076-21:2011 Edition 1.0 2011-12 IEEE Std C57.15",
+    )
+    expect(parsed.to_s).to include("Edition 1.0 2011-12")
+  end
+
+  describe "regression checks" do
+    it "still parses the bare IEC Edition form (no colon-year)" do
+      parsed = Pubid::Ieee.parse("IEC 61671-2 Edition 1.0 2016-04")
+      expect(parsed.to_s).to eq("IEC 61671-2 Edition 1.0 2016-04")
+    end
+
+    it "still parses the paren-wrapped IEEE co-published form" do
+      parsed = Pubid::Ieee.parse(
+        "IEC 61523-4 Edition 1.0 2015-03 (IEEE Std 1801-2013)",
+      )
+      expect(parsed.to_s)
+        .to eq("IEC 61523-4 Edition 1.0 2015-03 (IEEE Std 1801-2013)")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds parser support for the IEC-led dual-form identifier

```
IEC 60076-21:2011 Edition 1.0 2011-12 IEEE Std C57.15
```

by stripping the redundant colon-year (`:2011`) from the IEC number when an Edition clause follows. The year is preserved in the Edition clause's `YYYY-MM`.

## Problem

Per #202, this form failed to parse. The IEEE parser's IEC-led branch accepts `Edition N.M YYYY-MM` but rejects the IEC colon-year suffix on the IEC number — the existing number rule doesn't accept `:`.

## Fix

A new pre-parser rule strips `:YYYY` from `IEC XXXX-YY:YYYY Edition N.M YYYY-MM` when the Edition clause follows. The year is preserved in the Edition's date, so no information is lost. The dual-form parser then handles the result via the existing semicolon-splitter.

## Examples

```ruby
Pubid::Ieee.parse("IEC 60076-21:2011 Edition 1.0 2011-12 IEEE Std C57.15").to_s
# => "IEC 60076-21 Edition 1.0 2011-12 and IEEE Std C57.15"
```

## Out of scope

The user's preferred output in the issue body was `IEC 60076-21:2011 ED1.0, December 2011 (IEEE C57.15)` — that exact spelling would require parser/renderer changes (preserve `:YEAR` on IEC number, abbreviate "Edition" to "ED", render the IEEE half parenthetically). My output is round-trip parseable and preserves all the input data; the cosmetic differences are noted as future work.

## Test plan

- [x] New `spec/pubid/ieee/iec_led_dual_form_spec.rb`: 4 examples covering the target form, edition-month preservation, and regression checks for the bare-Edition and parenthesized-IEEE forms.
- [x] Full IEEE suite: 191 examples, 0 failures.

Closes #202.
