### PR TITLE
fix(iec): round-trip amendment/series/CSV URNs in canonical ABNF form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,29 @@ pubid               # Meta-gem that bundles common gems (released last)
 - **Identifier models**: Core `Identifier` class extended by each standards org
 - **Renderers**: Output formatting in `renderer/` directories (base, URN formats). Supports `annotated: true` option in `to_s` to wrap semantic components in `<span>` tags with CSS classes (defined in `Pubid::Core::Renderer::Base::SEMANTIC_CLASSES`).
 
+### IEC URN canonical form (`gems/pubid-iec`)
+
+`Pubid::Iec::Identifier#urn` emits, and `.parse` accepts, the ABNF-canonical
+IEC URN used as ground truth by `relaton-data-iec`:
+
+```
+urn:iec:std:{pub}[-{copub}][:{type}]:{number}[-{part}][,{conj}]
+    :{date}:{stage}:{deliverable}:{language}{adjuncts}[{fragment}]
+```
+
+The four positional slots after the number/part are always colon-separated
+even when empty (plain doc → `...:2007:::`). `{deliverable}` holds `csv`/`rlv`/
+`cmv`/`exv`/`ser` (or the `ed-N` edition when no deliverable — the two never
+co-occur). Amendments/corrigenda follow the language slot with a relation-
+marker: `::` normally, `:plus:` for an amendment **merged into a consolidation**
+(CSV/CMV deliverable). Corrigenda are always `::`. Order is `amd:{num}:{date}`
+(number then date), e.g. `...:1999:::::amd:1:2003` and
+`...:2010::csv::plus:amd:1:2021`. Because the parser discards the `+`/`/`
+supplement join, the `:plus:` marker is **inferred** from the deliverable in
+`Renderer::Urn#render_amendments` — do not expect a stored consolidation flag.
+Deferred (also unsupported before): typed docs with the type in the canonical
+after-date slot (`...:tr:csv:...`), ISH adjuncts, and the `ca` publisher.
+
 ### Version Synchronization
 
 Master version lives in `lib/pubid/version.rb`. All gem versions and inter-gem dependencies use exact version matching and must stay synchronized. Use `rake version:bump[patch|minor|major]` to update all gems atomically.

--- a/gems/pubid-iec/lib/pubid/iec/identifier/base.rb
+++ b/gems/pubid-iec/lib/pubid/iec/identifier/base.rb
@@ -129,7 +129,11 @@ module Pubid::Iec
 
       def normalize_urn_params!(params)
         params[:publisher] = params[:publisher].to_s.upcase
-        params[:copublisher] = params[:copublisher].to_s.upcase if params[:copublisher]
+        # copublisher may be an array (e.g. ISO/IEC/IEEE -> [iec, ieee]);
+        # upcase each element rather than the array's inspect string.
+        if params[:copublisher]
+          params[:copublisher] = Array(params[:copublisher]).map { |c| c.to_s.upcase }
+        end
         params[:type] = params[:type].to_s.upcase if params[:type]
         params[:number] = params[:number].to_s.upcase
 
@@ -142,8 +146,9 @@ module Pubid::Iec
           end
         end
 
-        # Remove amendments/corrigendums parsed as bare strings from URN
-        # (full supplement round-trip support to be added later)
+        # Canonical URN supplements parse into amendment/corrigendum objects
+        # (see ParserUrn#urn_supplements). This guard only drops any stray
+        # bare-string capture, which the canonical grammar no longer produces.
         params.delete(:amendments) if params[:amendments].is_a?(String)
         params.delete(:corrigendums) if params[:corrigendums].is_a?(String)
       end

--- a/gems/pubid-iec/lib/pubid/iec/parser_urn.rb
+++ b/gems/pubid-iec/lib/pubid/iec/parser_urn.rb
@@ -64,20 +64,28 @@ module Pubid
               (dash >> array_to_str(VAP_CODES).as(:vap)).repeat
           end
 
-          rule(:urn_edition) do
-            (str("ed-") >> digits.as(:edition)).maybe
+          # Canonical deliverable slot: a deliverable code (csv/rlv/ser/…) or,
+          # when absent, the edition (ed-N). The two never co-occur.
+          rule(:urn_slot3) do
+            (urn_vap | (str("ed-") >> digits.as(:edition))).maybe
+          end
+
+          # Canonical adjunct: relation-marker ("::" normal, ":plus:"
+          # consolidated) + kind + ":" number + optional ":" date.
+          rule(:relation_marker) do
+            str(":plus:") | str("::")
           end
 
           rule(:urn_amendment) do
-            colon >> str("amd").as(:amendments) >>
-              (colon >> (year_digits | digits).as(:number)).maybe >>
-              (colon >> str("v") >> digits.as(:iteration)).maybe
+            (relation_marker >> str("amd") >> colon >>
+              digits.as(:number) >>
+              (colon >> year_digits.as(:year)).maybe).as(:amendments)
           end
 
           rule(:urn_corrigendum) do
-            colon >> str("cor").as(:corrigendums) >>
-              (colon >> (year_digits | digits).as(:number)).maybe >>
-              (colon >> str("v") >> digits.as(:iteration)).maybe
+            (relation_marker >> str("cor") >> colon >>
+              digits.as(:number) >>
+              (colon >> year_digits.as(:year)).maybe).as(:corrigendums)
           end
 
           rule(:urn_supplements) do
@@ -92,14 +100,17 @@ module Pubid
             (array_to_str(LANGUAGES) >> (dash >> array_to_str(LANGUAGES)).repeat).as(:language)
           end
 
+          # Positional structure: pub[:type]:number[-part][,conj]
+          #   :date:stage:deliverable:language{adjuncts}[fragment]
           rule(:urn_identifier) do
             str("urn:iec:std:") >> urn_publisher_copublisher >> urn_type >>
               urn_number >> urn_part >> urn_conjuction_part >>
               (colon >> urn_year >>
-                (colon >> (urn_stage | urn_vap).maybe >>
-                  (colon >> urn_edition >>
-                    urn_supplements >> urn_fragment >>
-                    (colon >> urn_language.maybe).maybe
+                (colon >> urn_stage.maybe >>
+                  (colon >> urn_slot3 >>
+                    (colon >> urn_language.maybe >>
+                      urn_supplements >> urn_fragment
+                    ).maybe
                   ).maybe
                 ).maybe
               ).maybe

--- a/gems/pubid-iec/lib/pubid/iec/renderer/trf_urn.rb
+++ b/gems/pubid-iec/lib/pubid/iec/renderer/trf_urn.rb
@@ -2,10 +2,14 @@ module Pubid::Iec::Renderer
   class TrfUrn < Urn
 
     def render_identifier(params)
+      # Trailing ":" is the (always-empty) language slot; TRF URNs carry no
+      # language. Previously this colon came from the base #render appending
+      # ":#{lang}", which no longer runs (language is now a positional slot in
+      # the base render_identifier, which TrfUrn overrides).
       "urn:iec:std:%{publisher}%{copublisher}:trf%{trf_publisher}:%{number}"\
       "%{part}%{conjuction_part}%{year}%{vap}"\
       "%{version}%{part_version}"\
-      "%{trf_version}" % params
+      "%{trf_version}:" % params
     end
 
     def render_trf_version(trf_version, _opts, _params)

--- a/gems/pubid-iec/lib/pubid/iec/renderer/urn.rb
+++ b/gems/pubid-iec/lib/pubid/iec/renderer/urn.rb
@@ -52,22 +52,39 @@ module Pubid::Iec::Renderer
                WPUB: 95.99
     }.freeze
 
+    # Renders the ABNF-canonical IEC URN (ground truth in relaton-data-iec):
+    #
+    #   urn:iec:std:{pub}[-{copub}][:{type}]:{number}[-{part}][,{conj}]
+    #       :{date}:{stage}:{deliverable}:{language}{adjuncts}[{fragment}]
+    #
+    # The four positional slots after the number/part are always colon-
+    # separated even when empty. Amendments/corrigenda follow the language
+    # slot with a "::" (or ":plus:" for a consolidated amendment) relation-
+    # marker; see #render_amendments / #render_corrigendums.
     def render_identifier(params)
       result = "urn:iec:std:#{params[:publisher]}#{params[:copublisher]}" \
                "#{params[:type]}:#{params[:number]}" \
                "#{params[:part]}#{params[:conjuction_part]}"
 
-      # Positional fields — always colon-separated even when empty
+      # Positional slots — always colon-separated even when empty.
       result += ":#{strip_leading_colon(params[:year])}"
 
-      stage_value = [params[:stage], params[:vap], params[:urn_stage],
+      # Stage slot (deliverable/vap is no longer folded in here; it has its
+      # own canonical deliverable slot below).
+      stage_value = [params[:stage], params[:urn_stage],
                      params[:corrigendum_stage], params[:iteration],
                      params[:version], params[:part_version]].map(&:to_s).join
       result += ":#{strip_leading_colon(stage_value)}"
 
-      result += ":#{strip_leading_colon(params[:edition])}"
+      # Deliverable slot: "ser" (all parts), a deliverable code (csv/rlv/…),
+      # or the edition (ed-N) when neither is present.
+      result += ":#{deliverable_slot(params)}"
 
-      # Non-positional suffixes
+      # Language slot.
+      result += ":#{strip_leading_colon(params[:language].to_s)}"
+
+      # Adjuncts (amendments/corrigenda) with the relation-marker, then any
+      # fragment.
       result += params[:amendments].to_s
       result += params[:corrigendums].to_s
       result += params[:fragment].to_s
@@ -76,15 +93,9 @@ module Pubid::Iec::Renderer
     end
 
     def render(with_date: true, with_language_code: :iso, annotated: false, **args)
-      base = render_base_identifier(**args.merge(
+      render_base_identifier(**args.merge(
         with_date: with_date, with_language_code: with_language_code, annotated: annotated,
       ))
-      lang = strip_leading_colon(@prerendered_params[:language].to_s)
-      if @prerendered_params.key?(:all_parts)
-        "#{base}ser"
-      else
-        "#{base}:#{lang}"
-      end
     end
 
     def render_part(part, _opts, _params)
@@ -127,12 +138,26 @@ module Pubid::Iec::Renderer
       ":#{type.downcase}"
     end
 
-    def render_amendments(amendments, _opts, _params)
-      amendments&.map(&:urn)&.join || ""
+    # Amendments render as "{marker}amd:{number}[:{date}]". The marker is
+    # ":plus:" when the base is a consolidation (CSV/CMV) — the amendment is
+    # merged into the consolidated document — otherwise "::".
+    def render_amendments(amendments, _opts, params)
+      marker = consolidated_deliverable?(params) ? ":plus:" : "::"
+      Array(amendments).map do |amendment|
+        s = "#{marker}amd:#{amendment.number}"
+        s += ":#{amendment.year}" if amendment.year
+        s
+      end.join
     end
 
+    # Corrigenda always use the "::" relation-marker (they are separate
+    # corrections, never merged into a consolidation).
     def render_corrigendums(corrigendums, _opts, _params)
-      corrigendums&.map(&:urn)&.join || ""
+      Array(corrigendums).map do |corrigendum|
+        s = "::cor:#{corrigendum.number}"
+        s += ":#{corrigendum.year}" if corrigendum.year
+        s
+      end.join
     end
 
     def render_language(language, _opts, _params)
@@ -144,6 +169,33 @@ module Pubid::Iec::Renderer
     end
 
     private
+
+    # The canonical deliverable slot: "ser" for an all-parts series, else the
+    # rendered deliverable code (csv/rlv/cmv/exv/…), else the edition (ed-N).
+    # Deliverable and edition never co-occur in practice, so one slot serves
+    # both.
+    def deliverable_slot(params)
+      if present?(params[:all_parts])
+        "ser"
+      elsif present?(params[:vap])
+        strip_leading_colon(params[:vap])
+      elsif present?(params[:edition])
+        strip_leading_colon(params[:edition])
+      else
+        ""
+      end
+    end
+
+    # True when the base document is a consolidation that merges its
+    # amendments (CSV/CMV deliverable).
+    def consolidated_deliverable?(params)
+      Array(params[:vap]).map { |v| v.to_s.downcase }
+        .any? { |v| %w[csv cmv].include?(v) }
+    end
+
+    def present?(value)
+      !value.nil? && !value.to_s.empty?
+    end
 
     def strip_leading_colon(value)
       s = value.to_s

--- a/gems/pubid-iec/spec/pubid_iec/identifier/base_spec.rb
+++ b/gems/pubid-iec/spec/pubid_iec/identifier/base_spec.rb
@@ -47,7 +47,7 @@ module Pubid::Iec
 
     context "IEC 60050-351:2013/AMD1:2016" do
       let(:pubid) { "IEC 60050-351:2013/AMD1:2016" }
-      let(:urn) { "urn:iec:std:iec:60050-351:2013:::amd:2016:v1:" }
+      let(:urn) { "urn:iec:std:iec:60050-351:2013:::::amd:1:2016" }
 
       it_behaves_like "converts pubid to pubid"
       it_behaves_like "converts pubid to urn"
@@ -55,7 +55,7 @@ module Pubid::Iec
 
     context "IEC 61010-2-201:2017 RLV" do
       let(:pubid) { "IEC 61010-2-201:2017 RLV" }
-      let(:urn) { "urn:iec:std:iec:61010-2-201:2017:rlv::" }
+      let(:urn) { "urn:iec:std:iec:61010-2-201:2017::rlv:" }
 
       it_behaves_like "converts pubid to pubid"
       it_behaves_like "converts pubid to urn"
@@ -73,7 +73,7 @@ module Pubid::Iec
 
     context "IEC 61666:2010+AMD1:2021 CSV" do
       let(:pubid) { "IEC 61666:2010+AMD1:2021 CSV" }
-      let(:urn) { "urn:iec:std:iec:61666:2010:csv::amd:2021:v1:" }
+      let(:urn) { "urn:iec:std:iec:61666:2010::csv::plus:amd:1:2021" }
 
       it_behaves_like "converts pubid to pubid"
       it_behaves_like "converts pubid to urn"
@@ -81,7 +81,7 @@ module Pubid::Iec
 
     context "IEC 62439-1:2010+AMD1:2012+AMD2:2016 CSV" do
       let(:pubid) { "IEC 62439-1:2010+AMD1:2012+AMD2:2016 CSV" }
-      let(:urn) { "urn:iec:std:iec:62439-1:2010:csv::amd:2012:v1:amd:2016:v2:" }
+      let(:urn) { "urn:iec:std:iec:62439-1:2010::csv::plus:amd:1:2012:plus:amd:2:2016" }
 
       it_behaves_like "converts pubid to pubid"
       it_behaves_like "converts pubid to urn"
@@ -90,7 +90,7 @@ module Pubid::Iec
     context "IEC 60529:1989+AMD1:1999 CSV/COR2:2007" do
       let(:original) { "IEC 60529:1989+AMD1:1999 CSV/COR2:2007"}
       let(:pubid) { "IEC 60529:1989+AMD1:1999 CSV/COR2:2007"}
-      let(:urn) { "urn:iec:std:iec:60529:1989:csv::amd:1999:v1:cor:2007:v2:" }
+      let(:urn) { "urn:iec:std:iec:60529:1989::csv::plus:amd:1:1999::cor:2:2007" }
 
       it_behaves_like "converts pubid to pubid"
       it_behaves_like "converts pubid to urn"
@@ -106,7 +106,7 @@ module Pubid::Iec
 
     context "IEC 60050-102:2007/AMD1:2017 ED1" do
       let(:pubid) { "IEC 60050-102:2007/AMD1:2017 ED1" }
-      let(:urn) { "urn:iec:std:iec:60050-102:2007::ed-1:amd:2017:v1:" }
+      let(:urn) { "urn:iec:std:iec:60050-102:2007::ed-1:::amd:1:2017" }
 
       it_behaves_like "converts pubid to pubid"
       it_behaves_like "converts pubid to urn"
@@ -114,7 +114,7 @@ module Pubid::Iec
 
     context "IEC 60050-111/AMD1/FRAG1 ED2" do
       let(:pubid) { "IEC 60050-111/AMD1/FRAG1 ED2" }
-      let(:urn) { "urn:iec:std:iec:60050-111:::ed-2:amd:1:v1:frag:1:" }
+      let(:urn) { "urn:iec:std:iec:60050-111:::ed-2:::amd:1:frag:1" }
 
       it_behaves_like "converts pubid to pubid"
       it_behaves_like "converts pubid to urn"
@@ -122,7 +122,7 @@ module Pubid::Iec
 
     context "IEC CA 01:2020 CSV" do
       let(:pubid) { "IEC CA 01:2020 CSV" }
-      let(:urn) { "urn:iec:std:iec:ca:01:2020:csv::" }
+      let(:urn) { "urn:iec:std:iec:ca:01:2020::csv:" }
 
       it_behaves_like "converts pubid to pubid"
       it_behaves_like "converts pubid to urn"
@@ -498,8 +498,8 @@ module Pubid::Iec
         it_behaves_like "parses URN roundtrip"
       end
 
-      context "urn:iec:std:iec:61010-2-201:2017:rlv::" do
-        let(:urn) { "urn:iec:std:iec:61010-2-201:2017:rlv::" }
+      context "urn:iec:std:iec:61010-2-201:2017::rlv:" do
+        let(:urn) { "urn:iec:std:iec:61010-2-201:2017::rlv:" }
         it_behaves_like "parses URN roundtrip"
       end
 
@@ -508,8 +508,8 @@ module Pubid::Iec
         it_behaves_like "parses URN roundtrip"
       end
 
-      context "urn:iec:std:iec:ca:01:2020:csv::" do
-        let(:urn) { "urn:iec:std:iec:ca:01:2020:csv::" }
+      context "urn:iec:std:iec:ca:01:2020::csv:" do
+        let(:urn) { "urn:iec:std:iec:ca:01:2020::csv:" }
         it_behaves_like "parses URN roundtrip"
       end
 

--- a/gems/pubid-iec/spec/pubid_iec/urn_roundtrip_spec.rb
+++ b/gems/pubid-iec/spec/pubid_iec/urn_roundtrip_spec.rb
@@ -1,0 +1,58 @@
+module Pubid::Iec
+  # Locks the ABNF-canonical IEC URN forms used as ground truth by
+  # relaton-data-iec (see references/iec-urn-specification.adoc). Every case
+  # must satisfy the round-trip identity: parse(urn).urn == urn.
+  RSpec.describe "IEC canonical URN round-trip" do
+    # pubid string => canonical URN (verified against relaton-data-iec)
+    CANONICAL = {
+      # plain amendment: 5-colon base, "::" relation-marker, amd:NUM:DATE
+      "IEC 61966-2-1:1999/AMD1:2003" =>
+        "urn:iec:std:iec:61966-2-1:1999:::::amd:1:2003",
+      "IEC 60050-102:2007/AMD1:2017" =>
+        "urn:iec:std:iec:60050-102:2007:::::amd:1:2017",
+      "IEC 60050-351:2013/AMD1:2016" =>
+        "urn:iec:std:iec:60050-351:2013:::::amd:1:2016",
+      # consolidated (CSV): "csv" in deliverable slot, ":plus:" for amendments
+      "IEC 61666:2010+AMD1:2021 CSV" =>
+        "urn:iec:std:iec:61666:2010::csv::plus:amd:1:2021",
+      "IEC 62439-1:2010+AMD1:2012+AMD2:2016 CSV" =>
+        "urn:iec:std:iec:62439-1:2010::csv::plus:amd:1:2012:plus:amd:2:2016",
+      # CSV consolidated amendment + separate corrigendum ("::" for cor)
+      "IEC 60529:1989+AMD1:1999 CSV/COR2:2007" =>
+        "urn:iec:std:iec:60529:1989::csv::plus:amd:1:1999::cor:2:2007",
+      # redline deliverable
+      "IEC 61010-2-201:2017 RLV" =>
+        "urn:iec:std:iec:61010-2-201:2017::rlv:",
+      # plain document (unchanged, must stay canonical-compatible)
+      "IEC 60050-102:2007" =>
+        "urn:iec:std:iec:60050-102:2007:::",
+      # non-IEC publisher amendment
+      "CISPR 10:1981/AMD1:1983" =>
+        "urn:iec:std:cispr:10:1981:::::amd:1:1983",
+    }.freeze
+
+    CANONICAL.each do |pubid, urn|
+      context pubid do
+        it "renders the canonical URN" do
+          expect(Identifier.parse(pubid).urn.to_s).to eq(urn)
+        end
+
+        it "parses the canonical URN" do
+          expect { Identifier.parse(urn) }.not_to raise_error
+        end
+
+        it "round-trips (parse(urn).urn == urn)" do
+          expect(Identifier.parse(urn).urn.to_s).to eq(urn)
+        end
+      end
+    end
+
+    context "dated all-parts series URN" do
+      let(:urn) { "urn:iec:std:iec:60034:2026::ser:" }
+
+      it "parses and round-trips, keeping the date" do
+        expect(Identifier.parse(urn).urn.to_s).to eq(urn)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The released v1 `pubid-iec` mishandles IEC URNs for amendments, series, and consolidated (CSV) documents:

- **Wrong generation:** an amendment emitted the non-conformant `amd:DATE:vNUM` form — `Pubid::Iec::Identifier.parse("IEC 61966-2-1:1999/AMD1:2003").urn` → `urn:iec:std:iec:61966-2-1:1999:::amd:2003:v1:`.
- **Cannot parse canonical URNs:** the ABNF-canonical `urn:iec:std:iec:61966-2-1:1999:::::amd:1:2003` (and series/CSV) raised `ParseError`, and re-parsing the gem's *own* amendment output crashed with `NoMethodError`.

`relaton-data-iec` stores URNs in the ABNF-canonical 5-colon form (the agreed ground truth), so any downstream feeding those to `pubid-iec` got a parse failure — the root cause behind relaton/relaton-iec#73 and metanorma/metanorma-pdfa#77.

## Fix

Render and parse the canonical positional structure so `Identifier.parse(urn).urn == urn`:

```
urn:iec:std:{pub}[-{copub}][:{type}]:{number}[-{part}][,{conj}]
    :{date}:{stage}:{deliverable}:{language}{adjuncts}[{fragment}]
```

| input | canonical URN |
|---|---|
| `IEC 61966-2-1:1999/AMD1:2003` | `urn:iec:std:iec:61966-2-1:1999:::::amd:1:2003` |
| `IEC 61666:2010+AMD1:2021 CSV` | `urn:iec:std:iec:61666:2010::csv::plus:amd:1:2021` |
| `IEC 60529:1989+AMD1:1999 CSV/COR2:2007` | `urn:iec:std:iec:60529:1989::csv::plus:amd:1:1999::cor:2:2007` |
| `IEC 60034 (dated series)` | `urn:iec:std:iec:60034:2026::ser:` |

Within a consolidation, **amendments** use the `:plus:` relation-marker (merged into the CSV/CMV) and **corrigenda** use `::`. Since v1 discards the `+`/`/` supplement join, that marker is inferred from the deliverable (verified against ground truth: every `:plus:` co-occurs with csv/cmv and only precedes `amd`).

Non-adjunct URNs (plain / stage / edition / TRF) render **byte-identically** to before. Also fixes `normalize_urn_params!` upcasing the copublisher **array** via `.to_s.upcase`, which broke tri-publisher (ISO/IEC/IEEE) URN round-trips.

**⚠️ Breaking change:** `#urn` output for amendments/corrigenda/CSV changes to the canonical ground-truth form (existing `base_spec` URN expectations updated accordingly). Sanctioned by the upstream hand-off — `relaton-iec` no longer depends on `pubid-iec`'s URN generator/parser.

## Testing

- Full monorepo suite green (pubid-iec 226, core 176, iso 742, ieee 386, nist 1009, itu 107, cen/bsi + others — **0 failures**; integration 9/0).
- New `urn_roundtrip_spec.rb` locks the canonical forms.
- Validated against a 9,795-URN sample of `relaton-data-iec` (all 9,219 amd/cor/ser/csv forms): **0 crashes, 0 round-trip mismatches** (v1 previously crashed re-parsing every amendment URN).

## Deferred (all pre-existing — failed before this change too)

Typed-doc URNs with the type in the canonical after-date slot (`...:tr:csv:...`), ISH interpretation-sheet adjuncts, and the `ca` publisher. Documented in `CLAUDE.md`.