### PR TITLE
fix(ieee): split multi-relationship parentheticals (#222)

### DIFF
--- a/lib/pubid/ieee/parser.rb
+++ b/lib/pubid/ieee/parser.rb
@@ -352,8 +352,11 @@ module Pubid
           str(" and ").absent? >>
           str(", ").absent? >>
           str(" as amended by ").absent? >>
-          str(" / ").absent? >>
-          str("; ").absent? >>
+          # Stop at any "/", ";", or "-" that introduces another relationship
+          # (look-ahead: separator + relationship_type keyword). This lets the
+          # slash inside "IEEE Std 525-2007/Cor 1-2015" stay part of the
+          # identifier, while the slash before "Incorporates ..." splits.
+          relationship_break.absent? >>
           str(")").absent? >>
           match(".")
         ).repeat(1)
@@ -378,15 +381,38 @@ module Pubid
           str(" and its approved amendments").as(:approved_amendments)
       end
 
+      # A character sequence that may separate two relationships inside the
+      # parenthetical: a "/", ";", or "-" with optional surrounding spaces.
+      # Standalone it is permissive — the actual decision to split is gated by
+      # `relationship_break`, which requires another relationship_type to
+      # follow. This way the slash in "IEEE Std 525-2007/Cor 1-2015" stays
+      # part of the related identifier.
+      rule(:relationship_separator) do
+        (space.maybe >> str("/") >> space.maybe) |
+          (space.maybe >> str(";") >> space.maybe) |
+          (space.maybe >> str("-") >> space.maybe)
+      end
+
+      # Look-ahead: a separator followed by another relationship_type keyword.
+      # Used as an absent? guard in identifier_string so the parser stops
+      # consuming characters right before a new relationship begins.
+      rule(:relationship_break) do
+        relationship_separator >> space.maybe >> relationship_type
+      end
+
       # Relationship clause (handles all relationship types)
       rule(:relationship_clause) do
         space.maybe >> str("(") >>
           relationship_type.as(:relationship_type) >>
           identifier_list.as(:related_ids) >>
           as_amended_by_clause.maybe >>
-          # Handle multiple relationships separated by " / " OR "; "
+          # Additional relationships separated by "/", ";", or "-" (optionally
+          # surrounded by spaces). The separator is only honored when followed
+          # by another relationship_type — identifier-internal slashes like
+          # "/Cor 1-2015" are not mistaken for relationship breaks because
+          # identifier_string stops at relationship_break ahead.
           (
-            (str(" / ") | str("; ")) >> # Support both separators
+            relationship_separator >>
             relationship_type.as(:relationship_type) >>
             identifier_list.as(:related_ids) >>
             as_amended_by_clause.maybe

--- a/spec/pubid/ieee/multi_relationship_spec.rb
+++ b/spec/pubid/ieee/multi_relationship_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "IEEE multi-relationship parsing — issue #222" do
+  # Each parenthetical may carry more than one relationship (e.g. a revision
+  # that also incorporates a corrigendum). Separators observed in the wild
+  # include " / ", "/", "; ", and even " - ". The parser must split on any of
+  # these only when another relationship keyword follows — otherwise the
+  # slash inside "IEEE Std 525-2007/Cor 1-2015" would be mistaken for a break.
+  {
+    "IEEE Std 605-2008 (Revision of IEEE Std 605-1998 / Incorporates IEEE Std 605a-2010)" =>
+      %w[revision_of incorporates],
+    "IEEE Std 80-2013 (Revision of IEEE Std 80-2000/ Incorporates IEEE Std 80-2013/Cor 1-2015)" =>
+      %w[revision_of incorporates],
+    "IEEE STD 525-2007 (Revision of IEEE Std 525-1992/Incorporates IEEE Std 525-2007/Cor1:2008)" =>
+      %w[revision_of incorporates],
+    "ANSI N42.18-2004 (Reaffirmation of ANSI N42.18-1980; Redesignation of ANSI N13.10-1974)" =>
+      %w[reaffirmation_of redesignation_of],
+    "IEEE Std 738-2012 (Revision of IEEE Std 738-2006 - Incorporates IEEE Std 738-2012 Cor 1-2013)" =>
+      %w[revision_of incorporates],
+    "IEEE Std C95.1-2019 (Revision of IEEE Std C95.1-2005/ Incorporates IEEE Std C95.1-2019/Cor 1-2019)" =>
+      %w[revision_of incorporates],
+  }.each do |input, expected_types|
+    it "splits #{input.inspect} into #{expected_types.inspect}" do
+      parsed = Pubid::Ieee.parse(input)
+      expect(parsed.relationships.map(&:relationship_type)).to eq(expected_types)
+    end
+
+    it "renders #{input.inspect} without nested 'IEEE Std (IEEE Std ...)'" do
+      parsed = Pubid::Ieee.parse(input)
+      rendered = parsed.to_s
+      expect(rendered).not_to match(/IEEE Std \(IEEE Std/)
+      expect(rendered).not_to match(/IEEE Std \(/)
+    end
+  end
+
+  it "does not split a corrigendum slash as a relationship break" do
+    parsed = Pubid::Ieee.parse("IEEE Std 80-2013 (Revision of IEEE Std 80-2000/ Incorporates IEEE Std 80-2013/Cor 1-2015)")
+    incorporates = parsed.relationships.find { |r| r.relationship_type == "incorporates" }
+    expect(incorporates.related_identifiers.size).to eq(1)
+    expect(incorporates.related_identifiers.first.to_s).to include("Cor")
+  end
+end


### PR DESCRIPTION
Closes #222.

## Summary
- Parentheticals with multiple relationships (revision + incorporates, etc.) used to collapse into a single revision_of, producing malformed nested output like `IEEE Std (IEEE Std 525-1992/...)`.
- The `relationship_clause` parser rule now splits on `/`, `;`, or `-` (optionally surrounded by whitespace) when another relationship keyword follows.
- A new `relationship_break` look-ahead in `identifier_string` keeps identifier-internal slashes like `/Cor 1-2015` intact.

## Examples
- `IEEE Std 605-2008 (Revision of IEEE Std 605-1998 / Incorporates IEEE Std 605a-2010)` → two relationships.
- `IEEE STD 525-2007 (Revision of IEEE Std 525-1992/Incorporates IEEE Std 525-2007/Cor1:2008)` → two relationships; the corrigendum slash stays inside the incorporated id.
- `IEEE Std 738-2012 (... - Incorporates ...)` → splits on the dash separator too.

## Test plan
- [x] New focused spec `spec/pubid/ieee/multi_relationship_spec.rb` covers all six issue examples.
- [x] Full IEEE suite: 209 examples, 0 failures (was 196 before — 13 new).