### PR TITLE
refactor(nist): compact to_hash and consolidate edition/revision

### DIFF
--- a/lib/pubid/nist/builder.rb
+++ b/lib/pubid/nist/builder.rb
@@ -287,8 +287,6 @@ module Pubid
 
               identifier.number = Components::Code.new(value: "#{first_num.value}-#{number_part}")
               identifier.edition = edition_obj
-              identifier.edition_component = edition_obj
-              identifier.revision = "r#{edition_id}"
             # CS Emergency pattern: e104-43 -> number=104, edition_year=1943
             # Logic: e104-43 means "emergency 104 from 1943" (43 = 1943)
             elsif first_num.value.to_s.match?(/^e(\d{3})$/) &&
@@ -304,7 +302,6 @@ module Pubid
 
               identifier.number = Components::Code.new(value: number_part)
               identifier.edition = edition_obj
-              identifier.edition_component = edition_obj
             elsif first_num.value.to_s.match?(/^(\d+)e(\d+)$/) &&
                 second_num.value.to_s.match?(/^\d{2,4}$/)
               # Pattern: "11e2-1915" OR "123e2-50" parsed as first="11e2"|"123e2", second="1915"|"50"
@@ -326,7 +323,6 @@ module Pubid
               edition_obj = Components::Edition.new(type: "e",
                                                     id: edition_id, additional_text: year_part)
               identifier.edition = edition_obj
-              identifier.edition_component = edition_obj
             elsif first_num.value.to_s.match?(/^(\d+)supp?$/) &&
                 second_num.value.to_s.match?(/^\d{4}$/)
               # Pattern: "25supp-1924" parsed as first="25supp", second="1924"
@@ -351,7 +347,6 @@ module Pubid
               identifier.number = first_num
               edition_obj = Components::Edition.new(type: "e",
                                                     id: second_num.value.to_s)
-              identifier.edition_component = edition_obj
               identifier.edition = edition_obj
               identifier.edition_year = second_num.value.to_s
             elsif part_num && series.part_num_as_component?

--- a/lib/pubid/nist/caster.rb
+++ b/lib/pubid/nist/caster.rb
@@ -201,9 +201,6 @@ module Pubid
                                            value: data[:letter_suffix].to_s.upcase),
                 edition: Components::Edition.new(type: "r",
                                                  id: data[:revision_id].to_s),
-                edition_component: Components::Edition.new(type: "r",
-                                                            id: data[:revision_id].to_s),
-                revision: "r#{data[:revision_id]}",
               }
             end
 
@@ -882,8 +879,6 @@ module Pubid
           # Store as id directly - renders as "e199206"
           {
             edition: Components::Edition.new(type: "e", id: edition_date),
-            edition_component: Components::Edition.new(type: "e",
-                                                       id: edition_date),
           }
 
         when :edition_e
@@ -894,8 +889,6 @@ module Pubid
 
           {
             edition: Components::Edition.new(type: "e", id: edition_id),
-            edition_component: Components::Edition.new(type: "e",
-                                                       id: edition_id),
           }
 
         when :edition_r
@@ -906,9 +899,6 @@ module Pubid
 
           {
             edition: Components::Edition.new(type: "r", id: edition_id),
-            edition_component: Components::Edition.new(type: "r",
-                                                       id: edition_id),
-            revision: "r#{edition_id}", # Also set revision string attribute for compatibility
           }
 
         when :edition_r_no_space
@@ -920,9 +910,6 @@ module Pubid
 
           {
             edition: Components::Edition.new(type: "r", id: edition_id),
-            edition_component: Components::Edition.new(type: "r",
-                                                       id: edition_id),
-            revision: "r#{edition_id}", # Also set revision string attribute for compatibility
           }
 
         when :edition_rev
@@ -933,9 +920,6 @@ module Pubid
 
           {
             edition: Components::Edition.new(type: "r", id: edition_id),
-            edition_component: Components::Edition.new(type: "r",
-                                                       id: edition_id),
-            revision: "r#{edition_id}", # Also set revision string attribute for compatibility
           }
 
         when :edition_r_letter
@@ -948,10 +932,6 @@ module Pubid
           {
             edition: Components::Edition.new(type: "r", id: edition_id,
                                              additional_text: edition_letter),
-            edition_component: Components::Edition.new(type: "r",
-                                                       id: edition_id,
-                                                       additional_text: edition_letter),
-            revision: "r#{edition_id}#{edition_letter}", # Also set revision string attribute for compatibility
           }
 
         when :edition_r_letter_only
@@ -962,9 +942,6 @@ module Pubid
 
           {
             edition: Components::Edition.new(type: "r", id: edition_letter),
-            edition_component: Components::Edition.new(type: "r",
-                                                       id: edition_letter),
-            revision: "r#{edition_letter}", # Also set revision string attribute for compatibility
           }
 
         when :edition_historical
@@ -975,8 +952,6 @@ module Pubid
 
           {
             edition: Components::Edition.new(type: "-", id: edition_id),
-            edition_component: Components::Edition.new(type: "-",
-                                                       id: edition_id),
           }
 
         when :edition_r_with_space_letter
@@ -996,10 +971,6 @@ module Pubid
             {
               edition: Components::Edition.new(type: "r", id: edition_id,
                                                additional_text: edition_letter),
-              edition_component: Components::Edition.new(type: "r",
-                                                         id: edition_id,
-                                                         additional_text: edition_letter),
-              revision: "r#{edition_id}#{edition_letter}",
             }
           else
             # Space was in original input - preserve format
@@ -1007,11 +978,6 @@ module Pubid
               edition: Components::Edition.new(type: "r", id: edition_id,
                                                additional_text: edition_letter,
                                                original_prefix: " r"),
-              edition_component: Components::Edition.new(type: "r",
-                                                         id: edition_id,
-                                                         additional_text: edition_letter,
-                                                         original_prefix: " r"),
-              revision: "r#{edition_id}#{edition_letter}",
             }
           end
 
@@ -1032,19 +998,12 @@ module Pubid
             # No original_prefix - space was added by preprocessing
             {
               edition: Components::Edition.new(type: "r", id: edition_id),
-              edition_component: Components::Edition.new(type: "r",
-                                                         id: edition_id),
-              revision: "r#{edition_id}",
             }
           else
             # Space was in original input - preserve format
             {
               edition: Components::Edition.new(type: "r", id: edition_id,
                                                original_prefix: " r"),
-              edition_component: Components::Edition.new(type: "r",
-                                                         id: edition_id,
-                                                         original_prefix: " r"),
-              revision: "r#{edition_id}",
             }
           end
 
@@ -1094,7 +1053,6 @@ module Pubid
                 )
                 return {
                   edition: edition_obj,
-                  edition_component: edition_obj,
                   edition_year: edition_id.to_s,
                 }
               else
@@ -1118,7 +1076,6 @@ module Pubid
           # Return as hash to set edition and edition_year
           {
             edition: edition_obj, # Main attribute for tests
-            edition_component: edition_obj, # V2 component
             edition_year: value.to_s, # Keep string for render logic
           }
 

--- a/lib/pubid/nist/identifiers/base.rb
+++ b/lib/pubid/nist/identifiers/base.rb
@@ -12,6 +12,77 @@ module Pubid
         Pubid::Nist.parse(identifier)
       end
 
+      # Compact, index-friendly serialization (mirrors the key_value flavors
+      # ISO/ITU/ETSI, without a 38-field key_value block). Two transforms,
+      # applied symmetrically by to_hash/from_hash so the round-trip stays
+      # idempotent:
+      #   - flatten the single-value Code components (series, number) to bare
+      #     scalars — `value` is the only stored field. NIST's
+      #     `Components::Code#part` is a *computed* reader
+      #     (`value.split("-").last`), and prefix/subpart/parts are never
+      #     assigned on series/number, so the scalar `value` is lossless:
+      #     expand recomputes exactly what the object would compute anyway;
+      #   - flatten the plain single-value components (volume) to bare scalars
+      #     too — `Components::Volume` holds only `value`, so it expands to a
+      #     bare { "value" => … } with no part;
+      #   - drop the redundant build artifacts, decomposed pieces of the
+      #     canonical number that identity/rendering never read.
+      COMPACT_FLAT_CODES = %w[series number subseries].freeze
+      COMPACT_FLAT_VALUES = %w[volume].freeze
+      COMPACT_DROP_ATTRS = %w[first_number second_number].freeze
+
+      # Deserialize a (possibly compact) hash: expand the flattened scalars
+      # back into Code sub-hashes, then let the shared polymorphic from_hash
+      # do the real work. Nested `base` documents are expanded recursively by
+      # their own from_hash via apply_mappings, so only this level is touched.
+      def self.from_hash(data, options = {})
+        super(expand_compact_hash(data), options)
+      end
+
+      # Expand a compact hash in place-safe fashion: a scalar series/number
+      # becomes { "value" => …, "part" => <last-dash segment> }.
+      def self.expand_compact_hash(data)
+        return data unless data.is_a?(::Hash)
+
+        out = data.dup
+        COMPACT_FLAT_CODES.each do |key|
+          out[key] = expand_code(out[key]) if out[key].is_a?(::String)
+        end
+        COMPACT_FLAT_VALUES.each do |key|
+          out[key] = { "value" => out[key] } if out[key].is_a?(::String)
+        end
+        out
+      end
+
+      # A flattened Code scalar -> { "value" => …, "part" => <last-dash seg> }.
+      def self.expand_code(value)
+        code = { "value" => value }
+        code["part"] = value.split("-").last if value.include?("-")
+        code
+      end
+
+      # Serialize, then apply the compact transforms (recursing into a nested
+      # `base`, which lutaml serialized via its own transform — bypassing this
+      # override — so it is not compacted otherwise).
+      def to_hash(*args)
+        hash = super
+        compact_hash!(hash) if hash.is_a?(::Hash)
+        hash
+      end
+
+      def compact_hash!(hash)
+        COMPACT_DROP_ATTRS.each { |key| hash.delete(key) }
+        (COMPACT_FLAT_CODES + COMPACT_FLAT_VALUES).each do |key|
+          value = hash[key]
+          next unless value.is_a?(::Hash) && value.key?("value")
+
+          hash[key] = value["value"]
+        end
+        compact_hash!(hash["base"]) if hash["base"].is_a?(::Hash)
+        hash
+      end
+      private :compact_hash!
+
       # Default: no typed stages. Subclasses override as needed.
       def self.typed_stages
         []
@@ -37,8 +108,13 @@ module Pubid
       attribute :number, Components::Code
 
       # V2 COMPONENTS (Lutaml::Model objects) - PROPER SEPARATION
+      # `edition` (Components::Edition: type + id + additional_text) is the
+      # single source of truth for edition/revision. The former
+      # `edition_component` (a byte-identical duplicate) and the `revision`
+      # string (always "#{edition.type}#{edition.id}") were unfinished V1->V2
+      # migration aliases; both removed. `#revision` survives as a derived
+      # reader below.
       attribute :edition, Components::Edition # Edition (type + id): e2, e2021, r5, -3
-      attribute :edition_component, Components::Edition # V2 edition component (alias)
       attribute :volume, Components::Volume # Volume component (v6)
       attribute :part, Components::Part  # Part component (n1 or pt1)
       attribute :stage, Components::Stage
@@ -57,7 +133,6 @@ module Pubid
 
       # LEGACY attributes (keep for backward compatibility during migration)
       attribute :parts, Components::Code, collection: true
-      attribute :revision, :string
       attribute :revision_year, :string # Year for revision (e.g., r6/1925, r1963, rJun1992)
       attribute :revision_month, :string # Month for revision (e.g., rJun1992)
       attribute :edition_year, :string # Legacy edition year for backward compatibility
@@ -113,7 +188,6 @@ module Pubid
       # Attributes that are build artifacts or rendering aliases, not part
       # of an identifier's logical identity. They diverge between equally-
       # valid spellings of the same id (e.g. long "Rev. 1" vs short "r1"):
-      #   - edition_component: redundant alias of :edition
       #   - first_number/second_number: decomposed parts of the canonical
       #     :number, retained from the parse for building
       #   - parsed_format: records the input format for round-trip rendering
@@ -122,7 +196,7 @@ module Pubid
       #     subseries codes. Ignored in equality so a manually-built id
       #     without subseries set still equals a parsed one.
       EQUALITY_IGNORED_ATTRS = %i[
-        edition_component first_number second_number parsed_format subseries
+        first_number second_number parsed_format subseries
       ].freeze
 
       # Logical identity comparison: equal when every attribute except the
@@ -189,15 +263,12 @@ module Pubid
         prefix + (rendered.empty? ? "sup" : rendered)
       end
 
-      # Compute revision from edition component for backward compatibility
+      # Derived, read-only revision string ("r5", "e1979", "-3") for backward
+      # compatibility. `edition` is the single stored representation; this is
+      # never persisted, compared, or merged — just a convenience view of it.
       # @return [String, nil] revision string (e.g., "r5") or nil
       def revision
-        return @revision if @revision
-
-        # Compute from edition component if available
-        if edition&.type && edition.id
-          "#{edition.type}#{edition.id}"
-        end
+        "#{edition.type}#{edition.id}" if edition&.type && edition.id
       end
 
       # Backward compatibility: translation method returns translation_component
@@ -262,6 +333,8 @@ module Pubid
       # @return [Integer] weight score (higher = more specific)
       def weight
         self.class.attributes.keys.inject(0) do |sum, key|
+          next sum if EQUALITY_IGNORED_ATTRS.include?(key)
+
           val = public_send(key)
           val && !val.to_s.empty? ? sum + 1 : sum
         end
@@ -289,7 +362,7 @@ module Pubid
                          when :edition
                            current_val.nil? || edition_greater?(new_val,
                                                                 current_val)
-                         when :volume, :part, :version, :revision
+                         when :volume, :part, :version
                            current_val.nil? || (new_val.to_s.length > current_val.to_s.length)
                          when :supplement, :errata, :index, :insert, :section, :appendix, :translation
                            true

--- a/lib/pubid/nist/series/ir.rb
+++ b/lib/pubid/nist/series/ir.rb
@@ -36,8 +36,6 @@ module Pubid
           )
           edition_obj = Components::Edition.new(type: "r", id: "1")
           identifier.edition = edition_obj
-          identifier.edition_component = edition_obj
-          identifier.revision = "r1"
           true
         end
 
@@ -52,7 +50,6 @@ module Pubid
             value: "#{match[1]}-#{match[2]}",
           )
           identifier.edition = nil
-          identifier.edition_component = nil
         end
       end
     end

--- a/spec/pubid/nist/compact_to_hash_spec.rb
+++ b/spec/pubid/nist/compact_to_hash_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/pubid"
+
+# Compact, index-friendly NIST serialization: the single-value Code components
+# (series, number) serialize as bare scalars, and the redundant build artifacts
+# (first_number, second_number, edition_component) are dropped — mirroring the
+# compact key_value flavors (ISO/ITU/ETSI). The to_hash/from_hash pair stays
+# symmetric so the round-trip is idempotent and relaton-index rows still verify.
+RSpec.describe "Pubid::Nist compact to_hash" do
+  describe "flattening + artifact drop" do
+    it "renders series as a bare scalar" do
+      h = Pubid::Nist.parse("NIST SP 800-53r5").to_hash
+      expect(h["series"]).to eq("SP")
+    end
+
+    it "renders number as a bare scalar" do
+      h = Pubid::Nist.parse("NIST SP 800-53r5").to_hash
+      expect(h["number"]).to eq("800-53")
+    end
+
+    it "drops the first_number/second_number build artifacts" do
+      h = Pubid::Nist.parse("NIST VTS 400-5").to_hash
+      expect(h).not_to have_key("first_number")
+      expect(h).not_to have_key("second_number")
+      expect(h["series"]).to eq("VTS")
+      expect(h["number"]).to eq("400-5")
+    end
+
+    it "drops the edition_component alias" do
+      h = Pubid::Nist.parse("NBS CIRC 101e2supp").to_hash
+      expect(h).not_to have_key("edition_component")
+    end
+
+    it "renders volume as a bare scalar" do
+      h = Pubid::Nist.parse("NBS CSM v9n10").to_hash
+      expect(h["volume"]).to eq("9")
+    end
+
+    it "renders SP subseries as a bare scalar" do
+      h = Pubid::Nist.parse("NIST SP 800-53r5").to_hash
+      expect(h["subseries"]).to eq("800")
+    end
+
+    it "drops the revision string alias (edition is the source of truth)" do
+      h = Pubid::Nist.parse("NIST SP 800-53r5").to_hash
+      expect(h).not_to have_key("revision")
+      expect(h["edition"]).to eq("type" => "r", "id" => "5")
+    end
+
+    it "keeps a derived revision reader for backward compatibility" do
+      # revision is no longer a stored attribute, but the computed reader
+      # (derived from edition) still answers so downstream callers keep working.
+      expect(Pubid::Nist.parse("NIST SP 800-53r5").revision).to eq("r5")
+    end
+
+    it "removes the edition_component attribute entirely" do
+      h = Pubid::Nist.parse("NBS CIRC 101e2supp").to_hash
+      expect(h).not_to have_key("edition_component")
+      expect(Pubid::Nist::Identifier.attributes).not_to have_key(:edition_component)
+    end
+
+    it "compacts a nested base document (CircularSupplement wrapper)" do
+      h = Pubid::Nist.parse("NBS LC 118supp3/1926").to_hash
+      expect(h["series"]).to eq("LCIRC")
+      expect(h["base"]).to include("series" => "LCIRC", "number" => "118")
+      expect(h["base"]).not_to have_key("first_number")
+    end
+  end
+
+  describe "round-trip idempotency through the compact hash" do
+    samples = [
+      "NIST SP 800-53r5", "NIST VTS 400-5", "NIST FIPS 197",
+      "NBS CIRC 24e7sup2", "NIST GCR 15-917-34", "NBS CRPL 4-m-5",
+      "NBS BRPD-CRPL-D 5-2-3-1", "NBS LC 118supp3/1926", "NIST IR 8165",
+      "NBS CSM v9n10",
+    ]
+    samples.each do |ref|
+      it "round-trips #{ref.inspect} (== and idempotent hash)" do
+        id = Pubid::Nist.parse(ref)
+        h  = id.to_hash
+        rt = Pubid::Nist::Identifier.from_hash(h)
+        expect(rt).to eq(id)
+        expect(rt.to_s).to eq(id.to_s)
+        expect(rt.to_hash).to eq(h)
+      end
+    end
+  end
+
+  describe "corpus-wide idempotency" do
+    it "keeps from_hash(to_hash).to_hash == to_hash across the pass corpus" do
+      files = Dir[File.join(__dir__, "../../fixtures/nist/identifiers/pass/*.txt")]
+      checked = 0
+      mismatches = []
+      files.each do |f|
+        File.readlines(f).map(&:strip).each do |line|
+          next if line.empty? || line.start_with?("#")
+
+          inp = line.start_with?("!") ? line.split("!")[1] : line
+          begin
+            h = Pubid::Nist.parse(inp).to_hash
+          rescue StandardError
+            next
+          end
+          checked += 1
+          rt = Pubid::Nist::Identifier.from_hash(h).to_hash
+          mismatches << inp if rt != h
+        end
+      end
+      expect(checked).to be > 20_000
+      expect(mismatches.first(15)).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Makes NIST's `to_hash` compact and index-friendly, and removes redundant edition/revision model state. Mirrors the direction of #294 (IEEE index-friendly serialization) for NIST.

### 1. Flatten single-value `Components::Code` to bare scalars
`series`, `number`, `subseries` and `volume` now serialize as plain strings instead of `{value: …}`:
```yaml
# before                          # after
series:                           series: SP
  value: SP
number:                           number: 800-53
  value: '800-53'
  part: '53'
```
`Components::Code#part` is a **computed** reader (`value.split("-").last`) and `prefix`/`subpart`/`parts` are never populated on these, so the scalar `value` is lossless — verified reversible across the whole ~21k fixture corpus. `to_hash`/`from_hash` are symmetric, and `from_hash` still accepts the **legacy nested shape**, so existing `relaton-data-nist` rows keep deserializing.

### 2. Drop build artifacts
`first_number` / `second_number` (decomposed pieces of `number`, already equality-ignored) are no longer serialized.

### 3. Consolidate edition / revision
`edition` (`Components::Edition`) is the single source of truth. Removed:
- **`edition_component`** attribute — a dead, never-read, byte-identical duplicate of `edition`.
- **`revision`** string attribute — always `"#{edition.type}#{edition.id}"`, verified across the corpus (0 divergences).

`#revision` survives as a **derived reader** for backward compatibility; it is no longer stored, serialized, compared, or merged. The now-dead assignments in `builder.rb` / `caster.rb` / `series/ir.rb` are cleaned up.

### 4. Fix `#weight`
`weight` now skips build artifacts, so it stops double-counting `edition` via `revision` (it has no internal callers).

## Resulting index row
```yaml
- :id:
    _type: pubid:nist:special-publication
    number: 800-53
    edition: { type: r, id: '5' }
    publisher: NIST
    series: SP
    subseries: '800'
  :file: data/nist-sp-800-53r5.yaml
```
No more `revision:`, `edition_component:`, `first_number:`, `second_number:`, and the Code components are one line each.

## Tests
- New `spec/pubid/nist/compact_to_hash_spec.rb`, including **corpus-wide `from_hash(to_hash).to_hash == to_hash` idempotency** over ~21k fixtures.
- Full NIST + integration: **1431 examples, 0 failures**.
- `to_s` output is byte-identical (renderers use the derived `revision`), so all fixture round-trips pass.

## Downstream note
`to_hash` rows change shape (smaller). `from_hash` is backward-compatible with old nested rows, so `relaton-data-nist` regeneration is an eventual cleanup, not a breaking prerequisite. `to_json`/`to_yaml` intentionally keep the nested shape (same trade-off as the `key_value` flavors); the index path uses `to_hash`.