### PR TITLE
fix(ieee): stop edition year double-capturing :year (Parslet "Duplicate subtrees")

### DIFF
--- a/lib/pubid/ieee/builder.rb
+++ b/lib/pubid/ieee/builder.rb
@@ -582,8 +582,14 @@ module Pubid
         attributes[:code] = code_str
 
         # Extract year (and optional numeric month, e.g. the -MM of a historical
-        # "…-2018-05" ISO-stage date)
-        attributes[:year] = extract_value(parsed[:year]) if parsed[:year]
+        # "…-2018-05" ISO-stage date). The joint ISO/IEC rules also use the
+        # `edition` rule, whose year is captured as :edition_year (parser.rb);
+        # it is promoted to the identity only when no base :year was captured.
+        if parsed[:year]
+          attributes[:year] = extract_value(parsed[:year])
+        elsif parsed[:edition_year]
+          attributes[:year] = extract_value(parsed[:edition_year])
+        end
         attributes[:month] = extract_value(parsed[:month]) if parsed[:month]
 
         # Extract edition, from relaton's "/E-<n>" suffix (normalized to
@@ -927,6 +933,14 @@ module Pubid
         if parsed[:year]
           year_str = extract_value(parsed[:year])
           attributes[:year] = year_str
+        elsif parsed[:edition_year]
+          # The `edition` rule captures its own year under :edition_year (not
+          # :year) so it never collides with the base -YYYY (see parser.rb).
+          # With no base year the edition's year IS the document date and is
+          # promoted to the identity (e.g. "IEEE Std 802.11 Edition 3.0-2009"
+          # -> year 2009). When a base year exists it wins above and
+          # :edition_year is dropped — the edition ordinal is still kept.
+          attributes[:year] = extract_value(parsed[:edition_year])
         elsif parsed[:trailing_year]
           # No base -YYYY identity year: the trailing "Month YYYY" IS the
           # document date (e.g. "IEEE Std 519, May 1993"), so promote it.

--- a/lib/pubid/ieee/parser.rb
+++ b/lib/pubid/ieee/parser.rb
@@ -285,15 +285,23 @@ module Pubid
       end
 
       # Edition - enhanced to support IEC formats like "Edition 1.0 2015-03"
+      #
+      # The edition's own year is captured as :edition_year (NOT :year). The
+      # generic Std branch carries a base "-YYYY" slot AND a separate trailing
+      # `edition.maybe`; a bare :year here would collide with the base :year
+      # when both fire, so Parslet warns "Duplicate subtrees … keys: [:year]"
+      # and drops the base identity year (the same failure #299 fixed for the
+      # trailing month/year clause). The builder promotes :edition_year to the
+      # identity year only when there is no base year.
       rule(:edition) do
-        (comma >> year_digits.as(:year) >> str(" Edition")) |
+        (comma >> year_digits.as(:edition_year) >> str(" Edition")) |
           ((space | dash) >> str("Edition ") >>
            (digits >> dot >> digits).as(:edition) >>
            # Year separator: a space, " - ", or a bare dash (preprocessing
            # rewrites "Edition 3.0 2016" -> "Edition 3.0-2016", the shape the
            # normalized "/E-<n>-YYYY" suffix produces — nil-residue item 1).
            (str(" - ") | space | dash) >>
-           year_digits.as(:year) >>
+           year_digits.as(:edition_year) >>
            (dash >> digit.repeat(2, 2).as(:edition_month)).maybe) # Capture -MM as edition_month
       end
 

--- a/spec/pubid/ieee/duplicate_year_capture_spec.rb
+++ b/spec/pubid/ieee/duplicate_year_capture_spec.rb
@@ -73,4 +73,47 @@ RSpec.describe "IEEE duplicate :year capture" do
     expect(id.month).to be_nil
     expect(id.to_s).to eq("IEEE Std 528-2019")
   end
+
+  # The `edition` rule ALSO exposes a top-level :year (the edition's own year),
+  # and the generic Std branch has a base-year slot AND a separate trailing
+  # `edition.maybe`. A base "-YYYY" plus a trailing "Edition X.Y[-YYYY]" then
+  # produced the same :year collision #299 fixed for the trailing month/year —
+  # Parslet warned and dropped the base identity year. The edition's year now
+  # uses a distinct :edition_year key; the base "-YYYY" wins, and the edition
+  # year is promoted to the identity only when there is no base year.
+  # (hand-off: ieee-identifier-duplicate-year-capture — edition variant.)
+  describe "base year vs. trailing edition year (no warning)" do
+    it "keeps the base year and drops the edition year, without warning" do
+      ref = "IEEE Std 802.11-2007 Edition 3.0-2009"
+      expect { klass.parse(ref) }
+        .not_to output(/Duplicate subtrees/).to_stderr
+      id = klass.parse(ref)
+      expect(id.year).to eq("2007")
+      expect(id.edition).to eq("3.0")
+      # The base identity year is preserved; the edition's year (2009) is
+      # dropped (base year wins, as in #299). The rendered form carries 2007,
+      # never the dropped 2009.
+      expect(id.to_s).to include("2007")
+      expect(id.to_s).not_to include("2009")
+    end
+  end
+
+  describe "edition-only forms keep the edition year (unchanged)" do
+    {
+      "IEEE Std 802.11 Edition 3.0-2009" => ["2009", "3.0", nil],
+      "IEEE P802.11 Edition 3.0-2009" => ["2009", "3.0", nil],
+      "IEEE Std 802.11 Edition 3.0 2015-03" => ["2015", "3.0", "03"],
+    }.each do |ref, (year, edition, edition_month)|
+      context ref.inspect do
+        it "promotes the edition year to the identity and emits no warning" do
+          expect { klass.parse(ref) }
+            .not_to output(/Duplicate subtrees/).to_stderr
+          id = klass.parse(ref)
+          expect(id.year).to eq(year)
+          expect(id.edition).to eq(edition)
+          expect(id.edition_month).to eq(edition_month)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Parsing certain IEEE identifiers still emitted the Parslet warning (flooding the relaton-data-ieee crawl stderr and silently dropping the base identity year):

```
Duplicate subtrees while merging result of
  IDENTIFIER
only the values of the latter will be kept. (keys: [:year])
```

This is a **remaining case** of the bug class #299 fixed. #299 renamed the *trailing month/year* captures to `:trailing_*`, but the `edition` rule **also** exposed a top-level `:year`, and the generic Std branch carries a base-year slot (`part_subpart_year`) **plus** a separate trailing `edition.maybe`. A base `-YYYY` followed by a trailing `Edition X.Y[-YYYY]` — the shape relaton's `/E-<n>-YYYY` normalization produces — therefore still collided:

```
IEEE Std 802.11-2007 Edition 3.0-2009
  → warns  keys: [:year]
  → base year 2007 silently DROPPED (kept 2009)
```

## Fix

Mirrors the #299 pattern:

- **parser** — `rule(:edition)` now captures its own year as `:edition_year` (not `:year`), so it never collides with the base year.
- **builder** — `:edition_year` is promoted to the identity year **only when there is no base year** (base year wins; the edition year is dropped, the edition ordinal is still kept via `:edition`). Applied in both `build_single_identifier` and `build_joint_development` (the joint ISO/IEC rules also use the `edition` rule).

After this, the generic/P/ANSI/draft sequences emit at most one top-level `:year`, so the warning is gone by construction.

| input | before | after |
|---|---|---|
| `IEEE Std 802.11-2007 Edition 3.0-2009` | warns; year=2009 (base lost) | no warn; **year=2007**, edition=3.0 |
| `IEEE Std 802.11 Edition 3.0-2009` (edition-only) | year=2009 | year=2009 (unchanged) |
| `IEEE Std 802.11 Edition 3.0 2015-03` | year=2015, edition_month=03 | unchanged |
| `IEEE P802.11 Edition 3.0-2009` | year=2009 | year=2009 (unchanged) |

## Verification

- New/extended `spec/pubid/ieee/duplicate_year_capture_spec.rb` (17 examples): collision case keeps the base year with no warning; edition-only forms unchanged.
- Full `bundle exec rake` (test:all + integration): green.
- IEEE suite: 593 examples, 0 failures.
- 0 `Duplicate subtrees` warnings across all fixtures + the 246-row unparseable-ids corpus.
- Rubocop: no new offenses on changed lines.

No model / `to_hash` / index change — the change touches neither `number` nor `stage`, so the multi-flavor determinism landmine does not apply.