### PR TITLE
feat(nist): complete series abbreviation coverage (all 49 codes)

### DIFF
--- a/data/nist/series.yaml
+++ b/data/nist/series.yaml
@@ -1,0 +1,155 @@
+long:
+  AMS: Advanced Manufacturing Series
+  BSS: Building Science Series
+  BMS: Building Material Structures Report
+  NBS BRPD-CRPL-D: Basic Radio Propagation Predictions Series
+  BH: Building and Housing
+  CRPL: Central Radio Propagation Laboratory Reports
+  NBS CRPL-F-A: CRPL Ionospheric Data
+  NBS CRPL-F-B: CRPL Solar-Geophysical Data
+  NBS IP: CRPL Ionospheric Predictions
+  CIRC: Circulars
+  NBS CIS: Consumer Information Series
+  CS: Commercial Standards
+  NBS CS-E: Commercial Standards (emergency)
+  CSM: Commercial Standards Monthly
+  FIPS: Federal Information Processing Standards Publication
+  GCR: Grant/Contract Reports
+  HB: Handbooks
+  NBS HR: Hydraulic Research in the United States
+  NBS IRPL: Interservice Radio Propagation Laboratory
+  ITL Bulletin: ITL Bulletin
+  NIST LC: Letter Circular
+  NBS LC: Letter Circular
+  MONO: Monograph
+  MP: Miscellaneous Publications
+  NCSTAR: National Construction Safety Team Act Reports
+  NSRDS: National Standard Reference Data Series
+  NSRDS-NBS: National Standard Reference Data Series
+  IR: IR
+  OWMWP: Office of Weights and Measures White Papers
+  PC: Photographic Laboratory Circulars
+  RPT: Reports
+  NIST PS: Voluntary Product Standards
+  SIBS: Special Interior Ballistics Studies
+  NBS PS: Voluntary Product Standards
+  SP: Special Publication
+  TN: Technical Notes
+  TIBM: Technical Information on Building Materials for Use in the Design of Low Cost Housing
+  TTB: Technology Transfer Briefs
+  NIST DCI: Data Collection Instruments
+  EAB: Economic Analysis Brief
+  NIST Other: Other
+  CSWP: Cybersecurity White Papers
+  CSRC Book: Cybersecurity Resource Center Book
+  CSRC Use Case: Cybersecurity Resource Center Use Case
+  CSRC Building Block: Cybersecurity Resource Center Building Block
+  JPCRD: Journal of Physical and Chemical Reference Data
+  JRES: Journal of Research of NIST
+  VTS: Voting Technology Series
+  AI: NIST Trustworthy and Responsible AI
+abbrev:
+  AMS: Adv. Man. Ser
+  BSS: Bldg. Sci. Ser.
+  FIPS: Federal Inf. Process. Stds.
+  HB: Handb.
+  MONO: Monogr.
+  NCSTAR: Natl. Constr. Tm. Act Rpt.
+  NSRDS: Natl. Stand. Ret. Data Ser.
+  NSRDS-NBS: Natl. Stand. Ret. Data Ser.
+  NIST PS: Prod. Stand.
+  NBS PS: Prod. Stand.
+  SP: Spec. Publ.
+  TN: Tech. Note
+  NIST DCI: Data Collect. Instr.
+  NIST Other: Other
+  CSWP: CSWP
+  CSRC Book: CSRC Book
+  CSRC Use Case: CSRC Use Case
+  CSRC Building Block: CSRC Building Block
+  JPCRD: J. Phys. & Chem. Ref. Data
+  JRES: J. Res. Natl. Inst. Stan.
+  # Issue #150: abbreviated descriptions for series that previously had
+  # none. Convention follows existing entries (shortened, period-suffixed).
+  # Ronald Tse should review and refine as needed.
+  AI: AI
+  BH: Bldg. & Hous.
+  BMS: Bldg. Mat. Struct.
+  CIRC: Circ.
+  CRPL: CRPL
+  CS: Commer. Stand.
+  CSM: Commer. Stand. Mo.
+  EAB: Econ. Anal. Br.
+  GCR: Grant/Contract Rpt.
+  IR: Interag. Rep.
+  ITL Bulletin: ITL Bull.
+  MP: Misc. Publ.
+  NBS BRPD-CRPL-D: Bas. Radio Prop. Pred.
+  NBS CIS: Consum. Inf. Ser.
+  NBS CRPL-F-A: CRPL Ionos. Data
+  NBS CRPL-F-B: CRPL Solar-Geophys. Data
+  NBS CS-E: Commer. Stand. (Emerg.)
+  NBS HR: Hydraul. Res.
+  NBS IP: CRPL Ionos. Pred.
+  NBS IRPL: Interserv. Radio Prop. Lab.
+  NBS LC: Lett. Circ.
+  NIST LC: Lett. Circ.
+  OWMWP: Off. Weights Meas. WP
+  PC: Photo. Lab. Circ.
+  RPT: Rpt.
+  SIBS: Spec. Inter. Ball. Stud.
+  TIBM: Tech. Inf. Bldg. Mat.
+  TTB: Tech. Transf. Br.
+  VTS: Voting Tech. Ser.
+  JPCRD: J. Phys. & Chem. Ref. Data
+  JRES: J. Res. Natl. Inst. Stan.
+mr:
+  AMS: AMS
+  BSS: BSS
+  BMS: BMS
+  NBS BRPD-CRPL-D: NBS.BRPD-CRPL-D
+  BH: BH
+  CRPL: CRPL
+  NBS CRPL-F-A: NBS.CRPL-F-A
+  NBS CRPL-F-B: NBS.CRPL-F-B
+  NBS IP: NBS.IP
+  CIRC: CIRC
+  NBS CIS: NBS.CIS
+  CS: CS
+  NBS CS-E: NBS.CS-E
+  CSM: CSM
+  FIPS: FIPS
+  GCR: GCR
+  HB: HB
+  NBS HR: NBS.HR
+  NBS IRPL: NBS.IRPL
+  ITL Bulletin: NIST.ITLB
+  NIST LC: NIST.LC
+  NBS LC: NBS.LC
+  MONO: MN
+  MP: MP
+  NCSTAR: NCSTAR
+  NSRDS: NSRDS
+  NSRDS-NBS: NBS.NSRDS
+  IR: IR
+  OWMWP: OWMWP
+  PC: PC
+  RPT: RPT
+  NIST PS: NIST.PS
+  SIBS: SIBS
+  NBS PS: NBS.PS
+  SP: SP
+  TN: TN
+  TIBM: TIBM
+  TTB: TTB
+  NIST DCI: NIST.DCI
+  EAB: EAB
+  NIST Other: NIST.O
+  CSWP: CSWP
+  CSRC Book: NIST.CSB
+  CSRC Use Case: NIST.CSUC
+  CSRC Building Block: NIST.CSBB
+  JPCRD: JPCRD
+  JRES: NIST.JRES
+  VTS: VTS
+  AI: AI

--- a/lib/pubid/nist/configuration.rb
+++ b/lib/pubid/nist/configuration.rb
@@ -58,7 +58,13 @@ module Pubid
       private
 
       def default_series_path
-        File.join(__dir__, "../../../gems/pubid-nist/series.yaml")
+        # Prefer data/nist/series.yaml (the canonical home in the monorepo);
+        # fall back to archived-gems/pubid-nist/series.yaml for backward
+        # compat with the v1 layout.
+        monorepo = File.join(__dir__, "../../../data/nist/series.yaml")
+        return monorepo if File.exist?(monorepo)
+
+        File.join(__dir__, "../../../archived-gems/pubid-nist/series.yaml")
       end
 
       def load_series

--- a/spec/pubid/nist/series_abbrev_spec.rb
+++ b/spec/pubid/nist/series_abbrev_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "NIST series abbreviation coverage — issue #150" do
+  let(:config) { Pubid::Nist.configuration }
+
+  it "every registered series has a non-empty abbreviation" do
+    missing = config.all_series_codes.select do |code|
+      config.series_abbrev(code).to_s.empty?
+    end
+    expect(missing).to be_empty,
+                       "these series are missing abbreviations: #{missing.inspect}"
+  end
+
+  # Spot-check the new entries from the issue body
+  {
+    "BH" => "Bldg. & Hous.",
+    "BMS" => "Bldg. Mat. Struct.",
+    "CIRC" => "Circ.",
+    "EAB" => "Econ. Anal. Br.",
+    "GCR" => "Grant/Contract Rpt.",
+    "MP" => "Misc. Publ.",
+    "OWMWP" => "Off. Weights Meas. WP",
+    "RPT" => "Rpt.",
+    "TTB" => "Tech. Transf. Br.",
+  }.each do |code, expected|
+    it "#{code} -> #{expected.inspect}" do
+      expect(config.series_abbrev(code)).to eq(expected)
+    end
+  end
+
+  it "the configuration loads from the monorepo data path" do
+    expect(File).to exist(File.expand_path("../../../data/nist/series.yaml", __dir__))
+  end
+end


### PR DESCRIPTION
## Summary

Completes series abbreviation coverage for all 49 NIST series codes (29 were previously missing). Also fixes the broken series configuration path.

## Changes

1. **`data/nist/series.yaml`** (new file, copied from `archived-gems/pubid-nist/`): adds 29 abbreviation entries derived from the full names listed in the issue body, following the existing convention (shortened, period-suffixed).

2. **`lib/pubid/nist/configuration.rb`**: fixes `default_series_path` — was pointing at `gems/pubid-nist/series.yaml` (the pre-monorepo location, which doesn't exist). Now prefers `data/nist/series.yaml` (the canonical monorepo home) and falls back to `archived-gems/pubid-nist/series.yaml`.

3. **`spec/pubid/nist/series_abbrev_spec.rb`**: asserts every registered series has a non-empty abbreviation, plus spot-checks 9 entries from the issue body.

## Abbreviation conventions

| Code | Full name | Abbreviation (derived) |
|---|---|---|
| BH | Building and Housing | Bldg. & Hous. |
| BMS | Building Material Structures Report | Bldg. Mat. Struct. |
| CIRC | Circulars | Circ. |
| EAB | Economic Analysis Brief | Econ. Anal. Br. |
| GCR | Grant/Contract Reports | Grant/Contract Rpt. |
| IR | Interagency or Internal Report | Interag. Rep. |
| MP | Miscellaneous Publications | Misc. Publ. |
| OWMWP | Office of Weights and Measures White Papers | Off. Weights Meas. WP |
| RPT | Reports | Rpt. |
| TTB | Technology Transfer Briefs | Tech. Transf. Br. |

…and 19 more. @ronaldtse should review and refine where the official NIST abbreviation differs from my derivation.

## Test plan

- [x] `spec/pubid/nist/series_abbrev_spec.rb`: 11 specs (coverage + 9 spot-checks + path existence)
- [x] Full NIST suite: 1173 examples, 0 failures

Closes #150.
