### PR TITLE
fix(ieee): stop double-capturing :year (Parslet "Duplicate subtrees" warning)

### DIFF
--- a/lib/pubid/ieee/builder.rb
+++ b/lib/pubid/ieee/builder.rb
@@ -927,6 +927,18 @@ module Pubid
         if parsed[:year]
           year_str = extract_value(parsed[:year])
           attributes[:year] = year_str
+        elsif parsed[:trailing_year]
+          # No base -YYYY identity year: the trailing "Month YYYY" IS the
+          # document date (e.g. "IEEE Std 519, May 1993"), so promote it.
+          # When a base year exists it wins (the IEEE approval/identity year)
+          # and the trailing date is intentionally dropped rather than
+          # fabricating a wrong month/year pairing. The trailing captures use
+          # distinct keys (:trailing_month/:trailing_year) so they never collide
+          # with the base :year (Parslet no longer warns "Duplicate subtrees").
+          attributes[:year] = extract_value(parsed[:trailing_year])
+          if parsed[:trailing_month]
+            attributes[:month] = extract_value(parsed[:trailing_month])
+          end
         end
 
         # Extract edition_month if parsed separately

--- a/lib/pubid/ieee/parser.rb
+++ b/lib/pubid/ieee/parser.rb
@@ -629,15 +629,19 @@ module Pubid
           (slash >> digits.as(:draft_version)).as(:digit_draft).maybe >>
           # FDIS and other ISO stage codes without D prefix (Pattern 3)
           fdraft.maybe >>
-          # Enhanced: Accept both comma and space before month/year
-          ((comma | space) >> month_name.as(:month) >> space >> year_digits.as(:year)).maybe >>
+          # Trailing "Month YYYY" print/reaffirm date. Captured under distinct
+          # keys so it never collides with the base -YYYY identity year (a
+          # collision made Parslet drop the base year and warn "Duplicate
+          # subtrees … keys: [:year]"). The builder promotes it to the identity
+          # only when there is no base year.
+          ((comma | space) >> month_name.as(:trailing_month) >> space >> year_digits.as(:trailing_year)).maybe >>
           corrigendum.maybe >>
           draft.maybe >>
           # Revision trails the draft (before any date), matching normalization's
           # ".../D<n>/R-<x>" repositioning of "P802.16Rev2/D3 Feb 2008".
           revision_suffix.maybe >>
           # ALSO accept month/year after draft (some patterns like /DX, Month YEAR)
-          ((comma | space) >> month_name.as(:month) >> space >> year_digits.as(:year)).maybe >>
+          ((comma | space) >> month_name.as(:trailing_month) >> space >> year_digits.as(:trailing_year)).maybe >>
           parenthetical.maybe
       end
 
@@ -647,15 +651,16 @@ module Pubid
           str("P") >> space.maybe >> # Make space after P optional
           number >>
           (part_subpart_year | edition).maybe >>
-          # Enhanced: Accept both comma and space before month/year
-          ((comma | space) >> month_name.as(:month) >> space >> year_digits.as(:year)).maybe >>
+          # Trailing "Month YYYY"/bare-year date under distinct keys so they
+          # never collide with the base -YYYY identity year (see ieee_p_identifier).
+          ((comma | space) >> month_name.as(:trailing_month) >> space >> year_digits.as(:trailing_year)).maybe >>
           corrigendum.maybe >>
           draft.maybe >>
           revision_suffix.maybe >>
           # ALSO accept month/year after draft
-          ((comma | space) >> month_name.as(:month) >> space >> year_digits.as(:year)).maybe >>
+          ((comma | space) >> month_name.as(:trailing_month) >> space >> year_digits.as(:trailing_year)).maybe >>
           # Accept bare year after draft: ", 2015"
-          ((comma | space) >> year_digits.as(:year)).maybe >>
+          ((comma | space) >> year_digits.as(:trailing_year)).maybe >>
           parenthetical.maybe
       end
 
@@ -666,8 +671,9 @@ module Pubid
           str("P") >>
           number >>
           (part_subpart_year | edition).maybe >>
-          # Enhanced: Accept month/year after draft number
-          (space >> month_name.as(:month) >> space >> year_digits.as(:year)).maybe >>
+          # Trailing "Month YYYY" date under distinct keys so it never collides
+          # with the base -YYYY identity year (see ieee_p_identifier).
+          (space >> month_name.as(:trailing_month) >> space >> year_digits.as(:trailing_year)).maybe >>
           draft.maybe >>
           revision_suffix.maybe >>
           parenthetical.maybe
@@ -925,8 +931,10 @@ module Pubid
           ieee_crossref.maybe >> # NEW: Add /C62.22.1-1996 cross-reference support
           draft.maybe >>
           revision_suffix.maybe >>
-          # Enhanced: Accept both comma and space before month/year
-          ((comma | space) >> month_name.as(:month) >> space >> year_digits.as(:year)).maybe >>
+          # Trailing "Month YYYY" print/reaffirm date under distinct keys so it
+          # never collides with the base -YYYY identity year (see
+          # ieee_p_identifier). The builder promotes it only when no base year.
+          ((comma | space) >> month_name.as(:trailing_month) >> space >> year_digits.as(:trailing_year)).maybe >>
           edition.maybe >>
           parenthetical.maybe >>  # REVERT: Back to single parenthetical
           book_nickname.maybe >>  # NEW: Add book nickname support

--- a/spec/pubid/ieee/duplicate_year_capture_spec.rb
+++ b/spec/pubid/ieee/duplicate_year_capture_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Several IEEE grammar rules carried a base "-YYYY" clause AND a separate
+# trailing "Month YYYY" clause, both of which captured :year. When an input
+# satisfied both (e.g. "IEEE Std 802.11-2007 September 2009"), Parslet merged
+# the sequence hash, found two :year keys, warned "Duplicate subtrees … keys:
+# [:year]", and kept only the LATTER — silently dropping the base identity year.
+#
+# Per IEEE practice the base "-YYYY" is the IEEE-SA Standards Board approval
+# year (the document identity), so it must win; a trailing "Month YYYY" is a
+# reaffirm/reprint/crawl artifact pubid has no model for and is dropped when a
+# base year is present, and promoted to the identity only when there is none.
+# The trailing captures now use distinct keys (:trailing_month/:trailing_year),
+# so the collision — and the warning — are gone.
+# (hand-off: ieee-identifier-duplicate-year-capture.)
+# Any month name that must NOT survive on a base-year render.
+DUP_YEAR_MONTHS = %w[September May February June].freeze
+
+# One representative per affected rule (generic Std branch, IEEE P, ANSI P,
+# Draft P); each pairs a base "-YYYY" with a trailing month/year.
+DUP_YEAR_BASE_CASES = {
+  "IEEE Std 802.11-2007 September 2009" => "2007",
+  "IEEE Std 519-1992, May 1993" => "1992",
+  "IEEE P90003-2014, February 2015" => "2014",
+  "ANSI P1234-2015, June 2016" => "2015",
+  "IEEE Draft P802.11-2010 September 2011" => "2010",
+}.freeze
+
+RSpec.describe "IEEE duplicate :year capture" do
+  subject(:klass) { Pubid::Ieee::Identifier }
+
+  describe "base year wins, trailing date dropped (no warning)" do
+    DUP_YEAR_BASE_CASES.each do |ref, expected_year|
+      context ref.inspect do
+        it "parses without the Parslet duplicate-subtree warning" do
+          expect { klass.parse(ref) }
+            .not_to output(/Duplicate subtrees/).to_stderr
+        end
+
+        it "keeps the base year #{expected_year}, drops the trailing date" do
+          id = klass.parse(ref)
+          expect(id.year).to eq(expected_year)
+          expect(id.to_s).to include("-#{expected_year}")
+          # No fabricated trailing month survives on the rendered form.
+          DUP_YEAR_MONTHS.each { |m| expect(id.to_s).not_to include(m) }
+        end
+      end
+    end
+  end
+
+  describe "no base year: trailing month/year is promoted to the identity" do
+    {
+      "IEEE Std 519, May 1993" => %w[1993 May],
+      "IEEE 802.16, September 2011" => %w[2011 September],
+    }.each do |ref, (year, month)|
+      context ref.inspect do
+        it "promotes the trailing date and still emits no warning" do
+          expect { klass.parse(ref) }
+            .not_to output(/Duplicate subtrees/).to_stderr
+          id = klass.parse(ref)
+          expect(id.year).to eq(year)
+          expect(id.month).to eq(month)
+        end
+      end
+    end
+  end
+
+  it "leaves a plain base-year id unchanged" do
+    id = klass.parse("IEEE Std 528-2019")
+    expect(id.year).to eq("2019")
+    expect(id.month).to be_nil
+    expect(id.to_s).to eq("IEEE Std 528-2019")
+  end
+end


### PR DESCRIPTION
## Problem

During the `relaton-data-ieee` crawl, pubid's IEEE parser floods stderr with:

```
Duplicate subtrees while merging result of IDENTIFIER
only the values of the latter will be kept. (keys: [:year])
```

**Root cause:** four grammar rules in `lib/pubid/ieee/parser.rb` pair a base `-YYYY`
clause (`(part_subpart_year | edition).maybe`, which captures `:year`) with a
*separate* trailing `((comma|space) >> month.as(:month) >> space >> year.as(:year)).maybe`
clause that also captures `:year`. When an input satisfies both (e.g.
`IEEE Std 802.11-2007 September 2009`), Parslet merges the sequence hash, finds two
`:year` keys, warns, and keeps only the **latter** — so the **base identity year is
silently dropped** (`802.11-2007` renders as `IEEE Std 802.11, September 2009`).

Affected rules: root `identifier`, `ieee_p_identifier`, `ansi_p_identifier`,
`ieee_draft_p_identifier`. (`joint_development_*`, the nested `draft`/`reaffirmed`/
`parenthetical` subtrees, and the base numeric date were never affected.)

## Fix (base year wins)

Per IEEE practice the base `-YYYY` is the IEEE-SA Standards Board **approval year** —
the document identity — so it must win; a trailing "Month YYYY" is a reaffirm/reprint/
crawl artifact with no slot in the designation grammar (fabricating "September 2007"
by pairing the trailing month with the base year would invent a date that never
existed).

- **`parser.rb`** — rename the 7 trailing captures to `:trailing_month`/`:trailing_year`
  so they never collide with the base `:year`.
- **`builder.rb`** — `build_single_identifier` promotes the trailing date to the
  identity **only when there is no base year** (e.g. `IEEE Std 519, May 1993` is
  unchanged); when a base year exists the trailing date is dropped (documented, not
  silent).

```
IEEE Std 802.11-2007 September 2009  ->  IEEE Std 802.11-2007   (year 2007, no warning)
IEEE Std 519, May 1993               ->  IEEE Std 519, May 1993 (unchanged, promoted)
```

No model / `to_hash` / index change — index-v2 was never affected (0/12 359 indexed
docids warned); this only cleans up the discarded candidate parses during the crawl.

## Verification

- New `spec/pubid/ieee/duplicate_year_capture_spec.rb` (13 examples) asserts **no
  Parslet warning** and the base year is retained across all four rules, plus the
  no-base-year promotion path.
- Full `bundle exec rake test:all`: **10 633 examples, 0 failures** (the multi-flavor
  `number`/`root.number` determinism guard — this change touches neither).
- Fixture round-trip delta: exactly **−1 of 8 812**
  (`IEEE P90003-2014, February 2015` → `IEEE P90003-2014`) — the canonical bug case
  itself; all floor thresholds still pass.