### PR TITLE
extend pubid to the full form

### DIFF
--- a/lib/pubid/bipm/builder.rb
+++ b/lib/pubid/bipm/builder.rb
@@ -87,6 +87,9 @@ module Pubid
         Identifiers::Mep.new(
           mep_code: node[:mep_code]&.to_s,
           report_code: node[:report_code]&.to_s,
+          appendix: node[:appendix]&.to_s,
+          annex: node[:annex]&.to_s,
+          part: node[:part]&.to_s,
         )
       end
 
@@ -95,6 +98,8 @@ module Pubid
           group: node[:group].to_s,
           guide_kind: node[:guide_kind].to_s,
           number: node[:number].to_s,
+          appendix: node[:appendix]&.to_s,
+          part: node[:part]&.to_s,
         )
       end
     end

--- a/lib/pubid/bipm/identifier.rb
+++ b/lib/pubid/bipm/identifier.rb
@@ -63,6 +63,11 @@ module Pubid
       attribute :report_code, :string # MEP report variant: "BIPM-2019/05"
       # Consultative-Committee guide kind ("MeP"/"RSI"); group + number reused.
       attribute :guide_kind, :string
+      # Full-content "Appendix N [Annex N] Part N.M" tail shared by MEP + guide
+      # primary-docidentifier forms (nil for the bare short docnumber spelling).
+      attribute :appendix, :string
+      attribute :annex, :string
+      attribute :part, :string
 
       # Polymorphic type map for lutaml::Model key_value (de)serialization:
       # maps each subclass's polymorphic_name to its class name so a stored hash
@@ -96,6 +101,9 @@ module Pubid
         map "mep_code", to: :mep_code
         map "report_code", to: :report_code
         map "guide_kind", to: :guide_kind
+        map "appendix", to: :appendix
+        map "annex", to: :annex
+        map "part", to: :part
       end
 
       # Publisher is always "BIPM". A plain constant (not a `publisher` method)

--- a/lib/pubid/bipm/parser.rb
+++ b/lib/pubid/bipm/parser.rb
@@ -107,38 +107,59 @@ module Pubid
       end
 
       # --- SI Brochure appendices / derived products ---
-      # Short docnumber forms used as the relaton index key (distinct from the
-      # bespoke edition form above): an appendix, or the Concise / FAQ products.
+      # The full primary-docidentifier content the relaton crawler indexes by,
+      # e.g. "BIPM SI Brochure Appendix 3" / "…Concise" / "…FAQ". The bare
+      # "SI Brochure Appendix 3" docnumber form is accepted too (rendered back
+      # with the "BIPM " prefix, matching the base SI Brochure record).
       rule(:brochure_variant) do
         ((str("Appendix") >> space >> digits) | str("Concise") | str("FAQ"))
           .as(:variant)
       end
       rule(:si_brochure_variant) do
-        (str("SI Brochure") >> space >> brochure_variant)
-          .as(:si_brochure_variant)
+        ((str("BIPM SI Brochure") | str("SI Brochure")) >> space >>
+          brochure_variant).as(:si_brochure_variant)
+      end
+
+      # Shared "Appendix N [Annex N] Part N[.M]" tail carried by the full
+      # docidentifier content of MEPs and CC guides (the "Appendix 2 Part 1.1"
+      # or "Appendix 2 Annex 2 Part 1" suffix on "BIPM SI MEP …" etc.).
+      rule(:appendix_part) do
+        str("Appendix") >> space >> digits.as(:appendix) >>
+          (space >> str("Annex") >> space >> digits.as(:annex)).maybe >>
+          space >> str("Part") >> space >>
+          (digits >> (str(".") >> digits).maybe).as(:part)
       end
 
       # --- Mises en pratique (MEP) ---
-      # Standard MEP code (unit letter(s) + number, or an alphabetic code), and
-      # the "Rapport BIPM-YYYY/NN" report variant. Both index off the short
-      # docnumber, not the long "Appendix 2 Part x" content string.
+      # Two index-relevant spellings: the short docnumber ("SI MEP S1",
+      # "Rapport BIPM-2019/05") and the full "BIPM …" primary-docidentifier
+      # content the crawler actually keys on ("BIPM SI MEP S1 Appendix 2 Part
+      # 1.1"). The renderer reproduces whichever the identifier carries.
       rule(:mep_code) { match["0-9A-Za-z"].repeat(1).as(:mep_code) }
       rule(:report_code) do
         (str("BIPM-") >> digits >> str("/") >> digits).as(:report_code)
       end
+      rule(:mep_body) do
+        (str("SI MEP") >> space >> mep_code) |
+          (str("Rapport") >> space >> report_code)
+      end
       rule(:mep) do
-        ((str("SI MEP") >> space >> mep_code) |
-          (str("Rapport") >> space >> report_code)).as(:mep)
+        ((str("BIPM") >> space >> mep_body >> space >> appendix_part) |
+          mep_body).as(:mep)
       end
 
       # --- Consultative-Committee guides ---
-      # "<committee>-GD-<kind>-<number>", e.g. "CCL-GD-MeP-1", "CCEM-GD-RSI-1";
-      # <kind> is "MeP" (mise en pratique) or "RSI" (réalisation du SI). Reuses
-      # the shared `group` (committee) and `number` (trailing sequence).
+      # "<committee>-GD-<kind>-<number>" (e.g. "CCL-GD-MeP-1"), and its full
+      # "BIPM … Appendix 2 Part 2.2" content form. <kind> is "MeP" (mise en
+      # pratique) or "RSI" (réalisation du SI). Reuses the shared `group`
+      # (committee) and `number` (trailing sequence).
       rule(:guide_kind) { (str("MeP") | str("RSI")).as(:guide_kind) }
+      rule(:guide_body) do
+        group >> str("-GD-") >> guide_kind >> str("-") >> digits.as(:number)
+      end
       rule(:guide) do
-        (group >> str("-GD-") >> guide_kind >> str("-") >>
-          digits.as(:number)).as(:guide)
+        ((str("BIPM") >> space >> guide_body >> space >> appendix_part) |
+          guide_body).as(:guide)
       end
 
       # After a leading group token, the shape after the first space decides:

--- a/lib/pubid/bipm/renderer.rb
+++ b/lib/pubid/bipm/renderer.rb
@@ -72,8 +72,9 @@ module Pubid
       end
 
       def render_si_brochure(id)
-        # Short appendix / derived-product form indexed by relaton.
-        return "SI Brochure #{id.variant}" if id.variant
+        # Appendix / derived-product form indexed by relaton, keyed on the full
+        # "BIPM SI Brochure …" primary docidentifier content.
+        return "BIPM SI Brochure #{id.variant}" if id.variant
 
         phrase = id.language == "F" ? "sur le SI " : ""
         lang = id.language ? ", #{id.language}" : ""
@@ -81,16 +82,28 @@ module Pubid
           "(#{id.years}#{lang})"
       end
 
-      # MEP: standard "SI MEP <code>", or the "Rapport BIPM-YYYY/NN" variant.
+      # MEP: short docnumber ("SI MEP <code>" / "Rapport BIPM-YYYY/NN"), or the
+      # full "BIPM … Appendix N [Annex N] Part N.M" content the crawler keys on.
       def render_mep(id)
-        return "Rapport #{id.report_code}" if id.report_code
-
-        "SI MEP #{id.mep_code}"
+        body = id.report_code ? "Rapport #{id.report_code}" : "SI MEP #{id.mep_code}"
+        render_full_content(id, body)
       end
 
-      # Consultative-Committee guide: "<committee>-GD-<kind>-<number>".
+      # CC guide: short "<committee>-GD-<kind>-<number>", or its full
+      # "BIPM … Appendix N Part N.M" content form.
       def render_guide(id)
-        "#{id.group}-GD-#{id.guide_kind}-#{id.number}"
+        body = "#{id.group}-GD-#{id.guide_kind}-#{id.number}"
+        render_full_content(id, body)
+      end
+
+      # Wrap a short body in the "BIPM … Appendix N [Annex N] Part N.M" content
+      # form when the identifier carries the appendix/part tail; otherwise emit
+      # the bare short body. `part` presence is what distinguishes the two.
+      def render_full_content(id, body)
+        return body unless id.part
+
+        annex = id.annex ? " Annex #{id.annex}" : ""
+        "BIPM #{body} Appendix #{id.appendix}#{annex} Part #{id.part}"
       end
     end
   end

--- a/spec/fixtures/bipm/identifiers/pass/guide.txt
+++ b/spec/fixtures/bipm/identifiers/pass/guide.txt
@@ -1,11 +1,21 @@
 # BIPM Consultative-Committee guides — Pass
-# Short docnumber forms used as the relaton index key (data/guide-*.yaml).
-# Shape: <committee>-GD-<kind>-<number>, kind is MeP or RSI. One per line;
-# blank lines and # comments ignored.
+# Two spellings, both index-relevant (data/guide-*.yaml): the short docnumber
+# "<committee>-GD-<kind>-<number>" (kind is MeP or RSI), and the full
+# "BIPM … Appendix 2 Part N.M" primary-docidentifier content the crawler keys
+# index-v2 on. One per line; blank lines and # comments ignored.
 
+# --- Short docnumber form ---
 CCL-GD-MeP-1
 CCL-GD-MeP-2
 CCL-GD-MeP-3
 CCEM-GD-RSI-1
 CCM-GD-RSI-1
 CCM-GD-RSI-2
+
+# --- Full primary-docidentifier content (the index-v2 key) ---
+BIPM CCL-GD-MeP-1 Appendix 2 Part 2.2
+BIPM CCL-GD-MeP-2 Appendix 2 Part 2.2
+BIPM CCL-GD-MeP-3 Appendix 2 Part 2.3
+BIPM CCEM-GD-RSI-1 Appendix 2 Part 4.2
+BIPM CCM-GD-RSI-1 Appendix 2 Part 3.1
+BIPM CCM-GD-RSI-2 Appendix 2 Part 3.2

--- a/spec/fixtures/bipm/identifiers/pass/mep.txt
+++ b/spec/fixtures/bipm/identifiers/pass/mep.txt
@@ -1,9 +1,10 @@
 # BIPM mises en pratique (MEP) — Pass
-# Short docnumber forms used as the relaton index key (data/mep-*.yaml), not the
-# long "Appendix 2 Part x" content string. One identifier per line; blank lines
-# and # comments ignored.
+# Two spellings, both index-relevant (data/mep-*.yaml): the short docnumber, and
+# the full "BIPM … Appendix 2 [Annex N] Part N.M" primary-docidentifier content
+# the relaton crawler actually keys index-v2 on. One identifier per line; blank
+# lines and # comments ignored.
 
-# --- Standard MEP codes (unit letter(s) + number) ---
+# --- Short docnumber form: standard MEP codes (unit letter(s) + number) ---
 SI MEP A1
 SI MEP Cd1
 SI MEP K1
@@ -12,11 +13,25 @@ SI MEP M1
 SI MEP Mol1
 SI MEP S1
 
-# --- Alphabetic kelvin MEP codes ---
+# --- Short docnumber form: alphabetic kelvin MEP codes ---
 SI MEP KUPRTM
 SI MEP KAPRT
 SI MEP KLJNT
 SI MEP KRPRT
 
-# --- Report variant ---
+# --- Short docnumber form: report variant ---
 Rapport BIPM-2019/05
+
+# --- Full primary-docidentifier content (the index-v2 key) ---
+BIPM SI MEP A1 Appendix 2 Part 4.1
+BIPM SI MEP Cd1 Appendix 2 Part 7.1
+BIPM SI MEP K1 Appendix 2 Part 5.1
+BIPM SI MEP Kg1 Appendix 2 Part 3.1
+BIPM SI MEP M1 Appendix 2 Part 2.1
+BIPM SI MEP Mol1 Appendix 2 Part 6.1
+BIPM SI MEP S1 Appendix 2 Part 1.1
+BIPM SI MEP KUPRTM Appendix 2 Annex 2 Part 1
+BIPM SI MEP KAPRT Appendix 2 Annex 1 Part 1
+BIPM SI MEP KLJNT Appendix 2 Annex 4 Part 1
+BIPM SI MEP KRPRT Appendix 2 Annex 3 Part 1
+BIPM Rapport BIPM-2019/05 Appendix 2 Part 1

--- a/spec/fixtures/bipm/identifiers/pass/si_brochure.txt
+++ b/spec/fixtures/bipm/identifiers/pass/si_brochure.txt
@@ -5,8 +5,10 @@
 BIPM SI Brochure 9e v3.01 (2019/2024, E)
 BIPM SI Brochure sur le SI 9e v3.01 (2019/2024, F)
 
-# Appendix and derived-product short docnumbers (data/sib-a3.yaml,
-# data/si-brochure-concise.yaml, data/si-brochure-faq.yaml).
-SI Brochure Appendix 3
-SI Brochure Concise
-SI Brochure FAQ
+# Appendix and derived products, keyed on the full "BIPM SI Brochure …"
+# primary-docidentifier content (data/sib-a3.yaml, data/si-brochure-concise.yaml,
+# data/si-brochure-faq.yaml). The bare "SI Brochure Appendix 3" docnumber also
+# parses but renders back with the "BIPM " prefix, so only the full form here.
+BIPM SI Brochure Appendix 3
+BIPM SI Brochure Concise
+BIPM SI Brochure FAQ

--- a/spec/pubid/bipm/serialization_spec.rb
+++ b/spec/pubid/bipm/serialization_spec.rb
@@ -18,13 +18,16 @@ RSpec.describe "Pubid::Bipm serialization" do
     "Metrologia 51 1 128" => "pubid:bipm:metrologia-article",
     "Metrologia 1" => "pubid:bipm:metrologia-article",
     "BIPM SI Brochure 9e v3.01 (2019/2024, E)" => "pubid:bipm:si-brochure",
-    "SI Brochure Appendix 3" => "pubid:bipm:si-brochure",
-    "SI Brochure Concise" => "pubid:bipm:si-brochure",
+    "BIPM SI Brochure Appendix 3" => "pubid:bipm:si-brochure",
+    "BIPM SI Brochure Concise" => "pubid:bipm:si-brochure",
     "SI MEP S1" => "pubid:bipm:mep",
-    "SI MEP KUPRTM" => "pubid:bipm:mep",
     "Rapport BIPM-2019/05" => "pubid:bipm:mep",
+    "BIPM SI MEP S1 Appendix 2 Part 1.1" => "pubid:bipm:mep",
+    "BIPM SI MEP KUPRTM Appendix 2 Annex 2 Part 1" => "pubid:bipm:mep",
+    "BIPM Rapport BIPM-2019/05 Appendix 2 Part 1" => "pubid:bipm:mep",
     "CCL-GD-MeP-1" => "pubid:bipm:guide",
-    "CCEM-GD-RSI-1" => "pubid:bipm:guide",
+    "BIPM CCL-GD-MeP-1 Appendix 2 Part 2.2" => "pubid:bipm:guide",
+    "BIPM CCEM-GD-RSI-1 Appendix 2 Part 4.2" => "pubid:bipm:guide",
   }
 
   cases.each do |ref, type_tag|


### PR DESCRIPTION
extend the Mep/Guide/SiBrochure grammar to also parse BIPM <body> Appendix N [Annex N] Part N[.M] and
BIPM SI Brochure <variant>, adding appendix/annex/part attributes. Short docnumbers still parse too.