### PR TITLE
fix(itu): render amendments as "Amd." to match ITU and the sibling types

### DIFF
--- a/lib/pubid/itu/identifiers/amendment.rb
+++ b/lib/pubid/itu/identifiers/amendment.rb
@@ -4,7 +4,7 @@ module Pubid
   module Itu
     module Identifiers
       # Amendment identifier (Amd)
-      # Pattern: "ITU-T G.989 Amd 1", "ITU-T G.780/Y.1351 Amd 1 (2004)"
+      # Pattern: "ITU-T G.989 Amd. 1", "ITU-T G.780/Y.1351 Amd. 1 (2004)"
       class Amendment < Supplement
         def to_s
           result = base ? base.to_s : "#{publisher}-#{sector}"
@@ -14,7 +14,12 @@ module Pubid
             result += " #{series}"
           end
 
-          result += " Amd #{number}"
+          # "Amd." with the period, matching ITU's own rendering and the
+          # sibling supplement types (Cor./Err./Suppl.). The parser accepts
+          # both spellings (see Parser#supplement_type), so the period-less
+          # input form still round-trips through parse — it just normalizes
+          # to the canonical spelling here.
+          result += " Amd. #{number}"
 
           result += render_date_suffix
 

--- a/lib/pubid/itu/model.rb
+++ b/lib/pubid/itu/model.rb
@@ -86,7 +86,7 @@ module Pubid
 
         # Add amendment
         if amendment
-          parts << "Amd #{amendment}"
+          parts << "Amd. #{amendment}"
         end
 
         # Add corrigendum

--- a/spec/pubid/itu/identifiers/amendment_spec.rb
+++ b/spec/pubid/itu/identifiers/amendment_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Pubid::Itu::Identifiers::Amendment do
         expect(parsed.number).to eq("1")
       end
 
-      it "round-trips" do
-        expect(parsed.to_s).to eq(subject)
+      it "normalizes 'Amd' to the canonical 'Amd.'" do
+        expect(parsed.to_s).to eq("ITU-T G.989 Amd. 1")
       end
     end
 
@@ -44,15 +44,15 @@ RSpec.describe Pubid::Itu::Identifiers::Amendment do
         expect(parsed).to be_a(described_class)
       end
 
-      it "normalizes 'Amd.' to 'Amd'" do
-        expect(parsed.to_s).to eq("ITU-T G.989 Amd 1")
+      it "round-trips" do
+        expect(parsed.to_s).to eq(subject)
       end
     end
   end
 
   describe "amendment with dates" do
-    context "ITU-T G.780/Y.1351 Amd 1 (2004)" do
-      subject { "ITU-T G.780/Y.1351 Amd 1 (2004)" }
+    context "ITU-T G.780/Y.1351 Amd. 1 (2004)" do
+      subject { "ITU-T G.780/Y.1351 Amd. 1 (2004)" }
 
       let(:parsed) { Pubid::Itu.parse(subject) }
 
@@ -81,8 +81,8 @@ RSpec.describe Pubid::Itu::Identifiers::Amendment do
       end
     end
 
-    context "ITU-T G.989 Amd 2 (06/2018)" do
-      subject { "ITU-T G.989 Amd 2 (06/2018)" }
+    context "ITU-T G.989 Amd. 2 (06/2018)" do
+      subject { "ITU-T G.989 Amd. 2 (06/2018)" }
 
       let(:parsed) { Pubid::Itu.parse(subject) }
 
@@ -99,8 +99,8 @@ RSpec.describe Pubid::Itu::Identifiers::Amendment do
       end
     end
 
-    context "ITU-T M.3016.1 Amd 1 (2020)" do
-      subject { "ITU-T M.3016.1 Amd 1 (2020)" }
+    context "ITU-T M.3016.1 Amd. 1 (2020)" do
+      subject { "ITU-T M.3016.1 Amd. 1 (2020)" }
 
       let(:parsed) { Pubid::Itu.parse(subject) }
 
@@ -123,8 +123,8 @@ RSpec.describe Pubid::Itu::Identifiers::Amendment do
   end
 
   describe "ITU-R amendments" do
-    context "ITU-R V.574-5 Amd 1" do
-      subject { "ITU-R V.574-5 Amd 1" }
+    context "ITU-R V.574-5 Amd. 1" do
+      subject { "ITU-R V.574-5 Amd. 1" }
 
       let(:parsed) { Pubid::Itu.parse(subject) }
 
@@ -150,8 +150,8 @@ RSpec.describe Pubid::Itu::Identifiers::Amendment do
       end
     end
 
-    context "ITU-R SA.364-6 Amd 2 (2015)" do
-      subject { "ITU-R SA.364-6 Amd 2 (2015)" }
+    context "ITU-R SA.364-6 Amd. 2 (2015)" do
+      subject { "ITU-R SA.364-6 Amd. 2 (2015)" }
 
       let(:parsed) { Pubid::Itu.parse(subject) }
 
@@ -174,8 +174,8 @@ RSpec.describe Pubid::Itu::Identifiers::Amendment do
   end
 
   describe "multi-digit amendment numbers" do
-    context "ITU-T G.989 Amd 10" do
-      subject { "ITU-T G.989 Amd 10" }
+    context "ITU-T G.989 Amd. 10" do
+      subject { "ITU-T G.989 Amd. 10" }
 
       let(:parsed) { Pubid::Itu.parse(subject) }
 
@@ -188,8 +188,8 @@ RSpec.describe Pubid::Itu::Identifiers::Amendment do
       end
     end
 
-    context "ITU-T G.780 Amd 25 (2019)" do
-      subject { "ITU-T G.780 Amd 25 (2019)" }
+    context "ITU-T G.780 Amd. 25 (2019)" do
+      subject { "ITU-T G.780 Amd. 25 (2019)" }
 
       let(:parsed) { Pubid::Itu.parse(subject) }
 

--- a/spec/pubid/itu/identifiers/annex_of_recommendation_spec.rb
+++ b/spec/pubid/itu/identifiers/annex_of_recommendation_spec.rb
@@ -154,6 +154,7 @@ RSpec.describe Pubid::Itu::Identifiers::AnnexOfRecommendation do
       expect(parsed.number).to eq("1")
       expect(parsed.base).to be_a(described_class)
       expect(parsed.base.number).to eq("B")
+      expect(parsed.to_s).to eq("ITU-T J.112 Annex B (2001) Amd. 1 (02/2002)")
     end
 
     it "round-trips a corrigendum of an annex through to_hash/from_hash" do

--- a/spec/pubid/itu/identifiers/combined_identifier_spec.rb
+++ b/spec/pubid/itu/identifiers/combined_identifier_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Pubid::Itu::Identifiers::CombinedIdentifier do
   describe "as a supplement base" do
     # A supplement/amendment can wrap a combined recommendation; the nested
     # base must serialize (and round-trip) in its flat combined shape.
-    subject { "ITU-T G.780/Y.1351 Amd 1" }
+    subject { "ITU-T G.780/Y.1351 Amd. 1" }
 
     let(:parsed) { Pubid::Itu.parse(subject) }
 

--- a/spec/pubid/itu/identifiers/errata_spec.rb
+++ b/spec/pubid/itu/identifiers/errata_spec.rb
@@ -60,9 +60,7 @@ RSpec.describe Pubid::Itu::Identifiers::Errata do
   end
 
   describe "errata on another supplement (chained) — issue #230" do
-    # Errata on an Amendment. The Amendment base has its own pre-existing
-    # rendering convention of "Amd" without the period (see Amendment#to_s),
-    # so the chained round-trip yields "Amd 3" not "Amd. 3".
+    # Errata on an Amendment.
     context "ITU-T G.9701 (2014) Amd. 3 Err. 1 (12/2017)" do
       let(:parsed) { Pubid::Itu.parse("ITU-T G.9701 (2014) Amd. 3 Err. 1 (12/2017)") }
 
@@ -85,8 +83,8 @@ RSpec.describe Pubid::Itu::Identifiers::Errata do
         expect(parsed.date.month).to eq("12")
       end
 
-      it "round-trips with the Amendment's period-less rendering" do
-        expect(parsed.to_s).to eq("ITU-T G.9701 (2014) Amd 3 Err. 1 (12/2017)")
+      it "round-trips" do
+        expect(parsed.to_s).to eq("ITU-T G.9701 (2014) Amd. 3 Err. 1 (12/2017)")
       end
     end
 

--- a/spec/pubid/itu/serialization_spec.rb
+++ b/spec/pubid/itu/serialization_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Pubid::Itu compact flat serialization" do
     "combined/dual" => "ITU-R SA.1745/RS.1745",
     "combined/triple" => "ITU-T G.780/Y.1351/Z.1362",
     "supplement" => "ITU-T E.156 Suppl. 2",
-    "amendment" => "ITU-T G.989 Amd 1",
+    "amendment" => "ITU-T G.989 Amd. 1",
     "corrigendum" => "ITU-T Z.100 (1999) Cor. 1 (10/2001)",
     "errata" => "ITU-T G.9701 (2014) Err. 1 (07/2016)",
     "annex" => "Annex to ITU OB No. 1000",


### PR DESCRIPTION
## Problem

`Identifiers::Amendment#to_s` is the only supplement type that renders without a period:

| class | rendered |
|---|---|
| `Amendment` | ` Amd 1` |
| `Corrigendum` | ` Cor. 1` |
| `Errata` | ` Err. 1` |
| `Supplement` | ` Suppl. 1` |

ITU writes the period as well, so an id parsed from an ITU record came back spelled differently than it went in. In `relaton-data-itu` that is 1426 records whose `docidentifier` reads `ITU-T G.989.2 (2014) Amd. 1 (04/2016)` while the index row built from that same id renders `… Amd 1 …` — consumers comparing the record against the row they searched with disagree, and `relaton`'s `spec/itu/relaton/itu_spec.rb` carries a comment about exactly this.

## Change

`Amendment#to_s` renders `Amd.`. Parsing is untouched: `Parser#supplement_type` still accepts both spellings and `Builder` strips the period before dispatching on the type, so `ITU-T G.989 Amd 1` still parses — it now normalizes *to* the canonical `Amd. 1` rather than away from it. `Model#to_s` gets the same treatment, matching its own `Suppl.`/`Cor.`/`Add.`/`App.` rendering.

The specs that locked the period-less form are inverted accordingly, and the annex-of-recommendation example that parses `ITU-T J.112 Annex B (2001) Amd. 1 (02/2002)` can now assert its full round-trip — it was the one sibling of the `Err.` example without a `to_s` assertion, because the mismatch made it impossible.

## Testing

`spec/pubid/itu` — 533 examples, 0 failures. Full suite — 11,276 examples; the only failures are the four wall-clock thresholds in `spec/pubid/iso/performance_spec.rb`, which pass on their own and fail only when the machine is running other suites concurrently.