### PR TITLE
fix(ieee): normalize "IEEE Unapproved Draft Std P15289, 06" via update_codes

### DIFF
--- a/data/ieee/update_codes.yaml
+++ b/data/ieee/update_codes.yaml
@@ -1,4 +1,9 @@
 IEEE Unapproved Draft Std PC37.110/D911Oct 07: IEEE Unapproved Draft Std PC37.110/D711, Oct 07
+# Issue #206: "IEEE Unapproved Draft Std P15289, 06" — the ", 06" suffix
+# has no clear meaning in IEEE's own grammar. Treating it as a draft
+# iteration number (D6) gives a parseable form. Conservative targeted
+# normalization rather than a general rule; revisit if more cases surface.
+IEEE Unapproved Draft Std P15289, 06: IEEE Unapproved Draft Std P15289/D6
 IEEE C57.139/D14June 2010: IEEE C57.139/D14, June 2010
 IEEE P1653.5/D7d1 November, 2019: IEEE P1653.5/D7.1 November, 2019
 IEEE P1017/D062012: P1017/D062012, Jun 2012

--- a/spec/pubid/ieee/p15289_comma_form_spec.rb
+++ b/spec/pubid/ieee/p15289_comma_form_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "IEEE P15289 comma-form draft — issue #206" do
+  it "normalizes 'IEEE Unapproved Draft Std P15289, 06' to a parseable form" do
+    parsed = Pubid::Ieee.parse("IEEE Unapproved Draft Std P15289, 06")
+    expect(parsed).to be_a(Pubid::Ieee::Identifier)
+    expect(parsed.to_s).to include("/D6")
+  end
+end


### PR DESCRIPTION
## Summary

Targeted one-line normalization in `data/ieee/update_codes.yaml` makes `IEEE Unapproved Draft Std P15289, 06` parseable.

## Problem

Per #206, the identifier failed to parse and @ronaldtse was asked to clarify what `, 06` means — no answer yet.

## Fix

Add a targeted update_codes entry:

```yaml
IEEE Unapproved Draft Std P15289, 06: IEEE Unapproved Draft Std P15289/D6
```

Treating `, 06` as a draft iteration number (D6) is the most common suffix shape in IEEE draft identifiers and yields a parseable canonical form. This is conservative: a single targeted entry rather than a general parser rule, so when @ronaldtse clarifies the meaning, the entry can be swapped for the correct general interpretation.

## Test plan

- [x] New `spec/pubid/ieee/p15289_comma_form_spec.rb`: 1 spec verifying the form parses and the output contains `/D6`.
- [x] Full IEEE suite: 196 examples, 0 failures.

Closes #206.
