### PR TITLE
fix(ieee): drop "Std" from unapproved draft identifiers (#209)

### DIFF
--- a/lib/pubid/ieee/renderer.rb
+++ b/lib/pubid/ieee/renderer.rb
@@ -70,12 +70,18 @@ module Pubid
         # Draft status
         parts << id.draft_status if id.draft_status
 
-        # Type - only render for IEEE/AIEE publishers, and only for non-projects
+        # Type - only render for IEEE/AIEE publishers, and only for non-projects.
+        # An unapproved draft is not yet a standard, so per IEEE guidance the
+        # "Std" token is dropped from the type when draft_status is "Unapproved"
+        # (e.g. "Draft Std" -> "Draft", "Std" -> "").
         should_render_type = id.publisher&.match?(/^(IEEE|AIEE)/)
 
         if should_render_type && !id.typed_stage&.project_status && id.type && !id.type.to_s.strip.empty? && id.type != "P"
           type_str = id.type.dup
           type_str = type_str.sub(/^P/, "") if type_str.start_with?("P")
+          if id.draft_status.to_s.match?(/unapproved/i)
+            type_str = type_str.gsub(/\bStd\b/i, "").squeeze(" ").strip
+          end
           parts << type_str unless type_str.strip.empty?
         end
 

--- a/spec/pubid/ieee/default_draft_version_spec.rb
+++ b/spec/pubid/ieee/default_draft_version_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe "IEEE default draft version — issue #205" do
   describe "Draft type without explicit version" do
     it "appends /D1 to 'IEEE Unapproved Draft Std 802.3'" do
       parsed = Pubid::Ieee.parse("IEEE Unapproved Draft Std 802.3")
-      expect(parsed.to_s).to eq("IEEE Unapproved Draft Std 802.3/D1")
+      # Per IEEE guidance (issue #209), unapproved drafts are not yet standards,
+      # so the "Std" token is dropped from the rendered type.
+      expect(parsed.to_s).to eq("IEEE Unapproved Draft 802.3/D1")
     end
 
     it "appends /D1 to 'IEEE Draft Std 802.3'" do

--- a/spec/pubid/ieee/unapproved_draft_stds_spec.rb
+++ b/spec/pubid/ieee/unapproved_draft_stds_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "IEEE unapproved drafts must not render 'Std' — issue #209" do
+  # IEEE staff guidance: an "unapproved draft" is not yet a standard, so the
+  # "Std" token must not appear in the rendered identifier. "Draft" is kept;
+  # only the "Std" suffix on the type is stripped.
+  {
+    "IEEE Unapproved Draft Std 802.3" => "IEEE Unapproved Draft 802.3/D1",
+    "IEEE Unapproved Std 802.3" => "IEEE Unapproved 802.3",
+    "IEEE Unapproved Draft Std P802.3" => "IEEE Unapproved Draft P802.3/D1",
+  }.each do |input, expected|
+    it "renders #{input.inspect} as #{expected.inspect}" do
+      parsed = Pubid::Ieee.parse(input)
+      expect(parsed.to_s).to eq(expected)
+      expect(parsed.to_s).not_to match(/\bStd\b/)
+    end
+  end
+
+  it "drops 'Std' but keeps the year for dated unapproved drafts" do
+    parsed = Pubid::Ieee.parse("IEEE Unapproved Draft Std 802.3-2018")
+    expect(parsed.to_s).to include("2018")
+    expect(parsed.to_s).not_to match(/\bStd\b/)
+  end
+
+  it "still renders 'Std' for approved standards" do
+    parsed = Pubid::Ieee.parse("IEEE Std 802.3-2018")
+    expect(parsed.to_s).to eq("IEEE Std 802.3-2018")
+  end
+
+  it "still renders 'Draft Std' for non-unapproved drafts" do
+    parsed = Pubid::Ieee.parse("IEEE Draft Std 802.3")
+    expect(parsed.to_s).to eq("IEEE Draft Std 802.3/D1")
+  end
+end


### PR DESCRIPTION
Closes #209.

## Summary
- Per IEEE staff guidance, an unapproved draft is not yet a standard, so the "Std" token must not appear in the rendered type.
- The renderer now strips `Std` from the type when `draft_status` is `Unapproved`.
- Examples:
  - `IEEE Unapproved Draft Std 802.3` -> `IEEE Unapproved Draft 802.3/D1`
  - `IEEE Unapproved Std 802.3` -> `IEEE Unapproved 802.3`
  - `IEEE Unapproved Draft Std P802.3` -> `IEEE Unapproved Draft P802.3/D1` (project prefix kept)
- Approved standards and non-unapproved drafts keep their existing rendering.

## Test plan
- [x] New focused spec `spec/pubid/ieee/unapproved_draft_stds_spec.rb` covers all branches.
- [x] Existing `default_draft_version_spec.rb` updated to assert the corrected rendering.
- [x] Full IEEE suite: 202 examples, 0 failures.