### PR TITLE
get 21 missing SI-brochure-family IDs

### DIFF
--- a/lib/pubid/bipm/builder.rb
+++ b/lib/pubid/bipm/builder.rb
@@ -28,6 +28,12 @@ module Pubid
           build_metrologia(data[:metrologia])
         elsif data[:si_brochure]
           build_si_brochure(data[:si_brochure])
+        elsif data[:si_brochure_variant]
+          build_si_brochure_variant(data[:si_brochure_variant])
+        elsif data[:mep]
+          build_mep(data[:mep])
+        elsif data[:guide]
+          build_guide(data[:guide])
         else
           raise "Unrecognized BIPM parse tree: #{data.inspect}"
         end
@@ -70,6 +76,25 @@ module Pubid
           version: node[:version].to_s,
           years: node[:years].to_s,
           language: node[:language]&.to_s,
+        )
+      end
+
+      def build_si_brochure_variant(node)
+        Identifiers::SiBrochure.new(variant: node[:variant].to_s)
+      end
+
+      def build_mep(node)
+        Identifiers::Mep.new(
+          mep_code: node[:mep_code]&.to_s,
+          report_code: node[:report_code]&.to_s,
+        )
+      end
+
+      def build_guide(node)
+        Identifiers::Guide.new(
+          group: node[:group].to_s,
+          guide_kind: node[:guide_kind].to_s,
+          number: node[:number].to_s,
         )
       end
     end

--- a/lib/pubid/bipm/identifier.rb
+++ b/lib/pubid/bipm/identifier.rb
@@ -6,12 +6,13 @@ module Pubid
     # point — mirrors Pubid::Jis::Identifier. Concrete identifiers under
     # Pubid::Bipm::Identifiers descend from this class.
     #
-    # BIPM has four unrelated document families (committee documents, meetings,
-    # the Metrologia journal, and the SI Brochure) with no shared numbering, so
-    # every family-specific attribute lives here as a flat, nil-defaulted
-    # attribute and is used only by the classes that need it. The canonical
-    # `to_hash` drops any attribute at its default/empty value, so an unused
-    # attribute never appears in a family's serialized hash.
+    # BIPM has several unrelated document families (committee documents,
+    # meetings, the Metrologia journal, the SI Brochure and its appendices,
+    # mises en pratique, and Consultative-Committee guides) with no shared
+    # numbering, so every family-specific attribute lives here as a flat,
+    # nil-defaulted attribute and is used only by the classes that need it. The
+    # canonical `to_hash` drops any attribute at its default/empty value, so an
+    # unused attribute never appears in a family's serialized hash.
     class Identifier < ::Pubid::Identifier
       # Committee acronyms BIPM owns (JCGM excluded — see Pubid::Jcgm).
       GROUPS = %w[
@@ -55,6 +56,13 @@ module Pubid
       attribute :edition, :string   # "9e"
       attribute :version, :string   # "v3.01"
       attribute :years, :string     # "2019/2024"
+      # SI Brochure appendix/derived variant: "Appendix 3", "Concise", "FAQ".
+      attribute :variant, :string
+      # Mise en pratique (MEP) fields.
+      attribute :mep_code, :string    # "S1", "KUPRTM"
+      attribute :report_code, :string # MEP report variant: "BIPM-2019/05"
+      # Consultative-Committee guide kind ("MeP"/"RSI"); group + number reused.
+      attribute :guide_kind, :string
 
       # Polymorphic type map for lutaml::Model key_value (de)serialization:
       # maps each subclass's polymorphic_name to its class name so a stored hash
@@ -66,6 +74,8 @@ module Pubid
         "pubid:bipm:metrologia-article" =>
           "Pubid::Bipm::Identifiers::MetrologiaArticle",
         "pubid:bipm:si-brochure" => "Pubid::Bipm::Identifiers::SiBrochure",
+        "pubid:bipm:mep" => "Pubid::Bipm::Identifiers::Mep",
+        "pubid:bipm:guide" => "Pubid::Bipm::Identifiers::Guide",
       }.freeze
 
       key_value do
@@ -82,6 +92,10 @@ module Pubid
         map "edition", to: :edition
         map "version", to: :version
         map "years", to: :years
+        map "variant", to: :variant
+        map "mep_code", to: :mep_code
+        map "report_code", to: :report_code
+        map "guide_kind", to: :guide_kind
       end
 
       # Publisher is always "BIPM". A plain constant (not a `publisher` method)

--- a/lib/pubid/bipm/identifiers.rb
+++ b/lib/pubid/bipm/identifiers.rb
@@ -5,7 +5,9 @@ module Pubid
     # Namespace for concrete BIPM identifier types.
     module Identifiers
       autoload :CommitteeDocument, "#{__dir__}/identifiers/committee_document"
+      autoload :Guide, "#{__dir__}/identifiers/guide"
       autoload :Meeting, "#{__dir__}/identifiers/meeting"
+      autoload :Mep, "#{__dir__}/identifiers/mep"
       autoload :MetrologiaArticle, "#{__dir__}/identifiers/metrologia_article"
       autoload :SiBrochure, "#{__dir__}/identifiers/si_brochure"
     end

--- a/lib/pubid/bipm/identifiers/guide.rb
+++ b/lib/pubid/bipm/identifiers/guide.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Bipm
+    module Identifiers
+      # A Consultative-Committee guideline document (realization / calibration
+      # guide). Printed from its short docnumber form, the relaton index key.
+      #
+      # Printed forms (all round-trip):
+      #   "CCL-GD-MeP-1"    metre realization guide
+      #   "CCEM-GD-RSI-1"   ampere realization guide
+      #   "CCM-GD-RSI-2"    kilogram dissemination guide
+      #
+      # Shape: <committee>-GD-<kind>-<number>, where <kind> is "MeP" (mise en
+      # pratique guide) or "RSI" (réalisation du SI guide). The committee reuses
+      # the shared `group` attribute; the trailing sequence reuses `number`.
+      class Guide < Identifier
+        def self.type
+          { key: :guide, web: :guide, title: "Guide", short: "guide" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/bipm/identifiers/mep.rb
+++ b/lib/pubid/bipm/identifiers/mep.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Pubid
+  module Bipm
+    module Identifiers
+      # A mise en pratique (MEP) of an SI base-unit definition, and the related
+      # BIPM report variant. Printed from the short docnumber form that relaton
+      # uses as the index key — NOT the long "Appendix 2 Part x" content string.
+      #
+      # Printed forms (all round-trip):
+      #   "SI MEP S1"              standard MEP code (unit letter + number)
+      #   "SI MEP KUPRTM"          alphabetic MEP code
+      #   "Rapport BIPM-2019/05"   report variant (mep_code absent, report_code set)
+      class Mep < Identifier
+        def self.type
+          { key: :mep, web: :mep, title: "Mise en pratique", short: "mep" }
+        end
+      end
+    end
+  end
+end

--- a/lib/pubid/bipm/parser.rb
+++ b/lib/pubid/bipm/parser.rb
@@ -106,6 +106,41 @@ module Pubid
           str("(") >> years >> str(", ") >> lang >> str(")")).as(:si_brochure)
       end
 
+      # --- SI Brochure appendices / derived products ---
+      # Short docnumber forms used as the relaton index key (distinct from the
+      # bespoke edition form above): an appendix, or the Concise / FAQ products.
+      rule(:brochure_variant) do
+        ((str("Appendix") >> space >> digits) | str("Concise") | str("FAQ"))
+          .as(:variant)
+      end
+      rule(:si_brochure_variant) do
+        (str("SI Brochure") >> space >> brochure_variant)
+          .as(:si_brochure_variant)
+      end
+
+      # --- Mises en pratique (MEP) ---
+      # Standard MEP code (unit letter(s) + number, or an alphabetic code), and
+      # the "Rapport BIPM-YYYY/NN" report variant. Both index off the short
+      # docnumber, not the long "Appendix 2 Part x" content string.
+      rule(:mep_code) { match["0-9A-Za-z"].repeat(1).as(:mep_code) }
+      rule(:report_code) do
+        (str("BIPM-") >> digits >> str("/") >> digits).as(:report_code)
+      end
+      rule(:mep) do
+        ((str("SI MEP") >> space >> mep_code) |
+          (str("Rapport") >> space >> report_code)).as(:mep)
+      end
+
+      # --- Consultative-Committee guides ---
+      # "<committee>-GD-<kind>-<number>", e.g. "CCL-GD-MeP-1", "CCEM-GD-RSI-1";
+      # <kind> is "MeP" (mise en pratique) or "RSI" (réalisation du SI). Reuses
+      # the shared `group` (committee) and `number` (trailing sequence).
+      rule(:guide_kind) { (str("MeP") | str("RSI")).as(:guide_kind) }
+      rule(:guide) do
+        (group >> str("-GD-") >> guide_kind >> str("-") >>
+          digits.as(:number)).as(:guide)
+      end
+
       # After a leading group token, the shape after the first space decides:
       # a digit → meeting; a type word → committee.
       rule(:group_leading) do
@@ -114,7 +149,8 @@ module Pubid
       end
 
       rule(:identifier) do
-        metrologia | si_brochure | committee_long_fr | group_leading
+        metrologia | si_brochure | si_brochure_variant | mep | guide |
+          committee_long_fr | group_leading
       end
 
       root(:identifier)

--- a/lib/pubid/bipm/renderer.rb
+++ b/lib/pubid/bipm/renderer.rb
@@ -11,6 +11,8 @@ module Pubid
         when Identifiers::Meeting then render_meeting(@id)
         when Identifiers::MetrologiaArticle then render_metrologia(@id)
         when Identifiers::SiBrochure then render_si_brochure(@id)
+        when Identifiers::Mep then render_mep(@id)
+        when Identifiers::Guide then render_guide(@id)
         else
           raise "Cannot render BIPM identifier: #{@id.class}"
         end
@@ -70,10 +72,25 @@ module Pubid
       end
 
       def render_si_brochure(id)
+        # Short appendix / derived-product form indexed by relaton.
+        return "SI Brochure #{id.variant}" if id.variant
+
         phrase = id.language == "F" ? "sur le SI " : ""
         lang = id.language ? ", #{id.language}" : ""
         "BIPM SI Brochure #{phrase}#{id.edition} #{id.version} " \
           "(#{id.years}#{lang})"
+      end
+
+      # MEP: standard "SI MEP <code>", or the "Rapport BIPM-YYYY/NN" variant.
+      def render_mep(id)
+        return "Rapport #{id.report_code}" if id.report_code
+
+        "SI MEP #{id.mep_code}"
+      end
+
+      # Consultative-Committee guide: "<committee>-GD-<kind>-<number>".
+      def render_guide(id)
+        "#{id.group}-GD-#{id.guide_kind}-#{id.number}"
       end
     end
   end

--- a/spec/fixtures/bipm/identifiers/pass/guide.txt
+++ b/spec/fixtures/bipm/identifiers/pass/guide.txt
@@ -1,0 +1,11 @@
+# BIPM Consultative-Committee guides — Pass
+# Short docnumber forms used as the relaton index key (data/guide-*.yaml).
+# Shape: <committee>-GD-<kind>-<number>, kind is MeP or RSI. One per line;
+# blank lines and # comments ignored.
+
+CCL-GD-MeP-1
+CCL-GD-MeP-2
+CCL-GD-MeP-3
+CCEM-GD-RSI-1
+CCM-GD-RSI-1
+CCM-GD-RSI-2

--- a/spec/fixtures/bipm/identifiers/pass/mep.txt
+++ b/spec/fixtures/bipm/identifiers/pass/mep.txt
@@ -1,0 +1,22 @@
+# BIPM mises en pratique (MEP) — Pass
+# Short docnumber forms used as the relaton index key (data/mep-*.yaml), not the
+# long "Appendix 2 Part x" content string. One identifier per line; blank lines
+# and # comments ignored.
+
+# --- Standard MEP codes (unit letter(s) + number) ---
+SI MEP A1
+SI MEP Cd1
+SI MEP K1
+SI MEP Kg1
+SI MEP M1
+SI MEP Mol1
+SI MEP S1
+
+# --- Alphabetic kelvin MEP codes ---
+SI MEP KUPRTM
+SI MEP KAPRT
+SI MEP KLJNT
+SI MEP KRPRT
+
+# --- Report variant ---
+Rapport BIPM-2019/05

--- a/spec/fixtures/bipm/identifiers/pass/si_brochure.txt
+++ b/spec/fixtures/bipm/identifiers/pass/si_brochure.txt
@@ -4,3 +4,9 @@
 
 BIPM SI Brochure 9e v3.01 (2019/2024, E)
 BIPM SI Brochure sur le SI 9e v3.01 (2019/2024, F)
+
+# Appendix and derived-product short docnumbers (data/sib-a3.yaml,
+# data/si-brochure-concise.yaml, data/si-brochure-faq.yaml).
+SI Brochure Appendix 3
+SI Brochure Concise
+SI Brochure FAQ

--- a/spec/pubid/bipm/serialization_spec.rb
+++ b/spec/pubid/bipm/serialization_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe "Pubid::Bipm serialization" do
     "Metrologia 51 1 128" => "pubid:bipm:metrologia-article",
     "Metrologia 1" => "pubid:bipm:metrologia-article",
     "BIPM SI Brochure 9e v3.01 (2019/2024, E)" => "pubid:bipm:si-brochure",
+    "SI Brochure Appendix 3" => "pubid:bipm:si-brochure",
+    "SI Brochure Concise" => "pubid:bipm:si-brochure",
+    "SI MEP S1" => "pubid:bipm:mep",
+    "SI MEP KUPRTM" => "pubid:bipm:mep",
+    "Rapport BIPM-2019/05" => "pubid:bipm:mep",
+    "CCL-GD-MeP-1" => "pubid:bipm:guide",
+    "CCEM-GD-RSI-1" => "pubid:bipm:guide",
   }
 
   cases.each do |ref, type_tag|


### PR DESCRIPTION
Implemented distinct identifier types in the BIPM flavor
- Identifiers::Mep → pubid:bipm:mep — SI MEP S1…SI MEP KUPRTM, plus the Rapport BIPM-2019/05 variant
- Identifiers::Guide → pubid:bipm:guide — CCL-GD-MeP-1, CCEM-GD-RSI-1, … (reuses group+number)
- extended SiBrochure with a variant → SI Brochure Appendix 3 / Concise / FAQ

across parser/builder/renderer/identifier + fixtures + serialization spec.