### PR TITLE
fix(ieee): parse embedded stage-last ISO form NNNNN.part.STAGE

### DIFF
--- a/lib/pubid/ieee/parser.rb
+++ b/lib/pubid/ieee/parser.rb
@@ -613,7 +613,11 @@ module Pubid
           (
             (str(":") >> year_digits.as(:year)) |
             (dash >> year_digits.as(:year) >>
-             (dash >> month_numeric.as(:month)).maybe)
+             (dash >> month_numeric.as(:month)).maybe) |
+            # Trailing text date ", April 2015" / " April 2015" (build_joint_development
+            # already reads :month/:year). No :year collision — the iso rule has no
+            # other :year capture (edition uses :edition_year).
+            ((comma | space) >> month_name.as(:month) >> space >> year_digits.as(:year))
           ).maybe >>
           # Optional /D<draft> tail. normalize_relaton_suffixes repositions the
           # historical "…/D-3-2017" onto the number as "…-2017/D3", so by the
@@ -625,6 +629,46 @@ module Pubid
           # "Edition <n>.0[ YYYY]" (nil-residue hand-off item 1).
           edition.maybe >>
           revision_suffix.maybe
+      end
+
+      # Embedded (stage-LAST) ISO-led designations: the corpus writes the ISO
+      # stage AFTER the (dotted or dashed) part —
+      #   "ISO/IEC/IEEE 29119.4.FDIS, April 2015"   (dot part .4, stage .FDIS)
+      #   "ISO/IEC/IEEE 24748-5.CD3, February 2015" (dash part -5, stage .CD3)
+      #   "IEEE P24748.5.CD3, July 2015"            (bare IEEE + P)
+      # — rather than before the number (joint_development_iso_format). Same
+      # meaning as the stage-first form: `29119.4`/`29119-4` = "29119 part 4" and
+      # the trailing `.FDIS` is the ISO stage, NOT a second part. Routes through
+      # the same build_joint_development (via :joint_publishers/:iso_stage), so the
+      # stage is modeled correctly and the numeric part stays separate.
+      rule(:joint_development_embedded_stage) do
+        # publisher set mirrors joint_development_iso_format (incl. bare IEEE);
+        # longest token first.
+        (str("ISO/IEC/IEEE") | str("IEEE/ISO/IEC") | str("IEEE/IEC/ISO") |
+         str("ISO/IEEE") | str("IEC/IEEE") | str("IEEE/IEC") | str("ISO/IEC") |
+         str("IEEE")).as(:joint_publishers) >>
+          space >>
+          str("P").maybe >> # optional project marker on the number
+          digits.as(:number) >>
+          # optional numeric part (dot or dash); must not swallow a year
+          ((dot | dash) >> year_digits.absent? >> digits.as(:part)).maybe >>
+          # the embedded stage, dot-separated, closed vocab (same as iso_stage).
+          # The (digit|letter) look-ahead keeps it at a token boundary so "CD"
+          # can't match inside a longer token and a glued no-space date
+          # (".DISMay2013") is left to fall through.
+          dot >>
+          (str("FDIS") | str("FCD") | str("CDV") |
+           (str("DIS") >> digit.maybe) |
+           (str("CD") >> digit.maybe) |
+           str("WD") | str("PWI") | str("NP")).as(:iso_stage) >>
+          (digit | match("[A-Za-z]")).absent? >>
+          # optional trailing date: :YYYY, -YYYY[-MM], or text "Month YYYY"
+          (
+            (str(":") >> year_digits.as(:year)) |
+            (dash >> year_digits.as(:year) >>
+             (dash >> month_numeric.as(:month)).maybe) |
+            ((comma | space) >> month_name.as(:month) >> space >> year_digits.as(:year))
+          ).maybe
       end
 
       # Number-first pattern: "1873-2015 IEEE Standard..."
@@ -944,6 +988,7 @@ module Pubid
           conformance_identifier | # NEW: Try conformance identifier before generic patterns
           joint_development_ieee_format |
           joint_development_iso_format |
+          joint_development_embedded_stage | # stage-LAST embedded form (before generic)
           iec_ieee_copublished |
           number_first_identifier |
           ieee_approved_draft_identifier |

--- a/spec/pubid/ieee/embedded_iso_stage_spec.rb
+++ b/spec/pubid/ieee/embedded_iso_stage_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Embedded (stage-last) ISO-led designations from relaton-data-ieee that pubid
+# could not parse: the ISO stage is written AFTER the (dotted or dashed) part —
+# `ISO/IEC/IEEE 29119.4.FDIS, April 2015` — rather than before the number
+# (`ISO/IEC/IEEE FDIS 29119.4:2015`, already handled). Same meaning:
+# `29119.4`/`29119-4` = "29119 part 4" and the trailing `.FDIS`/`.CD3` is the
+# ISO stage, NOT a second part. Both spellings unify to a JointDevelopment with a
+# proper iso_stage and the numeric part kept separate.
+#
+# The relaton index gate is the HASH round-trip (from_hash(to_hash) == to_hash)
+# plus a non-empty root.number; `to_s` may canonicalize to the stage-first form.
+# (hand-off: ieee-iso-stage-dotted-part-embedded.)
+RSpec.describe "IEEE embedded/stage-last ISO designations" do
+  subject(:klass) { Pubid::Ieee::Identifier }
+
+  describe "embedded (stage-last) form" do
+    # ref => [bare root.number, iso_stage, numeric parts]
+    {
+      # dotted part + embedded stage (the corpus form)
+      "ISO/IEC/IEEE 29119.4.FDIS, April 2015" => ["29119", "FDIS", ["4"]],
+      "ISO/IEC/IEEE 24748.5.CD3, February 2015" => ["24748", "CD3", ["5"]],
+      "IEEE P24748.5.CD3, July 2015" => ["24748", "CD3", ["5"]],
+      "ISO/IEC/IEEE 29119.1.FDIS, March 2013" => ["29119", "FDIS", ["1"]],
+      "ISO/IEC/IEEE 29119.5.CD1, April 2014" => ["29119", "CD1", ["5"]],
+      "ISO/IEC/IEEE P29119.2.DIS, December 2011" => ["29119", "DIS", ["2"]],
+      # dashed part + embedded stage (previously parsed as a Standard with the
+      # stage mislabeled as a part — now unified to the correct model)
+      "ISO/IEC/IEEE 24748-5.CD3, February 2015" => ["24748", "CD3", ["5"]],
+      # no part, just embedded stage
+      "ISO/IEC/IEEE 29119.FDIS, April 2015" => ["29119", "FDIS", []],
+    }.each do |ref, (number, stage, parts)|
+      context ref.inspect do
+        let(:id) { klass.parse(ref) }
+
+        it "parses to a JointDevelopment" do
+          expect(id).to be_a(Pubid::Ieee::Identifiers::JointDevelopment)
+        end
+
+        it "exposes a non-empty root.number" do
+          expect(id.root.number).to eq(number)
+        end
+
+        it "recognizes the trailing token as the ISO stage (not a part)" do
+          h = id.to_hash
+          expect(h["iso_stage"]).to eq(stage)
+          expect(h["parts"] || []).to eq(parts)
+        end
+
+        it "round-trips through to_hash/from_hash (the relaton index gate)" do
+          h = id.to_hash
+          expect(klass.from_hash(h).to_hash).to eq(h)
+        end
+      end
+    end
+  end
+
+  # Cause 2: the stage-FIRST rule (joint_development_iso_format) must also take
+  # a trailing ", Month Year" text date, not only `:YYYY` / `-YYYY[-MM]`.
+  describe "stage-first form with a text date" do
+    {
+      "ISO/IEC/IEEE FDIS 29119-4, April 2015" => "29119",
+      "ISO/IEC/IEEE FDIS 29119.4, April 2015" => "29119",
+    }.each do |ref, number|
+      context ref.inspect do
+        let(:id) { klass.parse(ref) }
+
+        it "parses to a JointDevelopment" do
+          expect(id).to be_a(Pubid::Ieee::Identifiers::JointDevelopment)
+        end
+
+        it "exposes a non-empty root.number" do
+          expect(id.root.number).to eq(number)
+        end
+
+        it "round-trips through to_hash/from_hash (the relaton index gate)" do
+          h = id.to_hash
+          expect(klass.from_hash(h).to_hash).to eq(h)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`relaton-data-ieee`'s `index-v2` build skips ~18 ISO/IEC/IEEE staged-draft docids where the ISO stage is embedded **after a dotted part** — e.g. `ISO/IEC/IEEE 29119.4.FDIS, April 2015`, `ISO/IEC/IEEE 24748.5.CD3, February 2015`, `IEEE P24748.5.CD3, July 2015`. (Second-largest recoverable index-v2 cluster.)

Two isolated causes:

1. **Embedded stage after a dotted part fails.** The dash form `24748-5.CD3` already parsed — but via the generic bucket as a plain `Standard` with the stage mislabeled as a part (`parts:["5","CD3"]`, `iso_stage=nil`) — a latent bug. The dot form `29119.4.FDIS` failed entirely (after `part=.4`, the uppercase `.FDIS` couldn't match the lowercase-only subpart rule).
2. **The stage-first rule rejected a `, Month Year` date** (`ISO/IEC/IEEE FDIS 29119-4, April 2015`).

## Semantics

`29119.4` and `29119-4` mean the same thing — "29119 part 4"; dot and dash are equivalent part separators. The trailing `.FDIS`/`.CD3` is an **ISO stage**, not a part. The embedded form is just the already-supported stage-first form with the stage written at the end.

## Fix (parser-only, +46 lines)

- New rule `joint_development_embedded_stage` (stage-last), registered right after `joint_development_iso_format` and before the generic bucket. It routes through the **existing** `build_joint_development` (via `:joint_publishers`/`:number`/`:part`/`:iso_stage`/`:year`/`:month`) — no builder change. Both dot and dash forms now unify to a `JointDevelopment` with a proper `iso_stage` and the numeric part kept separate.
- Added a trailing `, Month Year` text-date branch to `joint_development_iso_format` (cause 2).

Result:

```
ISO/IEC/IEEE 29119.4.FDIS, April 2015 → JointDevelopment{number:"29119", parts:["4"], iso_stage:"FDIS"}  root.number="29119"
ISO/IEC/IEEE 24748-5.CD3, February 2015 → JointDevelopment{number:"24748", parts:["5"], iso_stage:"CD3"}  root.number="24748"
```

The relaton index gate (`from_hash(to_hash) == to_hash` + non-empty `root.number`) holds for every new form.

## Behavior change (intentional)

The dash form `24748-5.CD3` moves from `Standard` (stage-as-part) to `JointDevelopment` (proper `iso_stage`) — fixing the latent mislabel. No fixture/spec locked the old output (the integration spec only checks a ≥85% parse/round-trip pass-rate).

## Tests

- New `spec/pubid/ieee/embedded_iso_stage_spec.rb` (38 examples) — asserts JointDevelopment, non-empty `root.number`, `iso_stage` set with the numeric part kept separate, and hash round-trip.
- Full `bundle exec rake` (test:all + test:integration) green; IEEE suite 762/0.
- Adversarial review verified against `main`: no precedence theft (IecIeeeCopublished / `IEEE Std …` / baseline / stage-first all byte-identical), correct boundary guard, no ReDoS, no regressions.

## Deferred (per hand-off)

No-space glued date (`.DISMay2013`), trailing `.NNNN` yyww code (`.DIS2.1504`), underscore stage delimiter (`P29119.3_FDIS-2021-06`), and the `IEEE/IEC CDV P65700.19-…` one-off.