### PR TITLE
fix(iec): drop trailing colon on bare all-parts series URN (v1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,15 @@ supplement join, the `:plus:` marker is **inferred** from the deliverable in
 Deferred (also unsupported before): typed docs with the type in the canonical
 after-date slot (`...:tr:csv:...`), ISH adjuncts, and the `ca` publisher.
 
+**Bare-series exception to the always-colon rule:** a bare (undated,
+language-less, adjunct-less) all-parts series drops the trailing empty language
+slot — `urn:iec:std:iec:80000:::ser`, *not* `...:ser:` — matching the
+relaton-data-iec ground truth. A **dated** series keeps it
+(`urn:iec:std:iec:60034:2026::ser:`), as does any deliverable
+(`...:2017::rlv:`). `Renderer::Urn#bare_series?` gates this on the rendered
+deliverable value (`"ser"`), so it holds whether the series is carried as an
+`all_parts` flag or a `ser` vap.
+
 ### Version Synchronization
 
 Master version lives in `lib/pubid/version.rb`. All gem versions and inter-gem dependencies use exact version matching and must stay synchronized. Use `rake version:bump[patch|minor|major]` to update all gems atomically.

--- a/gems/pubid-iec/lib/pubid/iec/renderer/urn.rb
+++ b/gems/pubid-iec/lib/pubid/iec/renderer/urn.rb
@@ -78,10 +78,16 @@ module Pubid::Iec::Renderer
 
       # Deliverable slot: "ser" (all parts), a deliverable code (csv/rlv/…),
       # or the edition (ed-N) when neither is present.
-      result += ":#{deliverable_slot(params)}"
+      deliverable = deliverable_slot(params)
+      result += ":#{deliverable}"
 
-      # Language slot.
-      result += ":#{strip_leading_colon(params[:language].to_s)}"
+      # Language slot. A bare (undated, stage/language/adjunct-less) all-parts
+      # series omits the trailing empty language slot, matching the canonical
+      # relaton-data-iec form: urn:iec:std:iec:80000:::ser (not ...:ser:). A
+      # dated series (...:2026::ser:) or a deliverable (...::rlv:) keeps it.
+      unless bare_series?(deliverable, stage_value, params)
+        result += ":#{strip_leading_colon(params[:language].to_s)}"
+      end
 
       # Adjuncts (amendments/corrigenda) with the relation-marker, then any
       # fragment.
@@ -184,6 +190,21 @@ module Pubid::Iec::Renderer
       else
         ""
       end
+    end
+
+    # True for a bare all-parts series — deliverable "ser" with no date, stage,
+    # language or adjuncts — whose canonical URN drops the trailing language
+    # slot (urn:iec:std:iec:80000:::ser). Keyed on the rendered deliverable so
+    # it holds whether the series is carried as +all_parts+ or a +ser+ vap.
+    def bare_series?(deliverable, stage_value, params)
+      return false unless deliverable == "ser"
+      if present?(stage_value) || present?(params[:year]) ||
+          present?(params[:language])
+        return false
+      end
+
+      [params[:amendments], params[:corrigendums], params[:fragment]]
+        .all? { |adjunct| adjunct.to_s.empty? }
     end
 
     # True when the base document is a consolidation that merges its

--- a/gems/pubid-iec/spec/pubid_iec/urn_roundtrip_spec.rb
+++ b/gems/pubid-iec/spec/pubid_iec/urn_roundtrip_spec.rb
@@ -54,5 +54,28 @@ module Pubid::Iec
         expect(Identifier.parse(urn).urn.to_s).to eq(urn)
       end
     end
+
+    # A bare (undated) all-parts series is stored by relaton-data-iec without a
+    # trailing language slot: urn:iec:std:iec:80000:::ser (not ...:ser:).
+    context "bare all-parts series URN" do
+      ["urn:iec:std:iec:80000:::ser",
+       "urn:iec:std:iec:61076-7:::ser"].each do |urn|
+        context urn do
+          it "renders no trailing colon and round-trips" do
+            expect(Identifier.parse(urn).urn.to_s).to eq(urn)
+          end
+        end
+      end
+
+      # Guards that dropping the empty language slot does not swallow a
+      # legitimately-present language on a series.
+      context "urn:iec:std:iec:80000:::ser:fr" do
+        let(:urn) { "urn:iec:std:iec:80000:::ser:fr" }
+
+        it "keeps the language slot and round-trips" do
+          expect(Identifier.parse(urn).urn.to_s).to eq(urn)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

A bare all-parts series URN round-tripped with a stray trailing colon in released pubid-iec **1.15.20**:

```ruby
Pubid::Iec::Identifier.parse("urn:iec:std:iec:80000:::ser").urn
#   => "urn:iec:std:iec:80000:::ser:"   # WRONG — trailing ":"
#   expected: "urn:iec:std:iec:80000:::ser"
```

`relaton-iec` renders a `type="URN"` docidentifier by parsing the stored series URN and calling `#urn`; under 1.15.20 that produced the stray colon. This is the one case left over after the amendment/CSV URN fix (#308).

> Note: this is a **v1-only** bug — the v2 monorepo (`main`) already emits the clean form via its own `UrnGenerator#series_urn`. Hence this PR targets `v1`.

## Root cause

`gems/pubid-iec/lib/pubid/iec/renderer/urn.rb#render_identifier` always appended the trailing (empty) language slot, mirroring relaton's generic `code_to_urn`. For a bare series that yields `...:ser:`.

## Fix

Add a `bare_series?(deliverable, stage_value, params)` guard that omits the trailing language slot **only** for a bare (undated, stage/language/adjunct-less) all-parts series. It's keyed on the *rendered* deliverable value (`"ser"`), so it holds whether the series is carried as an `all_parts` flag or a `ser` vap (a URN-parsed series arrives as `vap: ["ser"]`).

Forms that legitimately keep the trailing colon are preserved:
- dated series `urn:iec:std:iec:60034:2026::ser:`
- deliverable/redline `urn:iec:std:iec:61010-2-201:2017::rlv:`
- plain/amendment `...:2007:::`, `...::amd:1:2017`
- series **with** a language `urn:iec:std:iec:80000:::ser:fr` (not swallowed)

## Tests

`spec/pubid_iec/urn_roundtrip_spec.rb` gains a "bare all-parts series URN" context: `:::ser`, subpart `61076-7:::ser`, and a `:::ser:fr` guard.

- `urn_roundtrip_spec.rb`: 31 examples, 0 failures
- Full `pubid-iec` suite: **229 examples, 0 failures**

Closes the `metanorma__pubid__iec-series-urn-trailing-colon` hand-off.