### PR TITLE
feat(cen_cenelec): register all CEN PROJEX stage codes

### DIFF
--- a/lib/pubid/cen_cenelec.rb
+++ b/lib/pubid/cen_cenelec.rb
@@ -21,118 +21,122 @@ module Pubid
     autoload :UrnParser, "#{__dir__}/cen_cenelec/urn_parser"
 
     # TYPED_STAGES_REGISTRY for native CEN types
+    # Covers the CEN PROJEX stage-code table per issue #251.
     TYPED_STAGES_REGISTRY = [
-      # European Norm (EN)
+      # === European Norm (EN) lifecycle ===
+      # Preliminary (pWI EN): proposal/WI stages
       Pubid::Components::TypedStage.new(
-        code: :puben,
-        stage_code: :published,
-        type_code: :en,
-        abbr: ["EN"],
-        name: "European Norm",
+        code: :pwien, stage_code: :preliminary, type_code: :en,
+        abbr: ["pWI EN"], name: "Preliminary Work Item EN",
+        harmonized_stages: %w[00.60 10.98 10.99 20.60],
+      ),
+      # Proposal (prEN): working draft stages
+      Pubid::Components::TypedStage.new(
+        code: :pren, stage_code: :proposal, type_code: :en,
+        abbr: ["prEN"], name: "Proposal European Norm",
+        harmonized_stages: %w[30.00 30.20 30.60 30.92 30.97 30.98 30.99],
+      ),
+      # Final Proposal (FprEN): enquiry stages
+      Pubid::Components::TypedStage.new(
+        code: :fpren, stage_code: :final_proposal, type_code: :en,
+        abbr: ["FprEN"], name: "Final Proposal European Norm",
+        harmonized_stages: %w[40.00 40.20 40.60 40.92 40.97 40.98 40.99],
+      ),
+      # Formal Vote (FV prEN): COCOR + FV dispatch
+      Pubid::Components::TypedStage.new(
+        code: :fven, stage_code: :formal_vote, type_code: :en,
+        abbr: ["FV prEN"], name: "Formal Vote EN",
+        harmonized_stages: %w[43.20 43.60 43.97 43.98 45.97 45.98 45.99],
+      ),
+      # Vote (vEN): enquiry/vote
+      Pubid::Components::TypedStage.new(
+        code: :ven, stage_code: :vote, type_code: :en,
+        abbr: ["vEN"], name: "Vote EN",
+        harmonized_stages: %w[50.20 50.60 50.97 50.98],
+      ),
+      # Published (EN): ratification + publication milestones
+      Pubid::Components::TypedStage.new(
+        code: :puben, stage_code: :published, type_code: :en,
+        abbr: ["EN"], name: "European Norm",
+        harmonized_stages: %w[60.00 60.55 60.60 65.31 65.51 65.62],
+      ),
+      # Review (rvEN): 2-year review
+      Pubid::Components::TypedStage.new(
+        code: :rven, stage_code: :review, type_code: :en,
+        abbr: ["rvEN"], name: "Review EN",
+        harmonized_stages: %w[90.00 90.20 90.60 90.92 90.93 90.98],
+      ),
+      # Reactivation (racEN)
+      Pubid::Components::TypedStage.new(
+        code: :racen, stage_code: :reactivation, type_code: :en,
+        abbr: ["racEN"], name: "Re-activated EN",
+        harmonized_stages: %w[96.60],
+      ),
+      # Withdrawn (wdEN)
+      Pubid::Components::TypedStage.new(
+        code: :wden, stage_code: :withdrawn, type_code: :en,
+        abbr: ["wdEN"], name: "Withdrawn EN",
+        harmonized_stages: %w[99.60],
+      ),
+
+      # === Technical Specification (TS) ===
+      Pubid::Components::TypedStage.new(
+        code: :pubts, stage_code: :published, type_code: :ts,
+        abbr: ["TS"], name: "Technical Specification",
         harmonized_stages: %w[60.00 60.60],
       ),
       Pubid::Components::TypedStage.new(
-        code: :pren,
-        stage_code: :proposal,
-        type_code: :en,
-        abbr: ["prEN"],
-        name: "Proposal European Norm",
+        code: :prts, stage_code: :proposal, type_code: :ts,
+        abbr: ["prTS"], name: "Proposal Technical Specification",
         harmonized_stages: %w[30.00 30.20 30.60 30.92 30.98 30.99],
       ),
-      Pubid::Components::TypedStage.new(
-        code: :fpren,
-        stage_code: :final_proposal,
-        type_code: :en,
-        abbr: ["FprEN"],
-        name: "Final Proposal European Norm",
-        harmonized_stages: %w[40.00 40.20 40.60 40.92 40.98 40.99],
-      ),
 
-      # Technical Specification (TS)
+      # === Technical Report (TR) ===
       Pubid::Components::TypedStage.new(
-        code: :pubts,
-        stage_code: :published,
-        type_code: :ts,
-        abbr: ["TS"],
-        name: "Technical Specification",
-        harmonized_stages: %w[60.00 60.60],
-      ),
-      Pubid::Components::TypedStage.new(
-        code: :prts,
-        stage_code: :proposal,
-        type_code: :ts,
-        abbr: ["prTS"],
-        name: "Proposal Technical Specification",
-        harmonized_stages: %w[30.00 30.20 30.60 30.92 30.98 30.99],
-      ),
-
-      # Technical Report (TR)
-      Pubid::Components::TypedStage.new(
-        code: :pubtr,
-        stage_code: :published,
-        type_code: :tr,
-        abbr: ["TR"],
-        name: "Technical Report",
+        code: :pubtr, stage_code: :published, type_code: :tr,
+        abbr: ["TR"], name: "Technical Report",
         harmonized_stages: %w[60.00 60.60],
       ),
 
-      # CEN Workshop Agreement (CWA)
+      # === CEN Workshop Agreement (CWA) ===
       Pubid::Components::TypedStage.new(
-        code: :pubcwa,
-        stage_code: :published,
-        type_code: :cwa,
-        abbr: ["CWA"],
-        name: "CEN Workshop Agreement",
+        code: :pubcwa, stage_code: :published, type_code: :cwa,
+        abbr: ["CWA"], name: "CEN Workshop Agreement",
         harmonized_stages: %w[60.00 60.60],
       ),
 
-      # Guide
+      # === Guide ===
       Pubid::Components::TypedStage.new(
-        code: :pubguide,
-        stage_code: :published,
-        type_code: :guide,
-        abbr: ["Guide"],
-        name: "Guide",
+        code: :pubguide, stage_code: :published, type_code: :guide,
+        abbr: ["Guide"], name: "Guide",
         harmonized_stages: %w[60.00 60.60],
       ),
 
-      # Harmonization Document (HD)
+      # === Harmonization Document (HD) ===
       Pubid::Components::TypedStage.new(
-        code: :pubhd,
-        stage_code: :published,
-        type_code: :hd,
-        abbr: ["HD"],
-        name: "Harmonization Document",
+        code: :pubhd, stage_code: :published, type_code: :hd,
+        abbr: ["HD"], name: "Harmonization Document",
         harmonized_stages: %w[60.00 60.60],
       ),
 
-      # European Specification (ES)
+      # === European Specification (ES) ===
       Pubid::Components::TypedStage.new(
-        code: :pubes,
-        stage_code: :published,
-        type_code: :es,
-        abbr: ["ES"],
-        name: "European Specification",
+        code: :pubes, stage_code: :published, type_code: :es,
+        abbr: ["ES"], name: "European Specification",
         harmonized_stages: %w[60.00 60.60],
       ),
 
-      # CEN Report (CR)
+      # === CEN Report (CR) ===
       Pubid::Components::TypedStage.new(
-        code: :pubcr,
-        stage_code: :published,
-        type_code: :cr,
-        abbr: ["CR"],
-        name: "CEN Report",
+        code: :pubcr, stage_code: :published, type_code: :cr,
+        abbr: ["CR"], name: "CEN Report",
         harmonized_stages: %w[60.00 60.60],
       ),
 
-      # European Prestandard (ENV)
+      # === European Prestandard (ENV) ===
       Pubid::Components::TypedStage.new(
-        code: :pubenv,
-        stage_code: :published,
-        type_code: :env,
-        abbr: ["ENV"],
-        name: "European Prestandard",
+        code: :pubenv, stage_code: :published, type_code: :env,
+        abbr: ["ENV"], name: "European Prestandard",
         harmonized_stages: %w[60.00 60.60],
       ),
     ].freeze

--- a/lib/pubid/cen_cenelec/identifiers/european_norm.rb
+++ b/lib/pubid/cen_cenelec/identifiers/european_norm.rb
@@ -6,29 +6,86 @@ module Pubid
       # European Norm (EN) identifier
       class EuropeanNorm < SingleIdentifier
         TYPED_STAGES = [
+          # Published (puben): 60.00-60.60 + publication milestones (65.xx)
           Components::TypedStage.new(
             code: :puben,
             stage_code: :published,
             type_code: :en,
             abbr: ["EN"],
             name: "European Norm",
-            harmonized_stages: %w[60.00 60.60],
+            harmonized_stages: %w[60.00 60.55 60.60 65.31 65.51 65.62],
           ),
+          # Preliminary (pwien): proposal/WI stages
+          Components::TypedStage.new(
+            code: :pwien,
+            stage_code: :preliminary,
+            type_code: :en,
+            abbr: ["pWI EN"],
+            name: "Preliminary Work Item EN",
+            harmonized_stages: %w[00.60 10.98 10.99 20.60],
+          ),
+          # Proposal (pren): working draft stages + split/merge interruption end
           Components::TypedStage.new(
             code: :pren,
             stage_code: :proposal,
             type_code: :en,
             abbr: ["prEN"],
             name: "Proposal European Norm",
-            harmonized_stages: %w[30.00 30.20 30.60 30.92 30.98 30.99],
+            harmonized_stages: %w[30.00 30.20 30.60 30.92 30.97 30.98 30.99],
           ),
+          # Final Proposal (fpren): enquiry stages
           Components::TypedStage.new(
             code: :fpren,
             stage_code: :final_proposal,
             type_code: :en,
             abbr: ["FprEN"],
             name: "Final Proposal European Norm",
-            harmonized_stages: %w[40.00 40.20 40.60 40.92 40.98 40.99],
+            harmonized_stages: %w[40.00 40.20 40.60 40.92 40.97 40.98 40.99],
+          ),
+          # Formal Vote (fven): COCOR + FV dispatch stages
+          Components::TypedStage.new(
+            code: :fven,
+            stage_code: :formal_vote,
+            type_code: :en,
+            abbr: ["FV prEN"],
+            name: "Formal Vote EN",
+            harmonized_stages: %w[43.20 43.60 43.97 43.98 45.97 45.98 45.99],
+          ),
+          # Vote (ven): enquiry/vote stages
+          Components::TypedStage.new(
+            code: :ven,
+            stage_code: :vote,
+            type_code: :en,
+            abbr: ["vEN"],
+            name: "Vote EN",
+            harmonized_stages: %w[50.20 50.60 50.97 50.98],
+          ),
+          # Review (rven): 2-year review stages
+          Components::TypedStage.new(
+            code: :rven,
+            stage_code: :review,
+            type_code: :en,
+            abbr: ["rvEN"],
+            name: "Review EN",
+            harmonized_stages: %w[90.00 90.20 90.60 90.92 90.93 90.98],
+          ),
+          # Reactivation (racen): re-activation stage
+          Components::TypedStage.new(
+            code: :racen,
+            stage_code: :reactivation,
+            type_code: :en,
+            abbr: ["racEN"],
+            name: "Re-activated EN",
+            harmonized_stages: %w[96.60],
+          ),
+          # Withdrawn (wden): withdrawal stage
+          Components::TypedStage.new(
+            code: :wden,
+            stage_code: :withdrawn,
+            type_code: :en,
+            abbr: ["wdEN"],
+            name: "Withdrawn EN",
+            harmonized_stages: %w[99.60],
           ),
         ].freeze
 

--- a/spec/pubid/cen_cenelec/stage_codes_spec.rb
+++ b/spec/pubid/cen_cenelec/stage_codes_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "CEN/CENELEC stage codes — issue #251" do
+  let(:all_stages) { Pubid::CenCenelec.all_typed_stages }
+  let(:all_harmonized) { all_stages.flat_map(&:harmonized_stages).sort.uniq }
+
+  ISSUE_CODES = %w[
+    00.60 10.98 10.99 20.60 30.97 30.98 30.99
+    40.20 40.60 40.97 40.98 40.99
+    43.20 43.60 43.97 43.98 45.97 45.98 45.99
+    50.20 50.60 50.97 50.98
+    60.55 60.60 65.31 65.51 65.62
+    90.00 90.20 90.60 90.92 90.93 90.98 96.60 99.60
+  ].freeze
+
+  it "covers every stage code from the issue body" do
+    missing = ISSUE_CODES - all_harmonized
+    expect(missing).to be_empty,
+                           "these codes are not in any typed stage: #{missing.inspect}"
+  end
+
+  it "has the new typed stages (pwien, fven, ven, rven, racen, wden)" do
+    codes = all_stages.map(&:code).map(&:to_s)
+    %w[pwien fven ven rven racen wden].each do |code|
+      expect(codes).to include(code), "missing typed stage #{code}"
+    end
+  end
+
+  it "extends puben with 60.55 and 65.xx publication milestones" do
+    puben = all_stages.find { |s| s.code.to_s == "puben" }
+    expect(puben.harmonized_stages).to include("60.55", "65.31", "65.51", "65.62")
+  end
+
+  it "extends pren with 30.97 (split/merge)" do
+    pren = all_stages.find { |s| s.code.to_s == "pren" }
+    expect(pren.harmonized_stages).to include("30.97")
+  end
+end


### PR DESCRIPTION
## Summary

Extends `TYPED_STAGES_REGISTRY` in `lib/pubid/cen_cenelec.rb` to cover all 34 stage codes from the CEN PROJEX stage table. Closes #251.

## Stage-to-typed-stage mapping

| Phase | Typed stage | New? | Stage codes |
|---|---|---|---|
| Preliminary | pwien (pWI EN) | new | 00.60, 10.98, 10.99, 20.60 |
| Proposal | pren (prEN) | extended | 30.00-30.99 (+30.97) |
| Final Proposal | fpren (FprEN) | extended | 40.00-40.99 (+40.97) |
| Formal Vote | fven (FV prEN) | new | 43.20, 43.60, 43.97, 43.98, 45.97, 45.98, 45.99 |
| Vote | ven (vEN) | new | 50.20, 50.60, 50.97, 50.98 |
| Published | puben (EN) | extended | 60.00-65.62 (+60.55, 65.31-62) |
| Review | rven (rvEN) | new | 90.00-90.98 |
| Reactivation | racen (racEN) | new | 96.60 |
| Withdrawn | wden (wdEN) | new | 99.60 |

Six new typed stages + three extensions to existing stages. Also mirrors the changes in `european_norm.rb`'s per-class `TYPED_STAGES` array to keep the two registries consistent.

## Test plan

- [x] `spec/pubid/cen_cenelec/stage_codes_spec.rb`: 4 specs covering issue-code coverage, new typed stages, and extended stages
- [x] Full CEN/CENELEC suite: 106 examples, 0 failures

Closes #251.
