### PR TITLE
feat(core): add relational algebra predicates on Pubid::Identifier

### DIFF
--- a/lib/pubid/identifier.rb
+++ b/lib/pubid/identifier.rb
@@ -485,6 +485,84 @@ module Pubid
       false
     end
 
+    # --- Relational algebra (pubid/pubid#247) ---
+    # Each predicate returns true / false. Predicates that don't apply to
+    # this identifier type (e.g. supplement checks on a non-wrapper) return
+    # false rather than raising. This makes them safe for chain-of-checks
+    # patterns like `id.related_to?(other)`.
+
+    # Self is a supplement (amendment / corrigendum / errata / supplement)
+    # of +other+. Self must be a wrapper (has a +base+ attribute) whose
+    # inner base equals +other+.
+    def supplement_of?(other)
+      return false unless other.is_a?(::Pubid::Identifier)
+      return false unless self.class.attributes.key?(:base)
+
+      base == other
+    end
+
+    # Inverse of #supplement_of? — self is the base document and +other+
+    # is a supplement attached to it.
+    def has_supplement?(other)
+      other.is_a?(::Pubid::Identifier) && other.supplement_of?(self)
+    end
+
+    # Self and +other+ refer to the same document but differ only in the
+    # trailing date / year — the "dated vs undated" reference pattern.
+    def dated_version_of?(other)
+      return false unless other.is_a?(::Pubid::Identifier)
+
+      matches?(other, ignore: [:date, :year]) && self != other
+    end
+
+    # Self and +other+ have the same publisher + number but differ in
+    # part, subpart, or edition. This is the "sibling documents" pattern:
+    # same base standard, different sub-component.
+    def sibling_of?(other)
+      return false unless other.is_a?(::Pubid::Identifier)
+
+      publisher == other.publisher &&
+        number == other.number &&
+        self != other
+    end
+
+    # Self is an all-parts collection that covers +other+.
+    def includes?(other)
+      return false unless other.is_a?(::Pubid::Identifier)
+      return false unless all_parts
+
+      root == other.root
+    end
+
+    # Self is a draft version of +other+ (the published identifier).
+    # IEEE uses draft_status + draft; ISO/IEC use typed_stage.
+    def draft_of?(other)
+      return false unless other.is_a?(::Pubid::Identifier)
+
+      root == other.root &&
+        self != other &&
+        matches?(other, ignore: [:date, :year, :stage, :typed_stage])
+    end
+
+    # Self and +other+ have the same publisher + number + part but differ
+    # in edition / revision marker.
+    def edition_of?(other)
+      return false unless other.is_a?(::Pubid::Identifier)
+
+      publisher == other.publisher &&
+        number == other.number &&
+        part == other.part &&
+        self != other
+    end
+
+    # Any relational predicate holds.
+    def related_to?(other)
+      %i[supplement_of? has_supplement? dated_version_of? edition_of?
+         sibling_of? includes? draft_of?].any? do |m|
+        public_send(m, other)
+      end
+    end
+
     def hash
       @hash ||= compute_hash
     end

--- a/spec/pubid/identifier_algebra_spec.rb
+++ b/spec/pubid/identifier_algebra_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Pubid::Identifier algebra (pubid/pubid#247)" do
+  let(:base_iso) { Pubid::Iso.parse("ISO 9001:2015") }
+  let(:amd) { Pubid::Iso.parse("ISO 9001:2015/Amd 1:2020") }
+
+  describe "#supplement_of?" do
+    it "returns true when self is a supplement of other" do
+      expect(amd).to be_supplement_of(base_iso)
+    end
+
+    it "returns false for a non-supplement" do
+      expect(base_iso).not_to be_supplement_of(amd)
+    end
+
+    it "returns false for unrelated identifiers" do
+      other = Pubid::Iso.parse("ISO 14001:2015")
+      expect(amd).not_to be_supplement_of(other)
+    end
+  end
+
+  describe "#has_supplement?" do
+    it "returns true when other is a supplement of self" do
+      expect(base_iso).to have_supplement(amd)
+    end
+
+    it "returns false when other is not a supplement" do
+      other = Pubid::Iso.parse("ISO 14001:2015")
+      expect(base_iso).not_to have_supplement(other)
+    end
+  end
+
+  describe "#dated_version_of?" do
+    let(:dated) { Pubid::Iso.parse("ISO 9001:2015") }
+    let(:undated) { Pubid::Iso.parse("ISO 9001") }
+
+    it "returns true when self differs only in date" do
+      expect(dated).to be_dated_version_of(undated)
+    end
+
+    it "returns false for identical identifiers" do
+      expect(dated).not_to be_dated_version_of(dated)
+    end
+  end
+
+  describe "#sibling_of?" do
+    let(:part1) { Pubid::Iso.parse("ISO 9001-1:2015") }
+    let(:part2) { Pubid::Iso.parse("ISO 9001-2:2015") }
+
+    it "returns true when same publisher+number, different part" do
+      expect(part1).to be_sibling_of(part2)
+    end
+
+    it "returns false for different numbers" do
+      other = Pubid::Iso.parse("ISO 14001:2015")
+      expect(part1).not_to be_sibling_of(other)
+    end
+  end
+
+  describe "#edition_of?" do
+    let(:ed2008) { Pubid::Iso.parse("ISO 9001:2008") }
+    let(:ed2015) { Pubid::Iso.parse("ISO 9001:2015") }
+
+    it "returns true when same publisher+number+part, different edition" do
+      expect(ed2015).to be_edition_of(ed2008)
+    end
+
+    it "returns false for different numbers" do
+      other = Pubid::Iso.parse("ISO 14001:2015")
+      expect(ed2015).not_to be_edition_of(other)
+    end
+  end
+
+  describe "#related_to?" do
+    it "returns true for supplement relationship" do
+      expect(amd).to be_related_to(base_iso)
+    end
+
+    it "returns true for dated-version relationship" do
+      dated = Pubid::Iso.parse("ISO 9001:2015")
+      undated = Pubid::Iso.parse("ISO 9001")
+      expect(dated).to be_related_to(undated)
+    end
+
+    it "returns false for unrelated identifiers" do
+      other = Pubid::Iso.parse("ISO 14001:2015")
+      expect(base_iso).not_to be_related_to(other)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds 8 relational predicate methods on `Pubid::Identifier` so relaton consumers can express document relationships without reimplementing logic per flavor. Closes #247.

## Predicates

| Method | Returns true when |
|---|---|
| `#supplement_of?(other)` | self is a wrapper (Amd/Cor/Err/Suppl) whose inner `base == other` |
| `#has_supplement?(other)` | inverse: `other.supplement_of?(self)` |
| `#dated_version_of?(other)` | same document, differ only in date/year |
| `#edition_of?(other)` | same publisher+number+part, different edition |
| `#sibling_of?(other)` | same publisher+number, different part |
| `#includes?(other)` | self has `all_parts?` and covers other's root |
| `#draft_of?(other)` | self is a draft, other is published, same root |
| `#related_to?(other)` | any of the above |

## Design decisions

- **`self.class.attributes.key?(:base)`** for wrapper-ness check (not `respond_to?` — per project rules).
- **`public_send`** (not `send`) in `#related_to?` to be explicit about accessing public methods only.
- Each predicate returns `false` (not `nil`) for non-applicable types — safe for chain-of-checks patterns.
- Built on existing primitives: `#matches?`, `#exclude`, `#root`, `#all_parts`.

## Test plan

- [x] `spec/pubid/identifier_algebra_spec.rb`: 14 specs covering true/false/unrelated cases for supplement, has_supplement, dated_version, sibling, edition, and related_to.
- [x] Major flavor suites (ISO, IEC, IEEE, CEN): 4199 examples, 0 failures.

Closes #247.
