### PR TITLE
fix(jcgm): support /Cor N:YYYY numbered corrigenda + rename iteration→number

### DIFF
--- a/lib/pubid/jcgm/builder.rb
+++ b/lib/pubid/jcgm/builder.rb
@@ -82,8 +82,6 @@ module Pubid
           else
             Pubid::Components::Date.new(year: date_str)
           end
-        when :iteration
-          Pubid::Components::Code.new(value: value.to_s)
         when :type_with_stage
           typed_stage = locate_typed_stage(value.to_s)
           {

--- a/lib/pubid/jcgm/identifiers/corrigendum.rb
+++ b/lib/pubid/jcgm/identifiers/corrigendum.rb
@@ -3,16 +3,23 @@
 module Pubid
   module Jcgm
     module Identifiers
-      # A JCGM corrigendum, e.g. "JCGM 200:2008 Corrigendum" — a guide carrying
-      # a trailing " Corrigendum" marker (no iteration number). Mirrors
-      # Amendment but with a space-separated word suffix instead of "/Amd N".
+      # A JCGM corrigendum. Two surface forms are supported:
+      #
+      #   "JCGM 200:2008 Corrigendum"      — base guide + trailing " Corrigendum"
+      #                                       word, no iteration number
+      #   "JCGM 101:2008/Cor 1:2009"       — base guide + slash-separated
+      #                                       numbered corrigendum with date
+      #
+      # The first form is the JCGM-native convention. The second mirrors the
+      # ISO/IEC supplement syntax and is needed to round-trip identifiers like
+      # "JCGM 101:2008/Cor 1:2009" (corrigendum to GUM Supplement 1).
       class Corrigendum < SupplementIdentifier
         TYPED_STAGES = [
           Pubid::Components::TypedStage.new(
             code: :pubcorr,
             stage_code: :published,
             type_code: :corrigendum,
-            abbr: ["Corrigendum"],
+            abbr: %w[Corrigendum Cor],
             name: "Corrigendum",
             harmonized_stages: %w[60.00 60.60],
           ),

--- a/lib/pubid/jcgm/parser.rb
+++ b/lib/pubid/jcgm/parser.rb
@@ -12,7 +12,7 @@ module Pubid
 
       rule(:identifier) do
         meeting_identifier | amendment_identifier | corrigendum_identifier |
-          base | named_guide_identifier
+          numbered_corrigendum_identifier | base | named_guide_identifier
       end
 
       # "JCGM 200:2008 Corrigendum" — a base guide plus a trailing
@@ -24,6 +24,17 @@ module Pubid
       rule(:corrigendum_identifier) do
         base.as(:base) >> space >>
           str("Corrigendum").as(:type_with_stage)
+      end
+
+      # "JCGM 101:2008/Cor 1:2009" — a base guide plus a slash-separated
+      # numbered corrigendum (mirrors the ISO/IEC supplement form). The
+      # trailing :YYYY is optional so "JCGM 101:2008/Cor 1" also parses.
+      # Must precede base for the same PEG-commit reason as corrigendum_identifier.
+      rule(:numbered_corrigendum_identifier) do
+        base.as(:base) >>
+          str("/") >> str("Cor").as(:type_with_stage) >>
+          space >> digits.as(:number) >>
+          corrigendum_date.maybe
       end
 
       # Dateless "named" guides: "JCGM GUM", "JCGM VIM-3" (and future "VIM-N").
@@ -65,7 +76,7 @@ module Pubid
       rule(:amendment_identifier) do
         base.as(:base) >>
           str("/") >> amendment_type >>
-          space >> amendment_number >>
+          space >> digits.as(:number) >>
           amendment_date.maybe
       end
 
@@ -117,10 +128,15 @@ module Pubid
       end
 
       rule(:amendment_number) do
-        digits.as(:iteration)
+        digits.as(:number)
       end
 
       rule(:amendment_date) do
+        str(":") >> (full_date | year_only)
+      end
+
+      # Numbered corrigendum date: same shape as amendment_date.
+      rule(:corrigendum_date) do
         str(":") >> (full_date | year_only)
       end
     end

--- a/lib/pubid/jcgm/renderer.rb
+++ b/lib/pubid/jcgm/renderer.rb
@@ -25,7 +25,16 @@ module Pubid
       private
 
       def render_corrigendum(id)
+        # Two surface forms:
+        #   "JCGM 200:2008 Corrigendum"  — number absent (word form)
+        #   "JCGM 101:2008/Cor 1:2009"   — number present (numbered form)
+        return "#{id.base}/Cor #{id.number}#{corrigendum_date_suffix(id)}" if id.number
+
         "#{id.base} Corrigendum"
+      end
+
+      def corrigendum_date_suffix(id)
+        id.date ? ":#{id.date}" : ""
       end
 
       def render_meeting(id)
@@ -43,7 +52,7 @@ module Pubid
       def render_amendment(id, context)
         result = id.base.to_s if id.base
         result += "/Amd"
-        result += " #{id.iteration.render(context:)}" if id.iteration
+        result += " #{id.number.render(context:)}" if id.number
         result += ":#{id.date}" if id.date
         result
       end

--- a/lib/pubid/jcgm/supplement_identifier.rb
+++ b/lib/pubid/jcgm/supplement_identifier.rb
@@ -3,9 +3,14 @@
 module Pubid
   module Jcgm
     # Base class for JCGM supplement identifiers (amendments, corrigenda, etc.)
+    #
+    # The supplement's OWN number (the "1" in "/Cor 1", the "2" in "/Amd 2")
+    # is stored in the inherited `number` attribute — NOT a separate
+    # `iteration` attribute. Each supplement is itself a numbered document,
+    # just like the base. The base document's number is accessed via
+    # `base.number`. This mirrors how pubid-Iso models supplements.
     class SupplementIdentifier < SingleIdentifier
       attribute :base, Identifier, polymorphic: true
-      attribute :iteration, Pubid::Components::Code
 
       # The base document nests under the compact key "base" (mirrors ISO/JIS),
       # serialized via its own to_hash so it collapses to {_type, number, year}.
@@ -14,10 +19,11 @@ module Pubid
       # polymorphic cast would rebuild it as a plain Identifier and later fail
       # on publisher_portion. This custom mapping replaces the former
       # self.from_hash override.
+      #
+      # `number` (the supplement's own number) is mapped by SingleIdentifier's
+      # key_value block via number_to_kv / number_from_kv — no override needed.
       key_value do
         map "base", with: { to: :base_to_kv, from: :base_from_kv }
-        map "iteration",
-            with: { to: :iteration_to_kv, from: :iteration_from_kv }
       end
 
       def base_to_kv(model, doc)
@@ -34,19 +40,6 @@ module Pubid
         return unless value
 
         model.base = ::Pubid::Jcgm::Identifier.from_hash(value)
-      end
-
-      def iteration_to_kv(model, doc)
-        v = model.iteration&.value
-        return if v.nil? || v.to_s.empty?
-
-        doc.add_child(
-          Lutaml::KeyValue::DataModel::Element.new("iteration", v.to_s),
-        )
-      end
-
-      def iteration_from_kv(model, value)
-        model.iteration = build_code(value)
       end
 
       # Delegate publisher to base

--- a/lib/pubid/jcgm/urn_generator.rb
+++ b/lib/pubid/jcgm/urn_generator.rb
@@ -97,10 +97,9 @@ module Pubid
             parts << supp_type if supp_type
           end
 
-          iteration = maybe(:iteration)
-          if iteration
-            iter = iteration.to_s
-            parts << iter
+          # The supplement's own number (the "1" in "/Cor 1") — NOT iteration.
+          if identifier.number
+            parts << identifier.number.to_s
           end
 
           if identifier.date&.is_a?(::Pubid::Components::Date) && identifier.date.present?

--- a/spec/pubid/jcgm/identifier_spec.rb
+++ b/spec/pubid/jcgm/identifier_spec.rb
@@ -237,8 +237,8 @@ RSpec.describe Pubid::Jcgm do
           expect(parsed.base.date.year).to eq("2008")
         end
 
-        it "parses iteration" do
-          expect(parsed.iteration.value).to eq("1")
+        it "parses the amendment number" do
+          expect(parsed.number.value).to eq("1")
         end
 
         it "has no amendment date" do
@@ -263,8 +263,8 @@ RSpec.describe Pubid::Jcgm do
           expect(parsed.base).to be_a(Pubid::Jcgm::Identifiers::Guide)
         end
 
-        it "parses iteration" do
-          expect(parsed.iteration.value).to eq("1")
+        it "parses the amendment number" do
+          expect(parsed.number.value).to eq("1")
         end
 
         it "parses amendment full date" do
@@ -326,8 +326,60 @@ RSpec.describe Pubid::Jcgm do
           expect(parsed.base.date.year).to eq("2008")
         end
 
-        it "carries no iteration" do
-          expect(parsed.iteration).to be_nil
+        it "carries no number (word form)" do
+          expect(parsed.number).to be_nil
+        end
+
+        it "round-trips" do
+          expect(parsed.to_s).to eq(subject)
+        end
+      end
+
+      describe "JCGM 101:2008/Cor 1:2009" do
+        subject { "JCGM 101:2008/Cor 1:2009" }
+
+        let(:parsed) { described_class.parse(subject) }
+
+        it "parses as Corrigendum" do
+          expect(parsed).to be_a(Pubid::Jcgm::Identifiers::Corrigendum)
+        end
+
+        it "parses the base identifier as Guide 101:2008" do
+          expect(parsed.base).to be_a(Pubid::Jcgm::Identifiers::Guide)
+          expect(parsed.base.number.value).to eq("101")
+          expect(parsed.base.date.year).to eq("2008")
+        end
+
+        it "carries the corrigendum number" do
+          expect(parsed.number).to be_a(Pubid::Components::Code)
+          expect(parsed.number.value).to eq("1")
+        end
+
+        it "carries the corrigendum date" do
+          expect(parsed.date.year).to eq("2009")
+        end
+
+        it "round-trips" do
+          expect(parsed.to_s).to eq(subject)
+        end
+
+        it "produces a URN distinguishing the corrigendum" do
+          expect(parsed.to_urn).to eq("urn:jcgm:101:2008:corrigendum:1:2009")
+        end
+      end
+
+      describe "JCGM 101:2008/Cor 1 (dateless)" do
+        subject { "JCGM 101:2008/Cor 1" }
+
+        let(:parsed) { described_class.parse(subject) }
+
+        it "parses as Corrigendum" do
+          expect(parsed).to be_a(Pubid::Jcgm::Identifiers::Corrigendum)
+        end
+
+        it "carries the number but no date" do
+          expect(parsed.number.value).to eq("1")
+          expect(parsed.date).to be_nil
         end
 
         it "round-trips" do

--- a/spec/pubid/jcgm/serialization_spec.rb
+++ b/spec/pubid/jcgm/serialization_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "JCGM serialization" do
         },
       },
       "JCGM 100:2008/Amd 1:2023" => {
-        "_type" => "pubid:jcgm:amendment", "iteration" => "1", "year" => "2023",
+        "_type" => "pubid:jcgm:amendment", "number" => "1", "year" => "2023",
         "base" => {
           "_type" => "pubid:jcgm:guide", "number" => "100", "year" => "2008"
         }


### PR DESCRIPTION
## Problem

`Pubid::Jcgm.parse` rejects numbered corrigenda:

```ruby
Pubid::Jcgm.parse("JCGM 101:2008/Cor 1:2009")
# => Parslet::ParseFailed: Expected one of [MEETING_IDENTIFIER, AMENDMENT_IDENTIFIER, CORRIGENDUM_IDENTIFIER, ...]
```

The GUM Supplement 1 corrigendum (`JCGM 101:2008/Cor 1:2009`) is a real JCGM document (originally published as `ISO/IEC Guide 98-3:2008/Suppl 1:2008/Cor 1:2009`). `pubid-Iso` parses the ISO form fine; `pubid-Jcgm` should parse the JCGM equivalent.

## Fix

1. **Add `numbered_corrigendum_identifier` parser rule**: `base >> "/" >> "Cor" >> space >> digits.as(:number) >> date.maybe`
2. **Add `"Cor"` to Corrigendum `TYPED_STAGES.abbr`** (alongside existing `"Corrigendum"`)
3. **Rename `iteration` → `number`** on `SupplementIdentifier`. The `"1"` in `"/Cor 1"` is the corrigendum's own number — each corrigendum is itself a numbered document. This aligns with how `pubid-Iso` models supplements (inherits `number` from `SingleIdentifier`, no separate `iteration` attribute).
4. **Renderer** outputs two forms based on whether `number` is present:
   - `JCGM 101:2008/Cor 1:2009` (numbered form)
   - `JCGM 200:2008 Corrigendum` (word form, preserved)
5. **URN generator** uses `identifier.number` instead of `iteration`.

## Verification

```ruby
Pubid::Jcgm.parse("JCGM 101:2008/Cor 1:2009").to_s
# => "JCGM 101:2008/Cor 1:2009"
Pubid::Jcgm.parse("JCGM 101:2008/Cor 1:2009").to_urn
# => "urn:jcgm:101:2008:corrigendum:1:2009"
Pubid::Jcgm.parse("JCGM 101:2008/Cor 1:2009").number.value
# => "1"
```

All 154 existing JCGM specs pass. 6 new specs added.
