### PR TITLE
fix(ieee): attach trademark symbol to the document number (v1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,44 @@ relaton-data-iec ground truth. A **dated** series keeps it
 deliverable value (`"ser"`), so it holds whether the series is carried as an
 `all_parts` flag or a `ser` vap.
 
+### IEEE trademark position (`gems/pubid-ieee`)
+
+`to_s(with_trademark: true)` attaches the mark to the **document number**, not
+to the end of the rendered string: IEEE prints `IEEE Std 1619™-2007`,
+`IEEE Std 802.3®-2018` — the symbol sits after the number (and its
+part/subpart) and **before** the stage, year, edition, corrigendum, draft,
+month and ` - Redline`. It is therefore rendered from a `%{trademark}` slot in
+all three `Renderer::Base#render_identifier` templates, fed by
+`Identifier::Base#to_s`, rather than concatenated to the finished string.
+Plain `to_s` is unchanged (default off) — the slot renders `""` when the key
+is absent, via the `@prerendered_params.default = ""` mechanism every other
+optional slot already uses.
+
+`#trademark(number)` picks ® for `REGISTERED_SERIES = %w[802 8802 2030]` with
+any leading project `P` stripped, so `IEEE P802.1AE/D1.0`, `ANSI/IEEE 802.9a`
+and the ISO/IEC co-published `8802` series all get ® (the old list was
+`%w(802 2030)` compared verbatim). The number alone is not enough, though: the
+registered mark is **IEEE's**, so it is claimed only when `IEEE` appears among
+the printed publishers (`[@publisher, *@copublisher]`, each split on `/`) —
+otherwise `AIEE Std No. 802` and `ANSI 802.1-1985` would assert an IEEE mark on
+documents that are not part of that series (AIEE dissolved in 1963, two decades
+before IEEE 802 existed). `ISO_ADOPTED_SERIES = "8802"` is the one escape: it
+*is* the ISO/IEC adoption of IEEE 802, so its number alone decides.
+
+Two forms have no IEEE number of their own. An ISO-led co-publication carries
+its IEEE designation in the parenthesised `alternative`, so `render_alternative`
+propagates `with_trademark` into that nested identifier (`ISO/IEC 8802-3:2021
+(IEEE Std 802.3®-2021)`); each alternative is marked, as IEEE prints co-equal
+designations. A purely ISO-routed form — one whose whole identity lives in
+`iso_identifier`, e.g. `ISO/IEC/IEEE 8802-11:2012/Amd.1:2013(E)` or
+`IEC 61588:2009(E)` — has no IEEE number to attach the mark to and keeps the
+trailing mark, guarded by `#marks_a_number?`, so the mark is never silently
+lost. Note `ISO/IEC/IEEE 8802-11:2012` (no supplement) does *not* take that
+branch: it parses with `number == "8802"` and marks inline. The trailing
+fallback still picks its symbol from a number — `#fallback_number` walks the
+ISO identifier's `base` chain, because a supplement's own `number` is its
+ordinal ("1"), not the document series.
+
 ### Version Synchronization
 
 Master version lives in `lib/pubid/version.rb`. All gem versions and inter-gem dependencies use exact version matching and must stay synchronized. Use `rake version:bump[patch|minor|major]` to update all gems atomically.

--- a/gems/pubid-ieee/lib/pubid/ieee/identifier/base.rb
+++ b/gems/pubid-ieee/lib/pubid/ieee/identifier/base.rb
@@ -143,16 +143,68 @@ module Pubid::Ieee
         Identifier.create(**identifier_params)
       end
 
+      # IEEE series carrying a registered trademark ("\u00AE"); everything else
+      # takes the unregistered mark ("\u2122"). 8802 is the ISO/IEC co-published
+      # form of the 802 series, and a project number keeps its series identity,
+      # so a leading "P" is stripped before the lookup.
+      REGISTERED_SERIES = %w[802 8802 2030].freeze
+
+      # The ISO/IEC adoption of IEEE 802: the number alone identifies the
+      # series, whatever publishers are printed.
+      ISO_ADOPTED_SERIES = "8802".freeze
+
       # @param [:short, :full] format
       def to_s(format = :short, with_trademark: false, annotated: false)
         opts = { format: format, with_trademark: with_trademark, annotated: annotated }
+        params = to_h(deep: false)
+        # IEEE attaches the mark to the standard number, before the year and
+        # every suffix ("IEEE Std 1619\u2122-2007"), so it is rendered from a
+        # dedicated slot in the format templates rather than appended to the
+        # finished string. An identifier without a number of its own (an
+        # ISO-led co-publication) carries its IEEE designation in the
+        # parenthesised alternative, which is marked by the renderer instead.
+        params[:trademark] = trademark(@number) if with_trademark && @number
         (@iso_identifier ? @iso_identifier.to_s(format: :ref_num_short, with_edition: true, annotated: annotated) : "") +
-          self.class.get_renderer_class.new(to_h(deep: false)).render(**opts) +
-          (with_trademark ? trademark(@number) : "")
+          self.class.get_renderer_class.new(params).render(**opts) +
+          (with_trademark && !marks_a_number? ? trademark(fallback_number) : "")
       end
 
+      # True when the rendered string carries the mark on a number of its own:
+      # either this identifier's number, or the IEEE designation it renders as
+      # a parenthesised alternative. A form that renders neither -- an
+      # ISO-led document with no IEEE designation of its own, such as
+      # "ISO/IEC/IEEE 8802-11:2012/Amd.1:2013(E)" or "IEC 61588:2009(E)" --
+      # keeps the trailing mark rather than losing it altogether.
+      def marks_a_number?
+        !@number.nil? || !@alternative.nil?
+      end
+
+      # Document number to pick the symbol from when the mark falls back to the
+      # end of the string. The ISO identifier holds the only number there is,
+      # and for a supplement it is the *base* document that carries the series
+      # (an amendment's own `number` is its ordinal, "1").
+      def fallback_number
+        return @number if @number
+
+        iso = @iso_identifier
+        iso = iso.base while iso.respond_to?(:base) && iso.base
+        iso&.number
+      end
+
+      # The registered mark belongs to IEEE, so it is claimed only when IEEE
+      # is among the printed publishers -- another body may simply have
+      # numbered a document 802 or 2030 ("AIEE Std No. 802" predates the IEEE
+      # 802 series by two decades). The ISO/IEC adoption 8802 is identified by
+      # its number alone, whatever publishers are printed.
       def trademark(number)
-        %w(802 2030).include?(number.to_s) ? "\u00AE" : "\u2122"
+        bare = number.to_s.sub(/\AP/, "")
+        return "\u2122" unless REGISTERED_SERIES.include?(bare)
+        return "\u00AE" if bare == ISO_ADOPTED_SERIES
+
+        ieee = [@publisher, *@copublisher].compact.any? do |publisher|
+          publisher.to_s.split("/").include?("IEEE")
+        end
+        ieee ? "\u00AE" : "\u2122"
       end
 
       class << self

--- a/gems/pubid-ieee/lib/pubid/ieee/renderer/base.rb
+++ b/gems/pubid-ieee/lib/pubid/ieee/renderer/base.rb
@@ -1,19 +1,22 @@
 module Pubid::Ieee::Renderer
   class Base < Pubid::Core::Renderer::Base
     def render_identifier(params)
+      # %{trademark} sits immediately after the number (and its part/subpart):
+      # IEEE attaches the mark to the standard number, before the year, the
+      # draft, the corrigendum and every other suffix — "IEEE Std 802.3®-2018".
       if params[:iso_identifier].to_s != "" && params[:number] != ""
-        " (%{publisher}%{stage}%{draft_status}%{type}%{number}%{iteration}%{part}%{subpart}%{month}%{year}%{corrigendum_comment}"\
+        " (%{publisher}%{stage}%{draft_status}%{type}%{number}%{iteration}%{part}%{subpart}%{trademark}%{month}%{year}%{corrigendum_comment}"\
         "%{corrigendum}%{draft}%{edition})%{alternative}%{supersedes}%{reaffirmed}%{incorporates}%{supplement}"\
         "%{revision}%{iso_amendment}%{amendment}%{edition}%{includes}%{redline}%{adoption}" % params
       else
         if params[:day].empty? && params[:month].empty?
           # if only year - edition and draft after year
-          "%{publisher}%{draft_status}%{type}%{number}%{part}%{subpart}%{stage}"\
+          "%{publisher}%{draft_status}%{type}%{number}%{part}%{subpart}%{trademark}%{stage}"\
           "%{year}%{edition}%{corrigendum_comment}%{corrigendum}%{draft}%{alternative}%{supersedes}%{reaffirmed}%{incorporates}%{supplement}"\
           "%{revision}%{iso_amendment}%{amendment}%{includes}%{redline}%{adoption}" % params
         else
           # if year and month - edition and draft before
-          "%{publisher}%{draft_status}%{type}%{number}%{part}%{subpart}%{edition}%{stage}"\
+          "%{publisher}%{draft_status}%{type}%{number}%{part}%{subpart}%{trademark}%{edition}%{stage}"\
           "%{corrigendum_comment}%{corrigendum}%{draft}%{month}%{day}%{year}%{alternative}%{supersedes}%{reaffirmed}%{incorporates}%{supplement}"\
           "%{revision}%{iso_amendment}%{amendment}%{includes}%{redline}%{adoption}" % params
         end
@@ -107,12 +110,21 @@ module Pubid::Ieee::Renderer
       # result
     end
 
-    def render_alternative(alternative, _opts, _params)
-      if alternative.is_a?(Array)
-        " (#{alternative.map { |a| Pubid::Ieee::Identifier::Base.new(**Pubid::Ieee::Identifier.convert_parser_parameters(**a)) }.join(', ')})"
-      else
-        " (#{Pubid::Ieee::Identifier::Base.new(**Pubid::Ieee::Identifier.convert_parser_parameters(**alternative))})"
+    def render_alternative(alternative, opts, params)
+      # An ISO-led co-publication has no IEEE number of its own — its IEEE
+      # designation is this alternative, so the trademark belongs on that
+      # number rather than on the ISO one.
+      with_trademark = opts[:with_trademark] && !params[:number]
+
+      # `annotated` is deliberately not propagated — the nested alternative was
+      # never annotated before, and this must not change plain rendering.
+      alternatives = (alternative.is_a?(Array) ? alternative : [alternative]).map do |a|
+        Pubid::Ieee::Identifier::Base
+          .new(**Pubid::Ieee::Identifier.convert_parser_parameters(**a))
+          .to_s(with_trademark: with_trademark || false)
       end
+
+      " (#{alternatives.join(', ')})"
     end
 
     def render_draft(draft, _opts, params)

--- a/gems/pubid-ieee/spec/pubid_ieee/identifier/base_spec.rb
+++ b/gems/pubid-ieee/spec/pubid_ieee/identifier/base_spec.rb
@@ -8,19 +8,156 @@ module Pubid::Ieee
           context "when 802" do
             let(:number) { 802 }
 
-            it { expect(subject).to eq("IEEE Std 802\u00AE") }
+            it { expect(subject).to eq("IEEE Std 802®") }
           end
 
           context "when 2030" do
             let(:number) { 2030 }
 
-            it { expect(subject).to eq("IEEE Std 2030\u00AE") }
+            it { expect(subject).to eq("IEEE Std 2030®") }
           end
 
           context "when other from 2030 or 802" do
             let(:number) { 1 }
 
-            it { expect(subject).to eq("IEEE Std 1\u2122") }
+            it { expect(subject).to eq("IEEE Std 1™") }
+          end
+        end
+
+        # IEEE attaches the mark to the standard number, before the year and
+        # every suffix: "IEEE Std 1619(TM)-2007", "IEEE Std 802.3(R)-2018".
+        # See metanorma/pubid#322.
+        context "trademark position" do
+          {
+            # reference                            => trademarked rendering
+            "IEEE Std 1619-2007" => "IEEE Std 1619™-2007",
+            "IEEE Std 1017.2-2021" => "IEEE Std 1017.2™-2021",
+            "IEEE Std C37.09-2018" => "IEEE Std C37.09™-2018",
+            "IEEE Std 802.3-2018" => "IEEE Std 802.3®-2018",
+            "IEEE Std 2030.5-2018" => "IEEE Std 2030.5®-2018",
+            "IEEE Std 802.15.22.3-2020" => "IEEE Std 802.15.22.3®-2020",
+            # mark precedes the corrigendum suffix
+            "IEEE Std 802.16-2004/Cor 1-2005" =>
+              "IEEE Std 802.16®-2004/Cor 1-2005",
+            "IEEE Std 1003.1-2002/Cor 1-2002" =>
+              "IEEE Std 1003.1™-2002/Cor 1-2002",
+            # mark precedes the draft suffix and the trailing date
+            "IEEE P802.1AE/D1.0" => "IEEE Draft Std P802.1AE®/D1.0",
+            "IEEE P802.1Q/D1.1, September 2015" =>
+              "IEEE Draft Std P802.1Q®/D1.1, September 2015",
+            # mark precedes the redline suffix
+            "IEEE Std 1012-1998 - Redline" =>
+              "IEEE Std 1012™-1998 - Redline",
+            "IEEE Std 802.3-2018 - Redline" =>
+              "IEEE Std 802.3®-2018 - Redline",
+          }.each do |reference, trademarked|
+            context reference do
+              subject(:identifier) { Pubid::Ieee::Identifier.parse(reference) }
+
+              it "renders the mark after the number, before every suffix" do
+                expect(identifier.to_s(with_trademark: true)).to eq(trademarked)
+              end
+
+              it "leaves the plain rendering unchanged" do
+                expect(identifier.to_s)
+                  .to eq(trademarked.delete("™®"))
+              end
+            end
+          end
+        end
+
+        # The registered mark belongs to the IEEE-published 802 / 8802 / 2030
+        # series, whatever the publisher *prefix* or the project "P" — see
+        # metanorma/pubid#322.
+        context "registered trademark series" do
+          {
+            "IEEE Std 802.3-2018" => "®",
+            "ANSI/IEEE 802.9a-1995" => "®",
+            "IEEE Std 8802-3-2021" => "®",
+            "IEEE P802.1AE/D1.0" => "®",
+            "IEEE Std 2030.5-2018" => "®",
+            "IEEE Std 1619-2007" => "™",
+            "IEEE Std C37.09-2018" => "™",
+            # The registered mark is IEEE's: another body that merely numbered
+            # a document 802 does not get it (AIEE dissolved in 1963, two
+            # decades before the IEEE 802 series).
+            "AIEE Std No. 802" => "™",
+            "ANSI 802.1-1985" => "™",
+          }.each do |reference, symbol|
+            it "renders #{symbol} for #{reference}" do
+              rendered = Pubid::Ieee::Identifier.parse(reference)
+                .to_s(with_trademark: true)
+              expect(rendered).to include(symbol)
+            end
+          end
+        end
+
+        # A purely ISO-routed form has no IEEE number of its own, so the mark
+        # falls back to the end of the string — but its symbol must still come
+        # from the document series, which for a supplement lives on the base
+        # (the supplement's own number is the ordinal "1").
+        context "ISO-routed form with no IEEE designation" do
+          {
+            "ISO/IEC/IEEE 8802-11:2012/Amd.1:2013(E)" => "®",
+            "IEC 61588:2009(E)" => "™",
+          }.each do |reference, symbol|
+            it "ends with #{symbol} for #{reference}" do
+              expect(Pubid::Ieee::Identifier.parse(reference)
+                .to_s(with_trademark: true)).to end_with(symbol)
+            end
+          end
+        end
+
+        # The IEEE designation of an ISO-led co-publication lives in the
+        # parenthesised alternative, so the mark belongs on that number.
+        context "ISO-led co-publication" do
+          subject(:identifier) do
+            Pubid::Ieee::Identifier.parse(
+              "ISO/IEC 8802-3:2021 (IEEE Std 802.3-2021)",
+            )
+          end
+
+          it "marks the IEEE designation, not the ISO one" do
+            expect(identifier.to_s(with_trademark: true))
+              .to eq("ISO/IEC 8802-3:2021 (IEEE Std 802.3®-2021)")
+          end
+        end
+
+        # The mark must be purely additive: removing it from the trademarked
+        # rendering must give back the plain rendering, for every fixture.
+        context "over the whole fixture corpus" do
+          let(:references) do
+            File.read(
+              File.join(__dir__, "..", "..", "fixtures", "pubid-parsed.txt"),
+            ).split("\n").map(&:strip).reject(&:empty?)
+          end
+
+          it "only ever adds a mark to the plain rendering" do
+            checked = 0
+
+            offenders = references.filter_map do |reference|
+              identifier = begin
+                Pubid::Ieee::Identifier.parse(reference)
+              rescue StandardError
+                next
+              end
+
+              plain = identifier.to_s
+              marked = identifier.to_s(with_trademark: true)
+              checked += 1
+              # ">= 1", not "== 1": an ISO-led form listing several IEEE
+              # designations marks each of them, as IEEE prints co-equal
+              # designations.
+              next if marked.delete("™®") == plain &&
+                marked.count("™®") >= 1
+
+              [reference, plain, marked]
+            end
+
+            expect(offenders).to eq([])
+            # Floor guard — without it this example passes vacuously if the
+            # fixture file moves or every reference stops parsing.
+            expect(checked).to be > 8_000
           end
         end
       end


### PR DESCRIPTION
Refs #322. This is the **v1 line** (`gems/pubid-ieee`); the v2/`main` fix is #323.

⚠️ Base branch is **`v1`**, not `main`.

IEEE attaches the trademark mark to the **standard number**, before the year: `IEEE Std 1619™-2007`, `IEEE Std 802.3®-2018`. `Identifier::Base#to_s` appended it to the finished string instead.

| reference | before | after |
| --- | --- | --- |
| `IEEE Std 1619-2007` | `IEEE Std 1619-2007™` | `IEEE Std 1619™-2007` |
| `IEEE Std 802.16-2004/Cor 1-2005` | `…/Cor 1-2005®` | `IEEE Std 802.16®-2004/Cor 1-2005` |
| `IEEE P802.1AE/D1.0` | `…/D1.0™` | `IEEE Draft Std P802.1AE®/D1.0` |
| `IEEE Std 1012-1998 - Redline` | `… - Redline™` | `IEEE Std 1012™-1998 - Redline` |

## How

A `%{trademark}` slot is placed after `number/part/subpart` in all three `Renderer::Base#render_identifier` templates, so the mark precedes stage, year, edition, corrigendum, draft, month and ` - Redline`. It is fed by `Identifier::Base#to_s` rather than concatenated afterwards.

Plain `to_s` is untouched: the slot renders `""` when the key is absent, via the `@prerendered_params.default = ""` mechanism every other optional slot already relies on.

## ®/™ rule widened (behaviour change)

`REGISTERED_SERIES = %w[802 8802 2030]` with a leading project `P` stripped, so `IEEE P802.1AE` and `ANSI/IEEE 802.9a` now get ®.

The registered mark is **IEEE's**, so it is claimed only when `IEEE` appears among the printed publishers (`[@publisher, *@copublisher]`, each split on `/`) — `AIEE Std No. 802` and `ANSI 802.1-1985` keep ™. (AIEE dissolved in 1963, two decades before the IEEE 802 series existed.) `ISO_ADOPTED_SERIES = "8802"` is the one escape: it *is* the ISO/IEC adoption of IEEE 802, so its number alone decides.

## Forms with no IEEE number of their own

- An ISO-led co-publication carries its IEEE designation in the parenthesised `alternative`, so `render_alternative` propagates the flag into that nested identifier: `ISO/IEC 8802-3:2021 (IEEE Std 802.3®-2021)`.
- A purely ISO-routed form (`ISO/IEC/IEEE 8802-11:2012/Amd.1:2013(E)`, `IEC 61588:2009(E)`) has nothing to attach to and keeps the **trailing** mark, guarded by `#marks_a_number?`, so it is never silently lost. `#fallback_number` walks the ISO identifier's `base` chain for the symbol, because a supplement's own `number` is its ordinal `"1"`, not the series.

## Tests

`gems/pubid-ieee/spec/pubid_ieee/identifier/base_spec.rb` gains a position table, a ®/™ table incl. the publisher gate, the ISO-routed and ISO-led cases, and a corpus property test over all 8,817 references in `spec/fixtures/pubid-parsed.txt` asserting the mark is purely additive (`to_s(with_trademark: true).delete("™®") == to_s`) with a `> 8_000` floor so it cannot pass vacuously — that guard is the byte-identity proof for plain `to_s`.

423 examples, 0 failures (`cd gems/pubid-ieee && bundle exec rspec`), plus the 9 root integration examples.

Note: run the IEEE specs from `gems/pubid-ieee`. From the monorepo root two pre-existing examples fail on a relative `open("spec/fixtures/…")` in `identifiers_parsing_spec.rb` — unrelated to this change, but it looks like a regression if you don't know.