### PR TITLE
fix(ieee): normalize 29 /D- corrupted draft docids via update_codes

### DIFF
--- a/data/ieee/update_codes.yaml
+++ b/data/ieee/update_codes.yaml
@@ -169,3 +169,42 @@ ISO/IEC/IEEE CD P26513/D1, August 2015: ISO/IEC/IEEE P26513/D1, August 2015
 "IEEE/ISO/IEC P42010.CD1-V1.0, April 2020": "IEEE/ISO/IEC CD1 P42010-2020-04"
 "Unapproved Draft Std ISO/IEC FDIS 15288:2007(E) IEEE P15288/D3,": "ISO/IEC/IEEE FDIS Std P15288/D-3-2007"
 "IS0/IEC/IEEE 8802-11:2012/Amd.5:2015(E) (Adoption of IEEE Std 802.11af-2014)": "ISO/IEC/IEEE 802.11/Amd5-2012"
+# `/D-` corrupted IEEE draft docids — malformed draft designations emitted by
+# relaton-ieee's RawbibIdParser fallback rendering (the `/D-`, `_CDV_`, `.pdf`,
+# `201x`, stray dots/spaces). Each maps to a canonical parseable form that
+# retains number/part/draft/stage/date in the hash (the relaton index-v2 gate
+# is the hash round-trip + non-empty root.number, not `to_s == input`).
+# Interim measure; the durable fix is upstream in RawbibIdParser. See
+# HANDOFFS/metanorma__pubid__ieee-update-codes-dashD-drafts.md.
+# --- 8 pre-verified ---
+"IEEE Approved Std P1609.3/D-23.pdf-2007-02": "IEEE Approved Std P1609.3/D23, 02 2007"
+"IEEE P3004.5/D-6.2.": "IEEE P3004.5/D6.2"
+"IEEE P730/D-0.16.-2025": "IEEE P730/D0.16-2025"
+"IEEE PC37.107/D-4.-2023-11": "IEEE PC37.107/D4, 11 2023"
+"IEEE PC37.113/D-8.0.-2015-08": "IEEE PC37.113/D8.0, 08 2015"
+"IEEE PC37.98/D-5.1D-2013": "IEEE PC37.98/D5.1D-2013"
+"IEEE PC57.637/D-6.2.-2014-03": "IEEE PC57.637/D6.2, 03 2014"
+"IEEE Std P650/D-9.-2006": "IEEE Std P650/D9-2006"
+# --- 21 derived (revision markers dropped, corrigendum reordered, joint
+#     stage+draft repositions year onto number with stage moved front) ---
+"IEC/IEEE P63198.2775/D-6.1_CDV_March-2022": "IEC/IEEE CDV P63198.2775/D6.1, March 2022"
+"IEEE 3.Rev.B/D-4.0-2023-01": "IEEE P3/D4.0, 01 2023"
+"IEEE 3.Rev.B/D-5.0-2023-03": "IEEE P3/D5.0, 03 2023"
+"IEEE P1003.1/D-5/Cor1-201x-2012-04": "IEEE P1003.1/Cor 1/D5, 04 2012"
+"IEEE P1003.1/D-5/Cor1-201x-2012-08": "IEEE P1003.1/Cor 1/D5, 08 2012"
+"IEEE P1127/D-4.1_July-2023": "IEEE P1127/D4.1, July 2023"
+"IEEE P2660_1/D-2-2020-06": "IEEE P2660.1/D2, 06 2020"
+"IEEE P802.1AE/D-1.0/R-/Cor1": "IEEE P802.1AE/Cor 1/D1.0"
+"IEEE P802.1AE_Rev/D-1.2-2018": "IEEE P802.1AE/D1.2-2018"
+"IEEE P802.1AE_Rev/D-1.3-2018": "IEEE P802.1AE/D1.3-2018"
+"IEEE Unapproved Std P802.16Rev2/D-9-2009-01": "IEEE Unapproved Std P802.16Rev2/D9-2009"
+"IEEE Unapproved Std P802.1X_REV/D-4.5-2009": "IEEE Unapproved Std P802.1X/D4.5-2009"
+"IEEE Unapproved Std PC37.91/D-8-2007-20": "IEEE Unapproved Std PC37.91/D8-2007"
+"IEEEE P1243/D-3-2023-02": "IEEE P1243/D3, 02 2023"
+"ISO/IEC/IEEE FDIS P15289./E-3/D-2-2016": "ISO/IEC/IEEE FDIS P15289-2016/D2"
+"ISO/IEC/IEEE P24641/D-2_CD-2020": "ISO/IEC/IEEE CD P24641-2020/D2"
+"ISO/IEC/IEEE P24641/D-3_CD2": "ISO/IEC/IEEE CD2 P24641/D3"
+"ISO/IEC/IEEE P24748.3/D-3_FDIS-2020": "ISO/IEC/IEEE FDIS P24748.3-2020/D3"
+"ISO/IEC/IEEE/ P12207.2/D-3_FDIS-2020": "ISO/IEC/IEEE FDIS P12207.2-2020/D3"
+"ISO/IEC/IEEE/ P24748.3/D-IS-2019": "ISO/IEC/IEEE DIS P24748.3-2019"
+"P1635/D10/ASHARE 21/D-10-2016": "IEEE P1635/D10-2016"

--- a/spec/pubid/ieee/update_codes_dashd_drafts_spec.rb
+++ b/spec/pubid/ieee/update_codes_dashd_drafts_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# `/D-` corrupted IEEE draft docids — normalized in data/ieee/update_codes.yaml.
+#
+# These malformed draft designations are emitted by relaton-ieee's
+# RawbibIdParser fallback rendering (`/D-`, `_CDV_`, `.pdf`, `201x`, stray
+# dots/spaces) and cannot be parsed directly. update_codes maps each corrupted
+# string (full-line, plain) to a canonical parseable form before parsing.
+#
+# Relaton's index-v2 gate is the *hash* round-trip plus a non-empty
+# root.number — NOT `to_s == input` — so joint ISO/IEC/IEEE draft forms that
+# render a colon `to_s` without the draft are still fine (the hash keeps
+# `ieee_draft`).
+
+# Every corrupted raw docid that should now parse + round-trip.
+IEEE_DASHD_RECOVERED = [
+  # 8 pre-verified (from the hand-off)
+  "IEEE Approved Std P1609.3/D-23.pdf-2007-02",
+  "IEEE P3004.5/D-6.2.",
+  "IEEE P730/D-0.16.-2025",
+  "IEEE PC37.107/D-4.-2023-11",
+  "IEEE PC37.113/D-8.0.-2015-08",
+  "IEEE PC37.98/D-5.1D-2013",
+  "IEEE PC57.637/D-6.2.-2014-03",
+  "IEEE Std P650/D-9.-2006",
+  # 21 derived
+  "IEC/IEEE P63198.2775/D-6.1_CDV_March-2022",
+  "IEEE 3.Rev.B/D-4.0-2023-01",
+  "IEEE 3.Rev.B/D-5.0-2023-03",
+  "IEEE P1003.1/D-5/Cor1-201x-2012-04",
+  "IEEE P1003.1/D-5/Cor1-201x-2012-08",
+  "IEEE P1127/D-4.1_July-2023",
+  "IEEE P2660_1/D-2-2020-06",
+  "IEEE P802.1AE/D-1.0/R-/Cor1",
+  "IEEE P802.1AE_Rev/D-1.2-2018",
+  "IEEE P802.1AE_Rev/D-1.3-2018",
+  "IEEE Unapproved Std P802.16Rev2/D-9-2009-01",
+  "IEEE Unapproved Std P802.1X_REV/D-4.5-2009",
+  "IEEE Unapproved Std PC37.91/D-8-2007-20",
+  "IEEEE P1243/D-3-2023-02",
+  "ISO/IEC/IEEE FDIS P15289./E-3/D-2-2016",
+  "ISO/IEC/IEEE P24641/D-2_CD-2020",
+  "ISO/IEC/IEEE P24641/D-3_CD2",
+  "ISO/IEC/IEEE P24748.3/D-3_FDIS-2020",
+  "ISO/IEC/IEEE/ P12207.2/D-3_FDIS-2020",
+  "ISO/IEC/IEEE/ P24748.3/D-IS-2019",
+  "P1635/D10/ASHARE 21/D-10-2016",
+].freeze
+
+# Genuinely broken source data — intentionally NOT mapped (documents the
+# boundary): D-- has no draft number; PSI.10 mis-parses and never round-trips.
+IEEE_DASHD_STILL_UNPARSEABLE = [
+  "IEEE P11073.10415/D--2019",
+  "IEEE PSI.10/D-1-2010-05",
+].freeze
+
+RSpec.describe "IEEE /D- corrupted draft docids — update_codes normalization" do
+  describe "recovered docids" do
+    IEEE_DASHD_RECOVERED.each do |raw|
+      context raw.inspect do
+        it "parses without raising" do
+          expect { Pubid::Ieee::Identifier.parse(raw) }.not_to raise_error
+        end
+
+        it "round-trips through to_hash / from_hash" do
+          hash = Pubid::Ieee::Identifier.parse(raw).to_hash
+          expect(Pubid::Ieee::Identifier.from_hash(hash).to_hash).to eq(hash)
+        end
+
+        it "has a non-empty root.number (relaton index key)" do
+          expect(Pubid::Ieee::Identifier.parse(raw).root.number.to_s)
+            .not_to be_empty
+        end
+      end
+    end
+  end
+
+  describe "intentionally unmapped (broken source data)" do
+    IEEE_DASHD_STILL_UNPARSEABLE.each do |raw|
+      it "#{raw.inspect} still raises" do
+        expect { Pubid::Ieee::Identifier.parse(raw) }
+          .to raise_error(Parslet::ParseFailed)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`relaton-data-ieee`'s `index-v2` build skips ~31 malformed **"`/D-` corrupted draft"** docids — draft designations emitted by relaton-ieee's `RawbibIdParser` fallback rendering (the `/D-`, `_CDV_`, `.pdf`, `201x`, stray dots/spaces) that `Pubid::Ieee::Identifier` can't parse. pubid's `update_codes` mechanism normalizes malformed inputs **before** parsing, so mapping each corrupted string to a canonical parseable form recovers it.

This adds **29** plain full-line entries to `data/ieee/update_codes.yaml` (8 pre-verified from the hand-off + 21 hand-derived), recovering those docids as parseable, round-tripping `_type: pubid:ieee:*` rows.

## What each derivation does

- Revision markers (`_REV` / `.Rev.B`) dropped (pubid strips lettered revisions anyway).
- `Cor1` reordered corrigendum-first (the parseable form).
- `201x` placeholder + bogus trailing month noise (`-20`, `-01`) dropped.
- Joint ISO/IEC/IEEE stage+draft repositioned: year onto the number, stage moved front — e.g. `ISO/IEC/IEEE FDIS P15289-2016/D2`. The colon `to_s` drops the draft, but the `ieee_draft` stays in the hash, which is the relaton gate.

Every recovered entry was verified to **parse**, **hash round-trip** (`from_hash(to_hash).to_hash == to_hash`), and have a **non-empty `root.number`** — the relaton index-v2 gate (**not** `to_s == input`).

## Intentionally skipped (2)

Genuinely broken source data, left unmapped; the spec asserts they still raise:
- `IEEE P11073.10415/D--2019` — no draft number (`D--`).
- `IEEE PSI.10/D-1-2010-05` — `PSI` prefix mis-parses, never round-trips.

## Safety

Entries are plain, full-line-anchored, `Regexp.escape`d strings (never regex), so each fires only on an exact whole-line match and cannot rewrite valid ids. The pre-existing unanchored month regexes precede the appended block, so there's no pre- or post-corruption — confirmed by analysis and by the spec exercising the real `update_codes` chain end-to-end.

## Tests

- New regression spec `spec/pubid/ieee/update_codes_dashd_drafts_spec.rb`: **89 examples, 0 failures** (parse + round-trip + `root.number` per entry, plus the 2 skip guards).
- Full `bundle exec rake`: **10780 examples, 0 failures, 1 pending** (pre-existing unrelated CSA expected-failure) + integration **191 examples, 0 failures**.
- Rubocop on the new spec: clean.

## Note

This is an **interim** measure keyed to `RawbibIdParser`'s exact output; the durable fix is upstream (`relaton__relaton-data-ieee__rawbib-draft-parsing`), which cleans the whole bucket on a re-crawl without per-string patches.