### PR TITLE
ci: run relaton-iso downstream test against lutaml-integration (v1)

### DIFF
--- a/.github/workflows/downstream-tests.yml
+++ b/.github/workflows/downstream-tests.yml
@@ -106,6 +106,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         repository: ${{ matrix.repository.owner }}/${{ matrix.repository.repo }}
+        ref: ${{ matrix.repository.ref }}   # empty string -> checkout uses the default branch
         submodules: true
         path: dependent
 

--- a/downstream-tests.json
+++ b/downstream-tests.json
@@ -3,6 +3,7 @@
     {
       "owner": "relaton",
       "repo": "relaton-iso",
+      "ref": "lutaml-integration",
       "gemspec": "relaton_iso.gemspec",
       "description": "Test dependent gem relaton-iso"
     }


### PR DESCRIPTION
## Why

pubid's downstream compatibility job runs relaton-iso's suite against the current pubid branch. On v1 (PR #310), it fails on **one** relaton-iso example — the `NoEditionError` WARN spec — because an intended pubid change already on v1 (commit `31c73b08`, #80) makes `Pubid::Iso::Identifier.parse("ISO 1111/Amd").urn` return `urn:iso:std:iso:1111:amd` instead of raising.

That obsolete rescue + spec live **only on relaton-iso's `main`**. relaton-iso's active branch, **`lutaml-integration`**, renders the URN via `pubid.urn` directly with no `NoEditionError` rescue and is already compatible.

## What changed (2 lines, backward-compatible)

- **`downstream-tests.json`** — add `"ref": "lutaml-integration"` to the relaton-iso entry.
- **`.github/workflows/downstream-tests.yml`** — add `ref: ${{ matrix.repository.ref }}` to the **dependent** checkout. An empty `ref` makes `actions/checkout` use the repo's default branch, so any downstream entry without a `ref` is unaffected.

The `Create combined matrix` step already spreads the whole repo object into `matrix.repository`, so the new `ref` field flows through with **no matrix-code change**.

## Scope

- Only **relaton-iso** is configured as a downstream test on v1; the `ref` is per-repository and applies to relaton-iso only.
- `v1` remains the pubid branch under test — this only selects which relaton-iso branch the suite runs from.

Source: hand-off `metanorma__pubid__downstream-test-relaton-iso-lutaml-branch.md`.