### PR TITLE
feat(nist): expose SP subseries as a queryable attribute (#161)

### DIFF
--- a/lib/pubid/nist/builder.rb
+++ b/lib/pubid/nist/builder.rb
@@ -379,6 +379,29 @@ module Pubid
                                                        id: extracted_revision.to_s)
         end
 
+        # Expose the SP subseries (Appendix A.2 of the NIST PubID Syntax) as
+        # a queryable attribute. For "NIST SP 800-53" the subseries is "800"
+        # (first_num) and the sequence is "53" (already folded into number).
+        # Pure metadata extraction — number is left intact so existing
+        # rendering and indexing stay byte-identical.
+        if identifier.is_a?(Identifiers::SpecialPublication) &&
+            first_num && identifier.respond_to?(:subseries=)
+          first_str = first_num.value.to_s
+          subseries_code =
+            if Identifiers::SpecialPublication::SP_SUBSERIES.include?(first_str)
+              first_str
+            elsif (m = first_str.match(/\A(\d+GB)\b/)) &&
+                Identifiers::SpecialPublication::SP_SUBSERIES.include?(m[1])
+              # Parser emits "1190GB-12" as a single first_number token; strip
+              # the suffix to surface the bare "1190GB" subseries code.
+              m[1]
+            end
+          if subseries_code
+            identifier.subseries =
+              Components::Code.new(value: subseries_code)
+          end
+        end
+
         # Series-specific post-processing (e.g., IR reverses the "84e2946"
         # form that preprocessing produced back to "84-2946").
         series.finalize_identifier(identifier, parsed_hash)

--- a/lib/pubid/nist/identifiers/base.rb
+++ b/lib/pubid/nist/identifiers/base.rb
@@ -27,6 +27,13 @@ module Pubid
       # raw string the circular/supplement builders pass straight through.
       attribute :publisher, :string
       attribute :series, Components::Code # Set by Builder from parsed data
+      # SP subseries (Appendix A.2 of the NIST PubID Syntax): for "NIST SP 800-53"
+      # the subseries is "800" and the sequence is "53". Populated by the Builder
+      # when the series is "SP" and the first number matches a known subseries
+      # code. Informational metadata derived from series+number — ignored in
+      # equality so a manually-built id (without subseries set) still equals a
+      # parsed one.
+      attribute :subseries, Components::Code
       attribute :number, Components::Code
 
       # V2 COMPONENTS (Lutaml::Model objects) - PROPER SEPARATION
@@ -110,8 +117,12 @@ module Pubid
       #   - first_number/second_number: decomposed parts of the canonical
       #     :number, retained from the parse for building
       #   - parsed_format: records the input format for round-trip rendering
+      #   - subseries: derived from series+number (which SP subseries the
+      #     document belongs to); populated by the Builder for known SP
+      #     subseries codes. Ignored in equality so a manually-built id
+      #     without subseries set still equals a parsed one.
       EQUALITY_IGNORED_ATTRS = %i[
-        edition_component first_number second_number parsed_format
+        edition_component first_number second_number parsed_format subseries
       ].freeze
 
       # Logical identity comparison: equal when every attribute except the

--- a/lib/pubid/nist/identifiers/special_publication.rb
+++ b/lib/pubid/nist/identifiers/special_publication.rb
@@ -9,6 +9,15 @@ module Pubid
       # - "NIST SP 800-53r5" = Special Publication 800-53 revision 5
       # - "NIST SP 800-57pt1r4" = Special Publication 800-57 part 1 revision 4
       class SpecialPublication < Identifier
+        # Per Appendix A.2 of the NIST PubID Syntax (April 2022), the SP series
+        # is subdivided into named subseries. The subseries number is the
+        # leading token of a report-num like "800-53" or "1190GB-12". The
+        # Builder exposes this as `identifier.subseries` so callers can query
+        # which subseries a document belongs to.
+        SP_SUBSERIES = %w[
+          250 260 300 400 480 500 700 800 823 960 1190GB 1200 1500 1800 1900 2000 2100
+        ].freeze
+
         TYPED_STAGES = [
           Pubid::Components::TypedStage.new(
             abbr: ["SP", "NIST SP", "NBS SP"], # Compound series

--- a/spec/pubid/nist/sp_subseries_spec.rb
+++ b/spec/pubid/nist/sp_subseries_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "NIST SP subseries — issue #161" do
+  # Per Appendix A.2 of the NIST PubID Syntax (April 2022), the SP series is
+  # subdivided into named subseries (SP 250, SP 260, ..., SP 800, SP 1190GB,
+  # ..., SP 2100). The Builder exposes the subseries code as a queryable
+  # attribute so callers can recognize, e.g., every "SP 800-X" document as
+  # belonging to the Computer Security subseries.
+  describe "#subseries" do
+    {
+      "NIST SP 800-53" => "800",
+      "NIST SP 800-90r1" => "800",
+      "NIST SP 800-90B" => "800",
+      "NIST SP 250-7" => "250",
+      "NIST SP 1190GB-12" => "1190GB",
+      "NIST SP 1190GB-4A" => "1190GB",
+      "NIST SP 1800-13B" => "1800",
+      "NIST SP 1500-7r2" => "1500",
+      "NIST SP 2100-5" => "2100",
+      "NIST SP 800" => "800",
+    }.each do |input, expected|
+      it "exposes #{expected.inspect} for #{input.inspect}" do
+        parsed = Pubid::Nist.parse(input)
+        expect(parsed.subseries&.value).to eq(expected)
+      end
+    end
+
+    {
+      "NIST SP 955" => nil, # 955 is not a known subseries
+      "NIST SP 964indx" => nil,
+      "NIST TN 2135sup" => nil, # TN series — no subseries concept
+      "NIST IR 8183Av1" => nil,
+      "NIST FIPS 140-2" => nil,
+    }.each do |input, expected|
+      it "is #{expected.inspect} for #{input.inspect}" do
+        parsed = Pubid::Nist.parse(input)
+        expect(parsed.subseries&.value).to eq(expected)
+      end
+    end
+  end
+
+  describe "rendering is unchanged" do
+    # The subseries attribute is informational metadata derived from
+    # series+number. Existing display and indexing must stay byte-identical.
+    [
+      "NIST SP 800-53",
+      "NIST SP 1190GB-12",
+      "NIST SP 1800-13B",
+    ].each do |input|
+      it "round-trips #{input.inspect}" do
+        expect(Pubid::Nist.parse(input).to_s).to eq(input)
+      end
+    end
+  end
+
+  describe "equality" do
+    # subseries lives in EQUALITY_IGNORED_ATTRS (it's derived from series+
+    # number), so a manually-built id without subseries still equals a parsed
+    # one — the canonical no-defaults to_hash invariant.
+    it "treats subseries as informational" do
+      parsed = Pubid::Nist.parse("NIST SP 800-53")
+      expect(parsed.subseries&.value).to eq("800")
+      expect(parsed.to_hash).to have_key("subseries")
+    end
+
+    it "round-trips through to_hash / from_hash" do
+      parsed = Pubid::Nist.parse("NIST SP 800-53")
+      round = Pubid::Nist::Identifier.from_hash(parsed.to_hash)
+      expect(round.subseries&.value).to eq("800")
+      expect(round.to_hash).to eq(parsed.to_hash)
+    end
+  end
+end


### PR DESCRIPTION
Closes #161.

## Summary
- Per Appendix A.2 of the NIST PubID Syntax (April 2022), the SP series is subdivided into 17 named subseries: SP 250, SP 260, SP 300, SP 400, SP 480, SP 500, SP 700, SP 800, SP 823, SP 960, SP 1190GB, SP 1200, SP 1500, SP 1800, SP 1900, SP 2000, SP 2100.
- Previously the parser only surfaced `NIST SP 800-53` as `series=SP, number=800-53` — callers couldn't tell which subseries a document belonged to.
- Adds a `subseries` attribute on `Pubid::Nist::Identifier`, populated when the series is SP and the first parsed number matches a known subseries code.

## Examples
- `Pubid::Nist.parse("NIST SP 800-53").subseries.value` => `"800"`
- `Pubid::Nist.parse("NIST SP 1190GB-12").subseries.value` => `"1190GB"`
- `Pubid::Nist.parse("NIST SP 955").subseries` => `nil` (955 is not in Appendix A.2)

## Design notes
- `subseries` lives in `EQUALITY_IGNORED_ATTRS` — it is derived from series+number, so a manually-built id without subseries still equals a parsed one and the canonical no-defaults `to_hash` round-trip is preserved.
- Existing rendering (`to_s`, `to_mr_style`) and indexing are byte-identical — the attribute is purely additive metadata.

## Test plan
- [x] New focused spec `spec/pubid/nist/sp_subseries_spec.rb` covers population, non-subseries cases, round-trip rendering, and serialization round-trip.
- [x] Full NIST suite: 1199 examples, 0 failures.
- [x] Cross-flavor specs (`identifier_hierarchy_spec`, `uniform_identifier_handle_spec`, `partial_ref_spec`): 128 examples, 0 failures.
